### PR TITLE
KMS-516: Fixed update to delete first, then update.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[Dockerfile,*.xml]
+end_of_line = lf
+indent_size = 2
+indent_style = space
+[{*.md}]
+indent_size = 4 #this is important, the markdown for API docs will not see 2 spaces
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,0 @@
-[Dockerfile,*.xml]
-end_of_line = lf
-indent_size = 2
-indent_style = space
-[{*.md}]
-indent_size = 4 #this is important, the markdown for API docs will not see 2 spaces
-indent_style = space
-insert_final_newline = true
-trim_trailing_whitespace = true

--- a/serverless-configs/aws-functions.yml
+++ b/serverless-configs/aws-functions.yml
@@ -37,7 +37,7 @@ createConcept:
     - http:
         method: post
         cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
-        path: concept/{conceptId}
+        path: concept
 createConcepts:
   handler: serverless/src/createConcepts/handler.default
   timeout: ${env:LAMBDA_TIMEOUT, '30'}
@@ -53,7 +53,7 @@ updateConcept:
     - http:
         method: put
         cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
-        path: concept/{conceptId}
+        path: concept
 
 deleteConcept:
   handler: serverless/src/deleteConcept/handler.default

--- a/serverless/src/deleteConcept/__tests__/handler.test.js
+++ b/serverless/src/deleteConcept/__tests__/handler.test.js
@@ -1,4 +1,3 @@
-// Serverless/src/deleteConcept/__tests__/handler.test.js
 import {
   describe,
   test,

--- a/serverless/src/deleteConcept/__tests__/handler.test.js
+++ b/serverless/src/deleteConcept/__tests__/handler.test.js
@@ -1,75 +1,73 @@
+// Serverless/src/deleteConcept/__tests__/handler.test.js
 import {
   describe,
+  test,
   expect,
   vi,
-  beforeEach,
-  afterEach
+  beforeEach
 } from 'vitest'
 import deleteConcept from '../handler'
+import deleteTriples from '../../utils/deleteTriples'
 import { getApplicationConfig } from '../../utils/getConfig'
-import { sparqlRequest } from '../../utils/sparqlRequest'
 
 // Mock the dependencies
+vi.mock('../../utils/deleteTriples')
 vi.mock('../../utils/getConfig')
-vi.mock('../../utils/sparqlRequest')
 
 describe('deleteConcept', () => {
-  const mockDefaultHeaders = { 'X-Custom-Header': 'value' }
-  const mockConceptId = '123'
+  const mockDefaultHeaders = { 'Content-Type': 'application/json' }
   const mockEvent = {
-    pathParameters: { conceptId: mockConceptId }
+    pathParameters: { conceptId: '123' }
   }
-  let consoleLogSpy
-  let consoleErrorSpy
 
   beforeEach(() => {
     vi.resetAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
     getApplicationConfig.mockReturnValue({ defaultResponseHeaders: mockDefaultHeaders })
-
-    // Set up spies for console.log and console.error
-    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
-  afterEach(() => {
-    // Restore the original console methods after each test
-    consoleLogSpy.mockRestore()
-    consoleErrorSpy.mockRestore()
-  })
-
-  test('should successfully delete a concept and return 200', async () => {
-    sparqlRequest.mockResolvedValue({ ok: true })
+  test('should successfully delete a concept', async () => {
+    deleteTriples.mockResolvedValue({ deleteResponse: { ok: true } })
 
     const result = await deleteConcept(mockEvent)
 
-    expect(sparqlRequest).toHaveBeenCalledWith({
-      contentType: 'application/sparql-update',
-      accept: 'application/sparql-results+json',
-      path: '/statements',
-      method: 'POST',
-      body: expect.stringContaining(`https://gcmd.earthdata.nasa.gov/kms/concept/${mockConceptId}`)
-    })
-
+    expect(deleteTriples).toHaveBeenCalledWith('https://gcmd.earthdata.nasa.gov/kms/concept/123')
     expect(result).toEqual({
       statusCode: 200,
-      body: JSON.stringify({ message: `Successfully deleted concept: ${mockConceptId}` }),
+      body: JSON.stringify({ message: 'Successfully deleted concept: 123' }),
       headers: mockDefaultHeaders
     })
-
-    expect(consoleLogSpy).toHaveBeenCalledWith(`Successfully deleted concept: ${mockConceptId}`)
   })
 
-  test('should handle SPARQL endpoint errors and return 500', async () => {
-    const errorMessage = 'SPARQL endpoint error'
-    sparqlRequest.mockResolvedValue({
-      ok: false,
-      status: 400,
-      text: () => Promise.resolve(errorMessage)
+  test('should return 500 if deleteTriples fails', async () => {
+    const mockError = new Error('Delete failed')
+    deleteTriples.mockRejectedValue(mockError)
+
+    const result = await deleteConcept(mockEvent)
+
+    expect(result).toEqual({
+      statusCode: 500,
+      body: JSON.stringify({
+        message: 'Error deleting concept',
+        error: 'Delete failed'
+      }),
+      headers: mockDefaultHeaders
+    })
+  })
+
+  test('should return 500 if deleteTriples returns non-ok response', async () => {
+    deleteTriples.mockResolvedValue({
+      deleteResponse: {
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve('Bad Request')
+      }
     })
 
     const result = await deleteConcept(mockEvent)
 
-    expect(sparqlRequest).toHaveBeenCalled()
     expect(result).toEqual({
       statusCode: 500,
       body: JSON.stringify({
@@ -78,92 +76,29 @@ describe('deleteConcept', () => {
       }),
       headers: mockDefaultHeaders
     })
-
-    expect(consoleLogSpy).toHaveBeenCalledWith('Response text:', errorMessage)
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Error deleting concept:', expect.any(Error))
   })
 
-  test('should handle unexpected errors and return 500', async () => {
-    const error = new Error('Unexpected error')
-    sparqlRequest.mockRejectedValue(error)
-
-    const result = await deleteConcept(mockEvent)
-
-    expect(sparqlRequest).toHaveBeenCalled()
-    expect(result).toEqual({
-      statusCode: 500,
-      body: JSON.stringify({
-        message: 'Error deleting concept',
-        error: 'Unexpected error'
-      }),
-      headers: mockDefaultHeaders
-    })
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Error deleting concept:', error)
-  })
-
-  test('should construct the correct SPARQL query', async () => {
-    sparqlRequest.mockResolvedValue({ ok: true })
-
-    await deleteConcept(mockEvent)
-
-    const expectedQuery = `
-     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-     DELETE {
-       ?s ?p ?o .
-     }
-     WHERE {
-       ?s ?p ?o .
-       FILTER(?s = <https://gcmd.earthdata.nasa.gov/kms/concept/${mockConceptId}>)
-     }
-   `
-
-    expect(sparqlRequest).toHaveBeenCalledWith({
-      accept: 'application/sparql-results+json',
-      body: expectedQuery,
-      contentType: 'application/sparql-update',
-      method: 'POST',
-      path: '/statements'
-    })
-  })
-
-  test('should handle missing conceptId in path parameters', async () => {
+  test('should handle missing conceptId', async () => {
     const eventWithoutConceptId = { pathParameters: {} }
 
     const result = await deleteConcept(eventWithoutConceptId)
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       statusCode: 500,
-      body: expect.stringContaining('Error deleting concept'),
       headers: mockDefaultHeaders
     })
 
-    expect(consoleErrorSpy).toHaveBeenCalled()
+    const body = JSON.parse(result.body)
+    expect(body).toHaveProperty('message', 'Error deleting concept')
+    expect(body).toHaveProperty('error')
+    expect(typeof body.error).toBe('string')
   })
 
-  test('should use the correct content type and accept headers', async () => {
-    sparqlRequest.mockResolvedValue({ ok: true })
+  test('should use correct conceptIRI format', async () => {
+    deleteTriples.mockResolvedValue({ deleteResponse: { ok: true } })
 
     await deleteConcept(mockEvent)
 
-    expect(sparqlRequest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        contentType: 'application/sparql-update',
-        accept: 'application/sparql-results+json'
-      })
-    )
-  })
-
-  test('should use the correct path and method for the SPARQL request', async () => {
-    sparqlRequest.mockResolvedValue({ ok: true })
-
-    await deleteConcept(mockEvent)
-
-    expect(sparqlRequest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        path: '/statements',
-        method: 'POST'
-      })
-    )
+    expect(deleteTriples).toHaveBeenCalledWith('https://gcmd.earthdata.nasa.gov/kms/concept/123')
   })
 })

--- a/serverless/src/deleteConcept/handler.js
+++ b/serverless/src/deleteConcept/handler.js
@@ -1,5 +1,5 @@
+import deleteTriples from '../utils/deleteTriples'
 import { getApplicationConfig } from '../utils/getConfig'
-import { sparqlRequest } from '../utils/sparqlRequest'
 
 /**
  * Deletes a SKOS Concept from the RDF store based on its rdf:about identifier.
@@ -37,26 +37,8 @@ const deleteConcept = async (event) => {
   // Construct the full IRI
   const conceptIRI = `https://gcmd.earthdata.nasa.gov/kms/concept/${conceptId}`
 
-  // Construct the SPARQL DELETE query
-  const deleteQuery = `
-     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-     DELETE {
-       ?s ?p ?o .
-     }
-     WHERE {
-       ?s ?p ?o .
-       FILTER(?s = <${conceptIRI}>)
-     }
-   `
-
   try {
-    const response = await sparqlRequest({
-      contentType: 'application/sparql-update',
-      accept: 'application/sparql-results+json',
-      path: '/statements',
-      method: 'POST',
-      body: deleteQuery
-    })
+    const { deleteResponse: response } = await deleteTriples(conceptIRI)
 
     if (!response.ok) {
       const responseText = await response.text()
@@ -64,8 +46,7 @@ const deleteConcept = async (event) => {
       throw new Error(`HTTP error! status: ${response.status}`)
     }
 
-    console.log(`Successfully deleted concept: ${conceptId}`)
-
+    // Return success response
     return {
       statusCode: 200,
       body: JSON.stringify({ message: `Successfully deleted concept: ${conceptId}` }),

--- a/serverless/src/getConcept/handler.js
+++ b/serverless/src/getConcept/handler.js
@@ -47,6 +47,7 @@ const getConcept = async (event) => {
     })
 
     const conceptIRI = `https://gcmd.earthdata.nasa.gov/kms/concept/${conceptId}`
+    const concept = await getSkosConcept(conceptIRI)
     const rdfJson = {
       'rdf:RDF': {
         '@xmlns:rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
@@ -54,7 +55,7 @@ const getConcept = async (event) => {
         '@xmlns:gcmd': 'https://gcmd.earthdata.nasa.gov/kms#',
         '@xmlns:kms': 'https://gcmd.earthdata.nasa.gov/kms#',
         'gcmd:gcmd': await getGcmdMetadata({ conceptIRI }),
-        'skos:Concept': [await getSkosConcept(conceptIRI)]
+        'skos:Concept': [concept]
 
       }
     }

--- a/serverless/src/updateConcept/__tests__/handler.test.js
+++ b/serverless/src/updateConcept/__tests__/handler.test.js
@@ -1,4 +1,3 @@
-// Serverless/src/updateConcept/__tests__/handler.test.js
 import {
   describe,
   expect,

--- a/serverless/src/updateConcept/handler.js
+++ b/serverless/src/updateConcept/handler.js
@@ -1,6 +1,8 @@
-import conceptIdExists from '../utils/conceptIdExists'
 import { getApplicationConfig } from '../utils/getConfig'
 import { sparqlRequest } from '../utils/sparqlRequest'
+import conceptIdExists from '../utils/conceptIdExists'
+import deleteTriples from '../utils/deleteTriples'
+import rollback from '../utils/rollback'
 
 /**
  * Updates an existing SKOS Concept in the RDF store.
@@ -32,12 +34,12 @@ import { sparqlRequest } from '../utils/sparqlRequest'
  * //   headers: { ... }
  * // }
  */
+
 const updateConcept = async (event) => {
   const { defaultResponseHeaders } = getApplicationConfig()
   const { body: rdfXml } = event
-  const { conceptId } = event.pathParameters // Assuming the concept ID is passed as a path parameter
+  const { conceptId } = event.pathParameters
 
-  // Construct the full IRI
   const conceptIRI = `https://gcmd.earthdata.nasa.gov/kms/concept/${conceptId}`
 
   try {
@@ -50,27 +52,50 @@ const updateConcept = async (event) => {
       }
     }
 
-    // If the concept exists, proceed with the update
-    const response = await sparqlRequest({
-      contentType: 'application/rdf+xml',
-      accept: 'application/rdf+xml',
-      path: '/statements',
-      method: 'POST',
-      body: rdfXml
-    })
+    // Delete existing triples and get the deleted data
+    const { deletedTriples, deleteResponse } = await deleteTriples(conceptIRI)
 
-    if (!response.ok) {
-      const responseText = await response.text()
-      console.log('Response text:', responseText)
-      throw new Error(`HTTP error! status: ${response.status}`)
+    if (!deleteResponse.ok) {
+      throw new Error(`HTTP error! delete status: ${deleteResponse.status}`)
     }
 
-    console.log(`Successfully updated concept: ${conceptId}`)
+    console.log(`Successfully deleted concept: ${conceptId}`)
 
-    return {
-      statusCode: 200,
-      body: JSON.stringify({ message: `Successfully updated concept: ${conceptId}` }),
-      headers: defaultResponseHeaders
+    // Try to insert the new data
+    try {
+      const insertResponse = await sparqlRequest({
+        contentType: 'application/rdf+xml',
+        accept: 'application/rdf+xml',
+        path: '/statements',
+        method: 'POST',
+        body: rdfXml
+      })
+
+      if (!insertResponse.ok) {
+        throw new Error(`HTTP error! insert status: ${insertResponse.status}`)
+      }
+
+      console.log(`Successfully updated concept: ${conceptId}`)
+
+      return {
+        statusCode: 200,
+        body: JSON.stringify({ message: `Successfully updated concept: ${conceptId}` }),
+        headers: defaultResponseHeaders
+      }
+    } catch (insertError) {
+      console.error('Error inserting new data, rolling back:', insertError)
+
+      // Rollback: reinsert the deleted triples
+      await rollback(deletedTriples)
+
+      return {
+        statusCode: 500,
+        body: JSON.stringify({
+          message: 'Error updating concept',
+          error: insertError.message
+        }),
+        headers: defaultResponseHeaders
+      }
     }
   } catch (error) {
     console.error('Error updating concept:', error)

--- a/serverless/src/utils/__tests__/deleteTriples.test.js
+++ b/serverless/src/utils/__tests__/deleteTriples.test.js
@@ -1,0 +1,153 @@
+import {
+  describe,
+  test,
+  expect,
+  vi,
+  beforeEach
+} from 'vitest'
+import deleteTriples from '../deleteTriples'
+import { sparqlRequest } from '../sparqlRequest'
+
+// Mock the sparqlRequest function
+vi.mock('../sparqlRequest')
+
+describe('deleteTriples', () => {
+  const mockConceptIRI = 'https://example.com/concept/123'
+  const mockDeletedTriples = [
+    {
+      s: { value: mockConceptIRI },
+      p: { value: 'predicate1' },
+      o: { value: 'object1' }
+    },
+    {
+      s: { value: mockConceptIRI },
+      p: { value: 'predicate2' },
+      o: { value: 'object2' }
+    }
+  ]
+
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.resetAllMocks()
+  })
+
+  test('should successfully delete triples', async () => {
+    sparqlRequest.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: { bindings: mockDeletedTriples } })
+    })
+
+    sparqlRequest.mockResolvedValueOnce({ ok: true })
+
+    const result = await deleteTriples(mockConceptIRI)
+
+    expect(sparqlRequest).toHaveBeenCalledTimes(2)
+    expect(sparqlRequest).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      contentType: 'application/sparql-query',
+      accept: 'application/sparql-results+json',
+      method: 'POST',
+      body: expect.stringContaining(`FILTER(?s = <${mockConceptIRI}>)`)
+    }))
+
+    expect(sparqlRequest).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      contentType: 'application/sparql-update',
+      accept: 'application/sparql-results+json',
+      path: '/statements',
+      method: 'POST',
+      body: expect.stringContaining(`FILTER(?s = <${mockConceptIRI}>)`)
+    }))
+
+    expect(result).toEqual({
+      deletedTriples: mockDeletedTriples,
+      deleteResponse: { ok: true }
+    })
+  })
+
+  test('should throw error if select query fails', async () => {
+    sparqlRequest.mockResolvedValueOnce({
+      ok: false,
+      status: 400
+    })
+
+    await expect(deleteTriples(mockConceptIRI)).rejects.toThrow('HTTP error! select status: 400')
+    expect(sparqlRequest).toHaveBeenCalledTimes(1)
+  })
+
+  test('should throw error if delete query fails', async () => {
+    sparqlRequest.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: { bindings: mockDeletedTriples } })
+    })
+
+    sparqlRequest.mockResolvedValueOnce({
+      ok: false,
+      status: 500
+    })
+
+    await expect(deleteTriples(mockConceptIRI)).rejects.toThrow('HTTP error! delete status: 500')
+    expect(sparqlRequest).toHaveBeenCalledTimes(2)
+  })
+
+  test('should handle empty result from select query', async () => {
+    sparqlRequest.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: { bindings: [] } })
+    })
+
+    sparqlRequest.mockResolvedValueOnce({ ok: true })
+
+    const result = await deleteTriples(mockConceptIRI)
+
+    expect(result).toEqual({
+      deletedTriples: [],
+      deleteResponse: { ok: true }
+    })
+  })
+
+  test('should propagate unexpected errors', async () => {
+    const mockError = new Error('Unexpected error')
+    sparqlRequest.mockRejectedValueOnce(mockError)
+
+    await expect(deleteTriples(mockConceptIRI)).rejects.toThrow('Unexpected error')
+  })
+
+  test('should use correct SPARQL queries', async () => {
+    sparqlRequest.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: { bindings: mockDeletedTriples } })
+    })
+
+    sparqlRequest.mockResolvedValueOnce({ ok: true })
+
+    await deleteTriples(mockConceptIRI)
+
+    const selectCall = sparqlRequest.mock.calls[0][0]
+    const deleteCall = sparqlRequest.mock.calls[1][0]
+
+    expect(selectCall.body).toContain('SELECT ?s ?p ?o')
+    expect(selectCall.body).toContain(`FILTER(?s = <${mockConceptIRI}>)`)
+
+    expect(deleteCall.body).toContain('DELETE {')
+    expect(deleteCall.body).toContain(`FILTER(?s = <${mockConceptIRI}>)`)
+  })
+
+  test('should handle large number of triples', async () => {
+    const largeNumberOfTriples = Array(1000).fill().map((_, i) => ({
+      s: { value: mockConceptIRI },
+      p: { value: `predicate${i}` },
+      o: { value: `object${i}` }
+    }))
+
+    sparqlRequest.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: { bindings: largeNumberOfTriples } })
+    })
+
+    sparqlRequest.mockResolvedValueOnce({ ok: true })
+
+    const result = await deleteTriples(mockConceptIRI)
+
+    expect(result.deletedTriples).toHaveLength(1000)
+    expect(sparqlRequest).toHaveBeenCalledTimes(2)
+  })
+})

--- a/serverless/src/utils/__tests__/getConceptId.test.js
+++ b/serverless/src/utils/__tests__/getConceptId.test.js
@@ -1,0 +1,115 @@
+import { describe, expect } from 'vitest'
+import getConceptId from '../getConceptId'
+
+describe('getConceptId', () => {
+  test('should extract concept ID from valid RDF/XML', () => {
+    const validXml = `
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+        <skos:Concept rdf:about="https://gcmd.earthdata.nasa.gov/kms/concept/123">
+          <skos:prefLabel>Test Concept</skos:prefLabel>
+        </skos:Concept>
+      </rdf:RDF>
+    `
+    expect(getConceptId(validXml)).toBe('123')
+  })
+
+  test('should return null for empty concept ID', () => {
+    const emptyIdXml = `
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+        <skos:Concept rdf:about="https://gcmd.earthdata.nasa.gov/kms/concept/">
+          <skos:prefLabel>Test Concept</skos:prefLabel>
+        </skos:Concept>
+      </rdf:RDF>
+    `
+    expect(getConceptId(emptyIdXml)).toBe(null)
+  })
+
+  test('should throw error for missing skos:Concept element', () => {
+    const noConceptXml = `
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+        <skos:Collection>
+          <skos:prefLabel>Test Collection</skos:prefLabel>
+        </skos:Collection>
+      </rdf:RDF>
+    `
+    expect(() => getConceptId(noConceptXml)).toThrow('Invalid XML: skos:Concept element not found')
+  })
+
+  test('should throw error for missing rdf:about attribute', () => {
+    const noAboutXml = `
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+        <skos:Concept>
+          <skos:prefLabel>Test Concept</skos:prefLabel>
+        </skos:Concept>
+      </rdf:RDF>
+    `
+    expect(() => getConceptId(noAboutXml)).toThrow('rdf:about attribute not found in skos:Concept element')
+  })
+
+  test('should handle concept ID with special characters', () => {
+    const specialCharsXml = `
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+        <skos:Concept rdf:about="https://gcmd.earthdata.nasa.gov/kms/concept/test_123-456">
+          <skos:prefLabel>Test Concept</skos:prefLabel>
+        </skos:Concept>
+      </rdf:RDF>
+    `
+    expect(getConceptId(specialCharsXml)).toBe('test_123-456')
+  })
+
+  test('should throw error for invalid XML', () => {
+    const invalidXml = `
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <skos:Concept>
+          <skos:prefLabel>Incomplete XML
+    `
+    expect(() => getConceptId(invalidXml)).toThrow('Error extracting concept ID:')
+  })
+
+  test('should throw error for multiple skos:Concept elements', () => {
+    const multiConceptXml = `
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+        <skos:Concept rdf:about="https://gcmd.earthdata.nasa.gov/kms/concept/123">
+          <skos:prefLabel>First Concept</skos:prefLabel>
+        </skos:Concept>
+        <skos:Concept rdf:about="https://gcmd.earthdata.nasa.gov/kms/concept/456">
+          <skos:prefLabel>Second Concept</skos:prefLabel>
+        </skos:Concept>
+      </rdf:RDF>
+    `
+    expect(() => getConceptId(multiConceptXml)).toThrow('Multiple skos:Concept elements found. Only one concept is allowed.')
+  })
+
+  test('should handle concept ID with query parameters', () => {
+    const queryParamXml = `
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+        <skos:Concept rdf:about="https://gcmd.earthdata.nasa.gov/kms/concept/789?version=1.0">
+          <skos:prefLabel>Test Concept</skos:prefLabel>
+        </skos:Concept>
+      </rdf:RDF>
+    `
+    expect(getConceptId(queryParamXml)).toBe('789?version=1.0')
+  })
+
+  test('should handle concept ID with fragment identifier', () => {
+    const fragmentXml = `
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+        <skos:Concept rdf:about="https://gcmd.earthdata.nasa.gov/kms/concept/101#section1">
+          <skos:prefLabel>Test Concept</skos:prefLabel>
+        </skos:Concept>
+      </rdf:RDF>
+    `
+    expect(getConceptId(fragmentXml)).toBe('101#section1')
+  })
+
+  test('should handle concept ID with encoded characters', () => {
+    const encodedXml = `
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+        <skos:Concept rdf:about="https://gcmd.earthdata.nasa.gov/kms/concept/test%20concept">
+          <skos:prefLabel>Test Concept</skos:prefLabel>
+        </skos:Concept>
+      </rdf:RDF>
+    `
+    expect(getConceptId(encodedXml)).toBe('test%20concept')
+  })
+})

--- a/serverless/src/utils/__tests__/rollback.test.js
+++ b/serverless/src/utils/__tests__/rollback.test.js
@@ -1,0 +1,102 @@
+// Rollback.test.js
+import {
+  describe,
+  expect,
+  vi,
+  beforeEach
+} from 'vitest'
+import rollback from '../rollback'
+import { sparqlRequest } from '../sparqlRequest'
+
+vi.mock('../sparqlRequest', () => ({
+  sparqlRequest: vi.fn()
+}))
+
+describe('rollback', () => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+
+  const mockDeletedTriples = [
+    {
+      s: { value: 'http://example.com/subject1' },
+      p: { value: 'http://example.com/predicate1' },
+      o: {
+        type: 'uri',
+        value: 'http://example.com/object1'
+      }
+    },
+    {
+      s: { value: 'http://example.com/subject2' },
+      p: { value: 'http://example.com/predicate2' },
+      o: {
+        type: 'literal',
+        value: 'Literal value'
+      }
+    }
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('should successfully rollback when sparqlRequest is successful', async () => {
+    sparqlRequest.mockResolvedValue({ ok: true })
+
+    await expect(rollback(mockDeletedTriples)).resolves.not.toThrow()
+
+    expect(sparqlRequest).toHaveBeenCalledTimes(1)
+    expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
+      contentType: 'application/sparql-update',
+      accept: 'application/sparql-results+json',
+      path: '/statements',
+      method: 'POST',
+      body: expect.stringContaining('INSERT DATA')
+    }))
+  })
+
+  test('should throw an error when sparqlRequest fails', async () => {
+    sparqlRequest.mockResolvedValue({
+      ok: false,
+      status: 500
+    })
+
+    await expect(rollback(mockDeletedTriples)).rejects.toThrow('Rollback failed! status: 500')
+
+    expect(sparqlRequest).toHaveBeenCalledTimes(1)
+  })
+
+  test('should construct correct SPARQL query from deletedTriples', async () => {
+    sparqlRequest.mockResolvedValue({ ok: true })
+
+    await rollback(mockDeletedTriples)
+
+    const expectedQueryParts = [
+      'INSERT DATA {',
+      '<http://example.com/subject1> <http://example.com/predicate1> <http://example.com/object1> .',
+      '<http://example.com/subject2> <http://example.com/predicate2> "Literal value" .',
+      '}'
+    ]
+
+    expect(sparqlRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining(expectedQueryParts[0])
+      })
+    )
+
+    expectedQueryParts.forEach((part) => {
+      expect(sparqlRequest.mock.calls[0][0].body).toContain(part)
+    })
+  })
+
+  test('should handle empty deletedTriples array', async () => {
+    sparqlRequest.mockResolvedValue({ ok: true })
+
+    await expect(rollback([])).resolves.not.toThrow()
+
+    expect(sparqlRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('INSERT DATA {')
+      })
+    )
+  })
+})

--- a/serverless/src/utils/__tests__/rollback.test.js
+++ b/serverless/src/utils/__tests__/rollback.test.js
@@ -1,4 +1,3 @@
-// Rollback.test.js
 import {
   describe,
   expect,

--- a/serverless/src/utils/deleteTriples.js
+++ b/serverless/src/utils/deleteTriples.js
@@ -1,4 +1,3 @@
-// Serverless/src/utils/deleteTriples.js
 import { sparqlRequest } from './sparqlRequest'
 
 async function deleteTriples(conceptIRI) {

--- a/serverless/src/utils/deleteTriples.js
+++ b/serverless/src/utils/deleteTriples.js
@@ -1,0 +1,63 @@
+// Serverless/src/utils/deleteTriples.js
+import { sparqlRequest } from './sparqlRequest'
+
+async function deleteTriples(conceptIRI) {
+  const selectQuery = `
+    SELECT ?s ?p ?o
+    WHERE {
+      ?s ?p ?o .
+      FILTER(?s = <${conceptIRI}>)
+    }
+  `
+
+  const deleteQuery = `
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    DELETE {
+      ?s ?p ?o .
+    }
+    WHERE {
+      ?s ?p ?o .
+      FILTER(?s = <${conceptIRI}>)
+    }
+  `
+
+  try {
+    // First, select all triples
+    const selectResponse = await sparqlRequest({
+      contentType: 'application/sparql-query',
+      accept: 'application/sparql-results+json',
+      method: 'POST',
+      body: selectQuery
+    })
+
+    if (!selectResponse.ok) {
+      throw new Error(`HTTP error! select status: ${selectResponse.status}`)
+    }
+
+    const selectData = await selectResponse.json()
+    const deletedTriples = selectData.results.bindings
+
+    // Then, delete the triples
+    const deleteResponse = await sparqlRequest({
+      contentType: 'application/sparql-update',
+      accept: 'application/sparql-results+json',
+      path: '/statements',
+      method: 'POST',
+      body: deleteQuery
+    })
+
+    if (!deleteResponse.ok) {
+      throw new Error(`HTTP error! delete status: ${deleteResponse.status}`)
+    }
+
+    return {
+      deletedTriples,
+      deleteResponse
+    }
+  } catch (error) {
+    console.error('Error deleting concept:', error)
+    throw error
+  }
+}
+
+export default deleteTriples

--- a/serverless/src/utils/getConceptId.js
+++ b/serverless/src/utils/getConceptId.js
@@ -1,0 +1,45 @@
+import { XMLParser } from 'fast-xml-parser'
+
+/**
+ * Extracts the concept ID from the RDF/XML data.
+ *
+ * @param {string} rdfXml - The RDF/XML representation of the concept.
+ * @returns {string|null} The extracted concept ID or null if not found.
+ * @throws {Error} If the XML is invalid, doesn't contain a skos:Concept element, or contains multiple concepts.
+ */
+const getConceptId = (rdfXml) => {
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: '@_',
+    allowBooleanAttributes: true,
+    isArray: (name) => name === 'skos:Concept'
+  })
+
+  try {
+    const result = parser.parse(rdfXml)
+    const concepts = result['rdf:RDF']['skos:Concept']
+
+    if (!concepts || concepts.length === 0) {
+      throw new Error('Invalid XML: skos:Concept element not found')
+    }
+
+    if (concepts.length > 1) {
+      throw new Error('Multiple skos:Concept elements found. Only one concept is allowed.')
+    }
+
+    const concept = concepts[0]
+    const aboutAttr = concept['@_rdf:about']
+    if (!aboutAttr) {
+      throw new Error('rdf:about attribute not found in skos:Concept element')
+    }
+
+    // Extract the concept ID using split and pop
+    const conceptId = aboutAttr.split('/').pop()
+
+    return conceptId || null
+  } catch (error) {
+    throw new Error(`Error extracting concept ID: ${error.message}`)
+  }
+}
+
+export default getConceptId

--- a/serverless/src/utils/rollback.js
+++ b/serverless/src/utils/rollback.js
@@ -1,4 +1,3 @@
-// Serverless/src/utils/rollback.js
 import { sparqlRequest } from './sparqlRequest'
 
 /**

--- a/serverless/src/utils/rollback.js
+++ b/serverless/src/utils/rollback.js
@@ -1,0 +1,50 @@
+// Serverless/src/utils/rollback.js
+import { sparqlRequest } from './sparqlRequest'
+
+/**
+ * Performs a rollback operation by reinserting deleted triples into the RDF store.
+ *
+ * This function is used as part of a transaction-like process in updating RDF concepts.
+ * If an update operation fails after deleting existing triples, this rollback function
+ * is called to reinsert the deleted triples, effectively undoing the deletion.
+ *
+ * @async
+ * @param {Array} deletedTriples - An array of triple objects, each containing s (subject),
+ *                                 p (predicate), and o (object) properties with their respective values.
+ * @throws {Error} Throws an error if the rollback operation fails.
+ *
+ * The function constructs a SPARQL INSERT DATA query from the deleted triples and
+ * sends it to the RDF store using the sparqlRequest utility. If the request is not
+ * successful (i.e., non-OK response), it throws an error. Any error during the process
+ * is logged and re-thrown for handling by the caller.
+ */
+const rollback = async (deletedTriples) => {
+  const rollbackQuery = `
+    INSERT DATA {
+      ${deletedTriples.map((triple) => `<${triple.s.value}> <${triple.p.value}> ${
+    triple.o.type === 'uri' ? `<${triple.o.value}>` : `"${triple.o.value}"`
+  } .`).join('\n')}
+    }
+  `
+
+  try {
+    const rollbackResponse = await sparqlRequest({
+      contentType: 'application/sparql-update',
+      accept: 'application/sparql-results+json',
+      path: '/statements',
+      method: 'POST',
+      body: rollbackQuery
+    })
+
+    if (!rollbackResponse.ok) {
+      throw new Error(`Rollback failed! status: ${rollbackResponse.status}`)
+    }
+
+    console.log('Rollback successful')
+  } catch (rollbackError) {
+    console.error('Rollback failed:', rollbackError)
+    throw rollbackError
+  }
+}
+
+export default rollback


### PR DESCRIPTION
# Overview

There was a bug in the update, where if a user wanted to update a concept, it didn't delete the old concept first.   As a result, duplicate fields were encountered.

### What is the Solution?

I changed the logic to delete first, if there was an error in the delete, I also created a rollback function that will rollback the deleted triples (best I can do without transactions).

### What areas of the application does this impact?

Updating SKOS concepts

# Testing

Try creating a SKOS concept, then updating it where the updated version does not have some fields.   Those fields should disappear when you try fetching the concept again.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
