### PR TITLE
KMS-532: Fix reading query parameter format

### DIFF
--- a/serverless/src/getConcepts/handler.js
+++ b/serverless/src/getConcepts/handler.js
@@ -34,12 +34,11 @@ import { toSkosJson } from '@/shared/toSkosJson'
  */
 export const getConcepts = async (event) => {
   const { defaultResponseHeaders } = getApplicationConfig()
-  const { queryStringParameters = {} } = event
-  const { format = '' } = queryStringParameters
+  const { queryStringParameters } = event
   const { conceptScheme, pattern } = event?.pathParameters || {}
   const { page_num: pageNumStr = '1', page_size: pageSizeStr = '2000' } = event?.queryStringParameters || {}
 
-  if (format === 'csv') {
+  if (queryStringParameters?.format === 'csv') {
     if (!conceptScheme) {
       return {
         headers: defaultResponseHeaders,


### PR DESCRIPTION
# Overview

### What is the feature?

Fix how handler reads parameter 'format'

### What is the Solution?

Read 'format' only when queryStringParameters exists

### What areas of the application does this impact?

/dev/concepts

# Testing

### Reproduction steps

Test interface concepts without any query parameters 

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
