### PR TITLE
KMS-510: cdk infrastructure code for deploying rdf4j

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,128 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request: {}
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+          node-version: ['lts/hydrogen']
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Cache node modules
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-node-modules
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        # not caching node_modules because `npm ci` removes it
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+    - name: Install dependencies
+      run: npm ci
+    - name: Run eslint
+      run: npm run lint
+  stylelint:
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+          node-version: ['lts/hydrogen']
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Cache node modules
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-node-modules
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        # not caching node_modules because `npm ci` removes it
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+    - name: Install dependencies
+      run: npm ci
+    - name: Run stylelint
+      run: npm run lint:css
+  vitest:
+    needs: [eslint, stylelint]
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+          node-version: ['lts/hydrogen']
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Cache node modules
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-node-modules
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        # not caching node_modules because `npm ci` removes it
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+    - name: Install dependencies
+      run: npm ci
+    - name: Run Vitest tests
+      run: npm run test
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  tests-passed:
+    needs: [vitest]
+    runs-on: ubuntu-latest
+    steps:
+    - name: All Tests Have Passed
+      run: 'echo true'
+
+  sync:
+    if: success() && github.ref == 'refs/heads/main' # only run on main success
+    needs: [tests-passed] # only run after vitest and cypress jobs complete
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Install SSH key
+      uses: shimataro/ssh-key-action@v2
+      with:
+        key: ${{ secrets.SSH_KEY }}
+        known_hosts: ${{ secrets.KNOWN_HOSTS }}
+    - name: Push to ECC
+      run: |
+        git remote add ecc ssh://git@git.earthdata.nasa.gov:7999/kms/kms.git
+        git fetch ecc "+refs/heads/*:refs/remotes/origin/*"
+
+        git fetch --unshallow || true
+        echo "GITHUB_COMMIT=$GITHUB_SHA"
+        git push ecc $GITHUB_SHA:refs/heads/main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,37 +35,8 @@ jobs:
       run: npm ci
     - name: Run eslint
       run: npm run lint
-  stylelint:
-    runs-on: ubuntu-latest
-    strategy:
-        matrix:
-          node-version: ['lts/hydrogen']
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Cache node modules
-      uses: actions/cache@v4
-      env:
-        cache-name: cache-node-modules
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        # not caching node_modules because `npm ci` removes it
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-    - name: Install dependencies
-      run: npm ci
-    - name: Run stylelint
-      run: npm run lint:css
   vitest:
-    needs: [eslint, stylelint]
+    needs: [eslint]
     runs-on: ubuntu-latest
     strategy:
         matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ tmp
 junit.xml
 
 cmr
+cdk.context.json
+infrastructure/rdfdb/cdk/cdk.context.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 coverage
 dist
 doc
-Dockerfile
 node_modules
 secret.config.json
 tmp

--- a/README.md
+++ b/README.md
@@ -39,3 +39,31 @@ To run the test suite, run:
     npm run test
 ```
 
+## Deploying RDF Database
+### Prerequisites
+#### Copy your AWS credentials and set these up as env variables
+```export AWS_ACCESS_KEY_ID=[your access key id]
+export AWS_SECRET_ACCESS_KEY=[your access secret access key]
+export AWS_SESSION_TOKEN=[your session token]
+```
+#### Retrieve the VPC_ID from AWS
+```export VPC_ID=[your vpc id]
+```
+#### Set the RDFDB user name and password
+```export RDFDB_USER_NAME=[your rdfdb user name]
+export RDFDB_PASSWORD=[your rdfdb password]
+```
+
+### Deploy Docker Container to Registry
+```cd infrastructure/rdfdb/cdk/bin
+export 
+./deploy_to_ecr.sh
+```
+
+### Deploy ECS Service to AWS
+```cd infrastructure/rdfdb/cdk
+cdk deploy rdf4jIamStack
+cdk deploy rdf4jEfsStack
+cdk deploy rdf4jEcsStack
+```
+One thing to note is if you destroy the rdf4jEfsStack and redeploy, this will create a new EFS file system.  You will need to copy the data from the old EFS file system to the new one.  This can be done by mounting the old EFS file system to an EC2 instance and copying the data to the new EFS file system.

--- a/bin/Dockerfile
+++ b/bin/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:18-bullseye
+COPY . /build
+WORKDIR /build
+RUN npm ci --omit=dev && npm run build

--- a/infrastructure/rdfdb/cdk/bin/deploy_to_ecr.sh
+++ b/infrastructure/rdfdb/cdk/bin/deploy_to_ecr.sh
@@ -2,8 +2,8 @@
 
 # Set variables
 REPO_NAME="rdf4j"
-REGION="us-east-1"  # Replace with your desired region
-DOCKER_FILE_PATH="../../docker"  # Adjust this path as needed
+REGION="us-east-1"
+DOCKER_FILE_PATH="../../docker"
 
 # Create ECR repository
 aws ecr create-repository --repository-name $REPO_NAME --region "us-east-1"

--- a/infrastructure/rdfdb/cdk/bin/deploy_to_ecr.sh
+++ b/infrastructure/rdfdb/cdk/bin/deploy_to_ecr.sh
@@ -9,7 +9,7 @@ DOCKER_FILE_PATH="../../docker"  # Adjust this path as needed
 aws ecr create-repository --repository-name $REPO_NAME --region "us-east-1"
 
 # Get the repository URI
-REPO_URI=$(aws ecr describe-repositories --repository-names $REPO_NAME --region "us-east-1" --query 'repositories[0].repositoryUri' --output text)
+REPO_URI=$(aws ecr describe-repositories --repository-names $REPO_NAME --region $REGION --query 'repositories[0].repositoryUri' --output text)
 
 # Authenticate Docker to ECR
 aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $REPO_URI

--- a/infrastructure/rdfdb/cdk/bin/deploy_to_ecr.sh
+++ b/infrastructure/rdfdb/cdk/bin/deploy_to_ecr.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Set variables
+REPO_NAME="rdf4j"
+REGION="us-east-1"  # Replace with your desired region
+DOCKER_FILE_PATH="../../docker"  # Adjust this path as needed
+
+# Create ECR repository
+aws ecr create-repository --repository-name $REPO_NAME --region "us-east-1"
+
+# Get the repository URI
+REPO_URI=$(aws ecr describe-repositories --repository-names $REPO_NAME --region "us-east-1" --query 'repositories[0].repositoryUri' --output text)
+
+# Authenticate Docker to ECR
+aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $REPO_URI
+
+# Build Docker image
+docker build -t $REPO_NAME $DOCKER_FILE_PATH
+
+# Tag the image
+docker tag $REPO_NAME:latest $REPO_URI:latest
+
+# Push the image to ECR
+docker push $REPO_URI:latest
+
+echo "Docker image pushed to $REPO_URI:latest"

--- a/infrastructure/rdfdb/cdk/bin/rdf4j-aws-deployment.js
+++ b/infrastructure/rdfdb/cdk/bin/rdf4j-aws-deployment.js
@@ -12,7 +12,7 @@ async function main() {
     region: process.env.CDK_DEFAULT_REGION
   }
 
-  const vpcId = 'vpc-05fdc01976f74a201' // SIT
+  const vpcId = process.env.VPC_ID
 
   const iamStack = new IamStack(app, 'rdf4jIamStack', {
     env,

--- a/infrastructure/rdfdb/cdk/bin/rdf4j-aws-deployment.js
+++ b/infrastructure/rdfdb/cdk/bin/rdf4j-aws-deployment.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+const cdk = require('aws-cdk-lib')
+const { EcsStack } = require('../lib/ecs-stack')
+const { EfsStack } = require('../lib/efs-stack')
+const { IamStack } = require('../lib/iam-stack')
+
+async function main() {
+  const app = new cdk.App()
+
+  const env = {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION
+  }
+
+  const vpcId = 'vpc-05fdc01976f74a201' // SIT
+
+  const iamStack = new IamStack(app, 'rdf4jIamStack', {
+    env,
+    vpcId
+  })
+  const efsStack = new EfsStack(app, 'rdf4jEfsStack', {
+    env,
+    vpcId,
+    efsTaskSecurityGroup: iamStack.efsTaskSecurityGroup
+  })
+
+  const ecsStack = new EcsStack(app, 'rdf4jEcsStack', {
+    env,
+    vpcId,
+    role: iamStack.role,
+    ecsTasksSecurityGroup: efsStack.ecsTasksSecurityGroup,
+    fileSystem: efsStack.fileSystem,
+    accessPoint: efsStack.accessPoint
+  })
+
+  // Add dependencies
+  efsStack.addDependency(iamStack)
+  ecsStack.addDependency(iamStack)
+  ecsStack.addDependency(efsStack)
+
+  app.synth()
+}
+
+main()

--- a/infrastructure/rdfdb/cdk/cdk.json
+++ b/infrastructure/rdfdb/cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node bin/rdf4j-aws-deployment.js"
+}

--- a/infrastructure/rdfdb/cdk/lib/ecs-stack.js
+++ b/infrastructure/rdfdb/cdk/lib/ecs-stack.js
@@ -1,0 +1,225 @@
+/* eslint-disable no-new */
+const {
+  Stack, RemovalPolicy, Duration, CfnOutput,
+  Fn
+} = require('aws-cdk-lib')
+const ec2 = require('aws-cdk-lib/aws-ec2')
+const iam = require('aws-cdk-lib/aws-iam')
+const ecr = require('aws-cdk-lib/aws-ecr')
+const ecs = require('aws-cdk-lib/aws-ecs')
+const logs = require('aws-cdk-lib/aws-logs')
+const ecspatterns = require('aws-cdk-lib/aws-ecs-patterns')
+const elbv2 = require('aws-cdk-lib/aws-elasticloadbalancingv2')
+const custom = require('aws-cdk-lib/custom-resources')
+
+class EcsStack extends Stack {
+  constructor(scope, id, props) {
+    super(scope, id, props)
+    const {
+      vpcId, fileSystem, accessPoint, ecsTasksSecurityGroup
+    } = props
+
+    this.initializeResources(vpcId, fileSystem, accessPoint, ecsTasksSecurityGroup)
+    this.createEcsResources()
+    this.configureSecurity()
+    this.addOutputs()
+  }
+
+  initializeResources(vpcId, fileSystem, accessPoint, ecsTasksSecurityGroup) {
+    this.vpc = this.getVpc(vpcId)
+    this.role = this.createRole()
+    this.fileSystem = fileSystem
+    this.accessPoint = accessPoint
+    this.ecsTasksSecurityGroup = this.getEcsTasksSecurityGroup(ecsTasksSecurityGroup)
+    this.cluster = this.createECSCluster()
+    this.repository = this.createOrGetECRRepository()
+    this.logGroup = this.createLogGroup()
+  }
+
+  createRole() {
+    return iam.Role.fromRoleArn(this, 'ImportedRole', Fn.importValue('rdf4jRoleArn'))
+  }
+
+  getVpc(vpcId) {
+    return ec2.Vpc.fromLookup(this, 'VPC', { vpcId })
+  }
+
+  getEcsTasksSecurityGroup(ecsTasksSecurityGroup) {
+    return ec2.SecurityGroup.fromSecurityGroupId(
+      this,
+      'ImportedEcsTasksSecurityGroup',
+      ecsTasksSecurityGroup.securityGroupId
+    )
+  }
+
+  createECSCluster() {
+    return new ecs.Cluster(this, 'rdf4jEcsCluster', {
+      vpc: this.vpc,
+      clusterName: 'rdf4jEcs'
+    })
+  }
+
+  createOrGetECRRepository() {
+    const repositoryName = 'rdf4j'
+    const checkRepo = this.createCheckRepositoryCustomResource(repositoryName)
+
+    return this.getOrCreateRepository(repositoryName, checkRepo)
+  }
+
+  createCheckRepositoryCustomResource(repositoryName) {
+    return new custom.AwsCustomResource(this, 'CheckRepository', {
+      onUpdate: {
+        service: 'ECR',
+        action: 'describeRepositories',
+        parameters: { repositoryNames: [repositoryName] },
+        physicalResourceId: custom.PhysicalResourceId.of(Date.now().toString())
+      },
+      policy: custom.AwsCustomResourcePolicy.fromSdkCalls({
+        resources: custom.AwsCustomResourcePolicy.ANY_RESOURCE
+      }),
+      installLatestAwsSdk: false
+    })
+  }
+
+  getOrCreateRepository(repositoryName, checkRepo) {
+    try {
+      checkRepo.getResponseField('repositories')
+
+      return ecr.Repository.fromRepositoryName(this, 'Existingrdf4jRepository', repositoryName)
+    } catch (e) {
+      return new ecr.Repository(this, 'rdf4jRepository', {
+        repositoryName,
+        removalPolicy: RemovalPolicy.RETAIN
+      })
+    }
+  }
+
+  createLogGroup() {
+    return new logs.LogGroup(this, 'rdf4jContainerLogs', {
+      logGroupName: '/ecs/rdf4j',
+      retention: logs.RetentionDays.ONE_DAY,
+      removalPolicy: RemovalPolicy.DESTROY
+    })
+  }
+
+  createEcsResources() {
+    const taskDefinition = this.createTaskDefinition()
+    const container = this.addContainerToTaskDefinition(taskDefinition)
+    this.addEFSVolumeToTaskDefinition(taskDefinition)
+    this.addMountPointToContainer(container)
+    this.fargateService = this.createFargateService(taskDefinition)
+    this.configureAutoScaling(this.fargateService)
+    this.configureHealthCheck(this.fargateService)
+  }
+
+  createTaskDefinition() {
+    return new ecs.FargateTaskDefinition(this, 'rdf4jTaskDef', {
+      memoryLimitMiB: 3072,
+      cpu: 1024,
+      executionRole: this.role,
+      taskRole: this.role,
+      networkMode: ecs.NetworkMode.AWS_VPC
+    })
+  }
+
+  addContainerToTaskDefinition(taskDefinition) {
+    const VERSION = process.env.VERSION || 'latest'
+
+    return taskDefinition.addContainer('rdf4j-container', {
+      image: ecs.ContainerImage.fromEcrRepository(this.repository, VERSION),
+      logging: ecs.LogDrivers.awsLogs({
+        streamPrefix: 'rdf4j-ecs',
+        logGroup: this.logGroup
+      }),
+      environment: {
+        REGION: this.region,
+        ACCOUNT: this.account,
+        rdf4j_DATA_DIR: '/rdf4j-data',
+        RDF4J_USER_NAME: process.env.RDF4J_USER_NAME,
+        RDF4J_PASSWORD: process.env.RDF4J_PASSWORD
+      },
+      portMappings: [{ containerPort: 8080 }],
+      essential: true,
+      memoryReservationMiB: 512
+    })
+  }
+
+  addEFSVolumeToTaskDefinition(taskDefinition) {
+    taskDefinition.addVolume({
+      name: 'rdf4j-data',
+      efsVolumeConfiguration: {
+        fileSystemId: this.fileSystem.fileSystemId,
+        transitEncryption: 'ENABLED',
+        authorizationConfig: {
+          accessPointId: this.accessPoint.accessPointId,
+          iam: 'ENABLED'
+        }
+      }
+    })
+  }
+
+  addMountPointToContainer(container) {
+    container.addMountPoints({
+      containerPath: '/rdf4j-data',
+      sourceVolume: 'rdf4j-data',
+      readOnly: false
+    })
+  }
+
+  createFargateService(taskDefinition) {
+    return new ecspatterns.ApplicationLoadBalancedFargateService(this, 'rdf4jService', {
+      cluster: this.cluster,
+      taskDefinition,
+      desiredCount: 1,
+      publicLoadBalancer: false,
+      listenerPort: 8080,
+      targetProtocol: elbv2.ApplicationProtocol.HTTP,
+      minHealthyPercent: 0,
+      maxHealthyPercent: 100,
+      enableExecuteCommand: true,
+      securityGroups: [this.ecsTasksSecurityGroup],
+      assignPublicIp: false,
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT }
+    })
+  }
+
+  configureAutoScaling(fargateService) {
+    fargateService.service.autoScaleTaskCount({
+      maxCapacity: 1,
+      minCapacity: 1
+    })
+  }
+
+  configureHealthCheck(fargateService) {
+    fargateService.targetGroup.configureHealthCheck({
+      path: '/rdf4j-server/protocol',
+      port: '8080',
+      healthyHttpCodes: '200,301,302',
+      healthyThresholdCount: 2,
+      unhealthyThresholdCount: 3,
+      timeout: Duration.seconds(10),
+      interval: Duration.seconds(30),
+      matcher: {
+        httpCode: '200-399'
+      }
+    })
+  }
+
+  configureSecurity() {
+    this.fileSystem.connections.allowDefaultPortFrom(this.ecsTasksSecurityGroup)
+  }
+
+  addOutputs() {
+    new CfnOutput(this, 'LoadBalancerDNS', {
+      value: this.fargateService.loadBalancer.loadBalancerDnsName,
+      description: 'DNS name of the load balancer'
+    })
+
+    new CfnOutput(this, 'rdf4jServiceUrl', {
+      value: `http://${this.fargateService.loadBalancer.loadBalancerDnsName}:8080`,
+      description: 'URL of the RDF4J service'
+    })
+  }
+}
+
+module.exports = { EcsStack }

--- a/infrastructure/rdfdb/cdk/lib/ecs-stack.js
+++ b/infrastructure/rdfdb/cdk/lib/ecs-stack.js
@@ -166,10 +166,11 @@ class EcsStack extends Stack {
     })
   }
 
-  // To prevent any scaling, we are setting the minHealthyPercent and maxHealthPercent to 100%.  This
+  // Multiple processes can read from the RDF db, but only 1 can write.   A future ticket
+  // will setup a lock manager so we can scale, but for now, we will prevent any scaling.
+  // To prevent any scaling, we are setting the minHealthyPercent and maxHealthPercent.  This
   // ensures that during deployments, ECS will first stop the old task before starting a new one,
   // preventing any period where two tasks might be running simultaneously.
-  // A Future ticket will need to add locking, so writes happen only 1 process at a time.
   createFargateService(taskDefinition) {
     return new ecspatterns.ApplicationLoadBalancedFargateService(this, 'rdf4jService', {
       cluster: this.cluster,

--- a/infrastructure/rdfdb/cdk/lib/ecs-stack.js
+++ b/infrastructure/rdfdb/cdk/lib/ecs-stack.js
@@ -166,6 +166,10 @@ class EcsStack extends Stack {
     })
   }
 
+  // To prevent any scaling, we are setting the minHealthyPercent and maxHealthPercent to 100%.  This
+  // ensures that during deployments, ECS will first stop the old task before starting a new one,
+  // preventing any period where two tasks might be running simultaneously.
+  // A Future ticket will need to add locking, so writes happen only 1 process at a time.
   createFargateService(taskDefinition) {
     return new ecspatterns.ApplicationLoadBalancedFargateService(this, 'rdf4jService', {
       cluster: this.cluster,
@@ -183,6 +187,8 @@ class EcsStack extends Stack {
     })
   }
 
+  // To further prevent any accidental scaling, we add a scaling lock.  This explicitly sets both the
+  // minimum and maximum number of tasks to 1, preventing any scaling operations.
   configureAutoScaling(fargateService) {
     fargateService.service.autoScaleTaskCount({
       maxCapacity: 1,

--- a/infrastructure/rdfdb/cdk/lib/efs-stack.js
+++ b/infrastructure/rdfdb/cdk/lib/efs-stack.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-new */
 const { Stack, RemovalPolicy, CfnOutput } = require('aws-cdk-lib')
 const efs = require('aws-cdk-lib/aws-efs')
 const ec2 = require('aws-cdk-lib/aws-ec2')

--- a/infrastructure/rdfdb/cdk/lib/efs-stack.js
+++ b/infrastructure/rdfdb/cdk/lib/efs-stack.js
@@ -1,0 +1,85 @@
+const { Stack, RemovalPolicy, CfnOutput } = require('aws-cdk-lib')
+const efs = require('aws-cdk-lib/aws-efs')
+const ec2 = require('aws-cdk-lib/aws-ec2')
+
+class EfsStack extends Stack {
+  constructor(scope, id, props) {
+    super(scope, id, props)
+    const { vpcId } = props
+
+    this.vpc = this.getVpc(vpcId)
+    this.ecsTasksSecurityGroup = this.createEcsTasksSecurityGroup()
+    this.fileSystem = this.createFileSystem()
+    this.accessPoint = this.createAccessPoint()
+
+    this.configureEFSSecurityGroups()
+    this.createOutputs()
+  }
+
+  getVpc(vpcId) {
+    return ec2.Vpc.fromLookup(this, 'VPC', { vpcId })
+  }
+
+  createEcsTasksSecurityGroup() {
+    return new ec2.SecurityGroup(this, 'EcsTasksSecurityGroup', {
+      vpc: this.vpc,
+      description: 'Security group for ECS tasks',
+      allowAllOutbound: true
+    })
+  }
+
+  createFileSystem() {
+    return new efs.FileSystem(this, 'rdf4jFileSystem', {
+      vpc: this.vpc,
+      lifecyclePolicy: efs.LifecyclePolicy.AFTER_14_DAYS,
+      performanceMode: efs.PerformanceMode.GENERAL_PURPOSE,
+      encrypted: true,
+      removalPolicy: RemovalPolicy.RETAIN
+    })
+  }
+
+  createAccessPoint() {
+    return this.fileSystem.addAccessPoint('AccessPoint', {
+      path: '/rdf4j-data',
+      createAcl: {
+        ownerUid: '101',
+        ownerGid: '65534',
+        permissions: '755'
+      },
+      posixUser: {
+        uid: '101',
+        gid: '65534'
+      }
+    })
+  }
+
+  configureEFSSecurityGroups() {
+    this.fileSystem.connections.allowDefaultPortFrom(this.ecsTasksSecurityGroup)
+
+    this.ecsTasksSecurityGroup.addIngressRule(
+      this.fileSystem.connections.securityGroups[0],
+      ec2.Port.tcp(2049),
+      'Allow ECS tasks to access EFS'
+    )
+
+    this.fileSystem.connections.securityGroups[0].addIngressRule(
+      this.ecsTasksSecurityGroup,
+      ec2.Port.tcp(2049),
+      'Allow EFS to accept connections from ECS tasks'
+    )
+  }
+
+  createOutputs() {
+    new CfnOutput(this, 'FileSystemId', {
+      value: this.fileSystem.fileSystemId,
+      exportName: 'rdf4jFileSystemId'
+    })
+
+    new CfnOutput(this, 'AccessPointId', {
+      value: this.accessPoint.accessPointId,
+      exportName: 'rdf4jAccessPointId'
+    })
+  }
+}
+
+module.exports = { EfsStack }

--- a/infrastructure/rdfdb/cdk/lib/iam-stack.js
+++ b/infrastructure/rdfdb/cdk/lib/iam-stack.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-new */
 const { Stack, CfnOutput } = require('aws-cdk-lib')
 const ec2 = require('aws-cdk-lib/aws-ec2')
 const iam = require('aws-cdk-lib/aws-iam')

--- a/infrastructure/rdfdb/cdk/lib/iam-stack.js
+++ b/infrastructure/rdfdb/cdk/lib/iam-stack.js
@@ -1,0 +1,83 @@
+const { Stack, CfnOutput } = require('aws-cdk-lib')
+const ec2 = require('aws-cdk-lib/aws-ec2')
+const iam = require('aws-cdk-lib/aws-iam')
+
+class IamStack extends Stack {
+  constructor(scope, id, props) {
+    super(scope, id, props)
+    const { vpcId } = props
+
+    this.vpc = this.getVpc(vpcId)
+    this.role = this.createIAMRole()
+    this.addManagedPolicies(this.role)
+    this.addInlinePolicies(this.role)
+    this.addEcsExecuteCommandPermissions(this.role)
+    this.addCustomPolicy(this.role)
+    this.addOutputs()
+  }
+
+  getVpc(vpcId) {
+    return ec2.Vpc.fromLookup(this, 'VPC', { vpcId })
+  }
+
+  createIAMRole() {
+    return new iam.Role(this, 'rdf4jRole', {
+      roleName: 'rdf4jRole',
+      assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com')
+    })
+  }
+
+  addManagedPolicies(role) {
+    role.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonECSTaskExecutionRolePolicy')
+    )
+  }
+
+  addInlinePolicies(role) {
+    role.addToPolicy(new iam.PolicyStatement({
+      actions: ['elasticfilesystem:ClientMount', 'elasticfilesystem:ClientWrite'],
+      resources: [`arn:aws:elasticfilesystem:${this.region}:${this.account}:access-point/*`]
+    }))
+  }
+
+  addEcsExecuteCommandPermissions(role) {
+    role.addToPolicy(new iam.PolicyStatement({
+      actions: [
+        'ssmmessages:CreateControlChannel',
+        'ssmmessages:CreateDataChannel',
+        'ssmmessages:OpenControlChannel',
+        'ssmmessages:OpenDataChannel',
+        'logs:CreateLogStream',
+        'logs:PutLogEvents'
+      ],
+      resources: ['*']
+    }))
+  }
+
+  addCustomPolicy(role) {
+    const policy = new iam.Policy(this, 'rdf4jRolePolicy', {
+      statements: [
+        new iam.PolicyStatement({
+          actions: [
+            'ecr:GetAuthorizationToken',
+            'ecr:BatchCheckLayerAvailability',
+            'ecr:GetDownloadUrlForLayer',
+            'ecr:BatchGetImage'
+          ],
+          resources: ['*']
+        })
+      ]
+    })
+
+    policy.attachToRole(role)
+  }
+
+  addOutputs() {
+    new CfnOutput(this, 'RoleArn', {
+      value: this.role.roleArn,
+      exportName: 'rdf4jRoleArn'
+    })
+  }
+}
+
+module.exports = { IamStack }

--- a/infrastructure/rdfdb/docker/Dockerfile
+++ b/infrastructure/rdfdb/docker/Dockerfile
@@ -1,0 +1,28 @@
+FROM eclipse/rdf4j-workbench:4.3.15
+USER root
+
+# Create the directory for EFS mount
+# Create the directory and set permissions
+RUN mkdir -p /rdf4j-data
+RUN chown -R tomcat:nogroup /rdf4j-data
+RUN chmod -R 755 /rdf4j-data
+
+    # Set the RDF4J data directory
+ENV RDF4J_DATA_DIR=/rdf4j-data
+
+# Install necessary tools
+RUN apt-get update && apt-get install -y unzip zip
+
+# Copy configuration files
+COPY config/tomcat-users.xml /usr/local/tomcat/conf/tomcat-users.xml
+
+# Copy scripts
+COPY scripts/setup.sh /usr/local/tomcat/setup.sh
+COPY scripts/modify_web_xml.sh /usr/local/tomcat/modify_web_xml.sh
+
+RUN chown -R tomcat:nogroup /usr/local/tomcat
+RUN rm -r /usr/local/tomcat/webapps/rdf4j-workbench*
+USER tomcat
+# Run setup script
+CMD ["/usr/local/tomcat/setup.sh"]
+

--- a/infrastructure/rdfdb/docker/Dockerfile
+++ b/infrastructure/rdfdb/docker/Dockerfile
@@ -1,13 +1,12 @@
 FROM eclipse/rdf4j-workbench:4.3.15
 USER root
 
-# Create the directory for EFS mount
-# Create the directory and set permissions
+# Create the directory for EFS mount and set permissions
 RUN mkdir -p /rdf4j-data
 RUN chown -R tomcat:nogroup /rdf4j-data
 RUN chmod -R 755 /rdf4j-data
 
-    # Set the RDF4J data directory
+# Set the RDF4J data directory
 ENV RDF4J_DATA_DIR=/rdf4j-data
 
 # Install necessary tools
@@ -23,6 +22,7 @@ COPY scripts/modify_web_xml.sh /usr/local/tomcat/modify_web_xml.sh
 RUN chown -R tomcat:nogroup /usr/local/tomcat
 RUN rm -r /usr/local/tomcat/webapps/rdf4j-workbench*
 USER tomcat
+
 # Run setup script
 CMD ["/usr/local/tomcat/setup.sh"]
 

--- a/infrastructure/rdfdb/docker/config/tomcat-users.xml
+++ b/infrastructure/rdfdb/docker/config/tomcat-users.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+              version="1.0">
+  <role rolename="rdf4j-user"/>
+  <role rolename="rdf4j-admin"/>
+  <user username="${RDF4J_USER_NAME}" password="${RDF4J_PASSWORD}" roles="rdf4j-user,rdf4j-admin"/>
+</tomcat-users>

--- a/infrastructure/rdfdb/docker/scripts/modify_web_xml.sh
+++ b/infrastructure/rdfdb/docker/scripts/modify_web_xml.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+WAR_FILE="/usr/local/tomcat/webapps/rdf4j-server.war"
+TEMP_DIR="/tmp/rdf4j-server"
+
+# Extract WAR file
+mkdir -p "$TEMP_DIR"
+cd "$TEMP_DIR"
+unzip -q "$WAR_FILE"
+
+# Modify web.xml
+WEB_XML="$TEMP_DIR/WEB-INF/web.xml"
+# Use sed to insert the security configurations just before the closing </web-app> tag
+sed -i '/<\/web-app>/i\
+  <security-constraint>\
+        <web-resource-collection>\
+            <web-resource-name>RDF4J Server</web-resource-name>\
+            <url-pattern>/protocol</url-pattern>\
+        </web-resource-collection>\
+        <!-- No auth-constraint here, making it publicly accessible --> \
+    </security-constraint>\
+\
+    <security-constraint>\
+        <web-resource-collection>\
+            <web-resource-name>RDF4J Server</web-resource-name>\
+            <url-pattern>/*</url-pattern>\
+        </web-resource-collection>\
+        <auth-constraint>\
+            <role-name>rdf4j-user</role-name>\
+        </auth-constraint>\
+    </security-constraint>\
+\
+    <login-config>\
+        <auth-method>BASIC</auth-method>\
+        <realm-name>RDF4J Server</realm-name>\
+    </login-config>\
+\
+    <security-role>\
+        <role-name>rdf4j-user</role-name>\
+    </security-role>\
+    <security-role>\
+        <role-name>rdf4j-admin</role-name>\
+    </security-role>' "$WEB_XML"
+
+# Repackage WAR file
+cd "$TEMP_DIR"
+zip -rq "$WAR_FILE" .
+
+# Clean up
+rm -rf "$TEMP_DIR"

--- a/infrastructure/rdfdb/docker/scripts/setup.sh
+++ b/infrastructure/rdfdb/docker/scripts/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+echo 'org.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.EnvironmentPropertySource' >> /usr/local/tomcat/conf/catalina.properties
+echo "RDF4J_DATA_DIR is set to: ${RDF4J_DATA_DIR}"
+
+/usr/local/tomcat/modify_web_xml.sh
+
+echo "showing rdf4j data directory"
+ls -l /rdf4j-data
+
+export JAVA_OPTS="-Dorg.eclipse.rdf4j.appdata.basedir=${RDF4J_DATA_DIR}"
+export CATALINA_OPTS="-Dorg.eclipse.rdf4j.appdata.basedir=${RDF4J_DATA_DIR}"
+echo "JAVA_OPTS=\"\$JAVA_OPTS -Dorg.eclipse.rdf4j.appdata.basedir=${RDF4J_DATA_DIR}\"" >> /usr/local/tomcat/bin/setenv.sh
+
+# Start Web Application
+catalina.sh run

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@vitejs/plugin-react": "^4.1.0",
         "@xmldom/xmldom": "^0.8.10",
+        "aws-cdk-lib": "^2.177.0",
         "esbuild": "^0.19.5",
         "eslint-import-resolver-alias": "^1.1.2",
         "eslint-plugin-testing-library": "^6.2.2",
@@ -84,6 +85,57 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.221",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.221.tgz",
+      "integrity": "sha512-+Vu2cMvgtkaHwNezrTVng4+FAMAWKJTkC/2ZQlgkbY05k0lHHK/2eWKqBhTeA7EpxVrx9uFN7GdBFz3mcThpxg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/asset-kubectl-v20": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.3.tgz",
+      "integrity": "sha512-cDG1w3ieM6eOT9mTefRuTypk95+oyD7P5X/wRltwmYxU7nZc3+076YEVS6vrjDKr3ADYbfn0lDKpfB1FBtO9CQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "39.2.10",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.2.10.tgz",
+      "integrity": "sha512-TpMEalAybKtRKoKUsJsg1Jp27jIaQUwwjNniZEVLDRDn/ATEMBkcTnUOSbCePSk5fJNmp5wHew0Z03eNxDsjkQ==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.7.0",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -7307,7 +7359,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7342,6 +7393,347 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.177.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.177.0.tgz",
+      "integrity": "sha512-nTnHAwjZaPJ5gfJjtzE/MyK6q0a66nWthoJl7l8srucRb+I30dczhbbXor6QCdVpJaTRAEliMOMq23aglsAQbg==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "table",
+        "yaml",
+        "mime-types"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.208",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.3",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^39.2.0",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
+        "minimatch": "^3.1.2",
+        "punycode": "^2.3.1",
+        "semver": "^7.6.3",
+        "table": "^6.8.2",
+        "yaml": "1.10.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.17.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.0.3",
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.6.3",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.8.2",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.2",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/aws-sdk": {
@@ -8688,6 +9080,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ=="
+    },
+    "node_modules/constructs": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
+      "integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -13746,8 +14145,7 @@
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
@@ -17693,7 +18091,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -17710,7 +18107,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -17725,7 +18121,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -17736,8 +18131,7 @@
     "node_modules/slice-ansi/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/sntp": {
       "version": "0.2.4",
@@ -18553,7 +18947,6 @@
       "version": "6.8.2",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
       "integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
-      "dev": true,
       "dependencies": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -18569,7 +18962,6 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18584,8 +18976,7 @@
     "node_modules/table/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/tar": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@vitejs/plugin-react": "^4.1.0",
     "@xmldom/xmldom": "^0.8.10",
+    "aws-cdk-lib": "^2.177.0",
     "esbuild": "^0.19.5",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-testing-library": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    1;95;0c  "name": "kms",
+  "name": "kms",
   "version": "0.0.1",
   "proxy": "http://localhost:8080",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
-  "name": "kms",
+    1;95;0c  "name": "kms",
   "version": "0.0.1",
   "proxy": "http://localhost:8080",
   "scripts": {
     "start": "vite",
     "build": "vite build",
     "lint": "eslint . --ext .jsx,.js",
-    "lint:css": "npx stylelint './static/src/**/*.(sc|c)ss'",
     "preview": "vite preview",
     "test": "vitest",
     "offline": "serverless offline start"

--- a/serverless/src/status/__tests__/handler.test.js
+++ b/serverless/src/status/__tests__/handler.test.js
@@ -1,4 +1,4 @@
-import status from "../handler"
+import status from '../handler'
 
 beforeEach(() => {
   vi.clearAllMocks()

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,22 +3,22 @@ import path from 'path'
 import fs from 'fs'
 
 function getHandlerEntries(dir) {
-  const entries = {};
-  const files = fs.readdirSync(dir, { withFileTypes: true });
-
-  for (const file of files) {
-    if (file.isDirectory()) {
-      const handlerPath = path.join(dir, file.name, 'handler.js');
+  return fs.readdirSync(dir, { withFileTypes: true })
+    .filter((file) => file.isDirectory())
+    .reduce((entries, file) => {
+      const handlerPath = path.join(dir, file.name, 'handler.js')
       if (fs.existsSync(handlerPath)) {
-        entries[`${file.name}/handler`] = path.resolve(__dirname, handlerPath);
+        return {
+          ...entries,
+          [`${file.name}/handler`]: path.resolve(__dirname, handlerPath)
+        }
       }
-    }
-  }
 
-  return entries;
+      return entries
+    }, {})
 }
 
-const handlerEntries = getHandlerEntries('./serverless/src');
+const handlerEntries = getHandlerEntries('./serverless/src')
 
 export default defineConfig({
   build: {
@@ -29,16 +29,21 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
-        'aws-sdk',
+        'aws-sdk'
         // Add other external dependencies here
-      ],
+      ]
     },
     outDir: 'dist',
-    sourcemap: true,
+    sourcemap: true
   },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'serverless/src')
     }
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['serverless/src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}']
   }
 })


### PR DESCRIPTION
The purpose of this code is to use CDK to deploy infrastructure code for deploying the RDF4J database.   It deploys 3 stacks:

rdf4jIamStack - This stack sets up the necessary IAM permissions for ECS tasks to run and be managed, interaction with EFS for file storage, using the ECS Execute Command feature for debugging, and pulling images from ECR.  The exported role ARN can be used by other stacks or services that need to reference this IAM role.

rdf4jEfsStack - This stack essentially sets up a persistent file storage system (EFS) that can be used by ECS tasks.   This is used for storing RDF4j data.  The security group configurations ensure that only the specified ECS tasks can access the EFS. The exported IDs can be used by other stacks or services that need to reference this EFS setup.

rdf4jEcsStack - This stack essentially sets up a containerized RDF4J service running on ECS Fargate, with persistent storage provided by EFS, and accessed through an Application Load Balancer. It's designed to run a single instance of the service, with auto-scaling configured to maintain exactly one task. The service  integrates with other AWS services like ECR for container images and CloudWatch for logging.  One thing to note. Multiple processes can read from the RDF db, but only 1 can write.   A future ticket will setup a lock manager so we can scale, but for now, we will prevent any scaling.

Finally, this includes a custom configuration for the container that runs in ECS.   It creates a customized RDF4J database environment, tailored for use with AWS EFS for persistent storage. It includes custom configuration and setup scripts, and prepares the environment for running as a non-root user (tomcat) for security purposes.
