### PR TITLE
KMS-532: Add handling for case scheme doesn't have csv columns defined

### DIFF
--- a/serverless/src/shared/__tests__/createCsvForScheme.test.js
+++ b/serverless/src/shared/__tests__/createCsvForScheme.test.js
@@ -7,10 +7,12 @@ import {
 
 import { createCsv } from '../createCsv'
 import { createCsvForScheme } from '../createCsvForScheme'
+import { generateCsvHeaders } from '../generateCsvHeaders'
 import { getApplicationConfig } from '../getConfig'
 import { getCsvHeaders } from '../getCsvHeaders'
 import { getCsvMetadata } from '../getCsvMetadata'
 import { getCsvPaths } from '../getCsvPaths'
+import { getMaxLengthOfSubArray } from '../getMaxLengthOfSubArray'
 
 // Mock the imported functions
 vi.mock('../getConfig')
@@ -18,6 +20,8 @@ vi.mock('../getCsvMetadata')
 vi.mock('../getCsvHeaders')
 vi.mock('../getCsvPaths')
 vi.mock('../createCsv')
+vi.mock('../generateCsvHeaders')
+vi.mock('../getMaxLengthOfSubArray')
 
 describe('createCsvForScheme', () => {
   beforeEach(() => {
@@ -87,6 +91,42 @@ describe('createCsvForScheme', () => {
         ['A', '1', '3']
       ]
       expect(createCsv).toHaveBeenCalledWith(mockMetadata, mockHeaders, expectedSortedPaths)
+    })
+
+    test('should generate headers if none are retrieved', async () => {
+      const scheme = 'testScheme'
+      const mockDefaultHeaders = { 'Default-Header': 'value' }
+      const mockMetadata = { some: 'metadata' }
+      const mockPaths = [['A', '1', '2'], ['B', '2', '3']]
+      const mockGeneratedHeaders = ['Header1', 'Header2', 'Header3']
+      const mockCsvContent = 'csv,content'
+
+      getApplicationConfig.mockReturnValue({ defaultResponseHeaders: mockDefaultHeaders })
+      getCsvMetadata.mockResolvedValue(mockMetadata)
+      getCsvHeaders.mockResolvedValue([]) // Return empty array to trigger header generation
+      getCsvPaths.mockResolvedValue(mockPaths)
+      getMaxLengthOfSubArray.mockReturnValue(3)
+      generateCsvHeaders.mockReturnValue(mockGeneratedHeaders)
+      createCsv.mockResolvedValue(mockCsvContent)
+
+      const result = await createCsvForScheme(scheme)
+
+      expect(result).toEqual({
+        statusCode: 200,
+        body: mockCsvContent,
+        headers: {
+          ...mockDefaultHeaders,
+          'Content-Type': 'text/csv',
+          'Content-Disposition': `attachment; filename=${scheme}.csv`
+        }
+      })
+
+      expect(getCsvMetadata).toHaveBeenCalledWith(scheme)
+      expect(getCsvHeaders).toHaveBeenCalledWith(scheme)
+      expect(getCsvPaths).toHaveBeenCalledWith(scheme, 0) // Called with 0 since initial headers were empty
+      expect(getMaxLengthOfSubArray).toHaveBeenCalledWith(mockPaths)
+      expect(generateCsvHeaders).toHaveBeenCalledWith(scheme, 3)
+      expect(createCsv).toHaveBeenCalledWith(mockMetadata, mockGeneratedHeaders, mockPaths)
     })
   })
 

--- a/serverless/src/shared/__tests__/generateCsvHeaders.test.js
+++ b/serverless/src/shared/__tests__/generateCsvHeaders.test.js
@@ -1,0 +1,36 @@
+import { describe, expect } from 'vitest'
+
+import { generateCsvHeaders } from '../generateCsvHeaders'
+
+describe('generateCsvHeaders', () => {
+  test('should generate headers for 2 columns', () => {
+    const headers = generateCsvHeaders('MyScheme', 2)
+    expect(headers).toEqual(['MyScheme', 'UUID'])
+  })
+
+  test('should generate headers for 5 columns', () => {
+    const headers = generateCsvHeaders('AnotherScheme', 5)
+    expect(headers).toEqual(['AnotherScheme', 'Level1', 'Level2', 'Level3', 'UUID'])
+  })
+
+  test('should generate headers for 3 columns', () => {
+    const headers = generateCsvHeaders('TestScheme', 3)
+    expect(headers).toEqual(['TestScheme', 'Level1', 'UUID'])
+  })
+
+  test('should handle large number of columns', () => {
+    const headers = generateCsvHeaders('LargeScheme', 10)
+    expect(headers).toEqual([
+      'LargeScheme',
+      'Level1',
+      'Level2',
+      'Level3',
+      'Level4',
+      'Level5',
+      'Level6',
+      'Level7',
+      'Level8',
+      'UUID'
+    ])
+  })
+})

--- a/serverless/src/shared/__tests__/getMaxLengthOfSubArray.test.js
+++ b/serverless/src/shared/__tests__/getMaxLengthOfSubArray.test.js
@@ -1,0 +1,55 @@
+import {
+  describe,
+  expect,
+  test
+} from 'vitest'
+
+import { getMaxLengthOfSubArray } from '../getMaxLengthOfSubArray'
+
+describe('getMaxLengthOfSubArray', () => {
+  describe('when successful', () => {
+    test('should return the correct length for a regular 2D array', () => {
+      const regularArray = [[1, 2, 3], [4, 5], [6, 7, 8, 9]]
+      expect(getMaxLengthOfSubArray(regularArray)).toBe(4)
+    })
+
+    test('should handle arrays with mixed types', () => {
+      const mixedArray = [[1, 2], 'string', [3, 4, 5]]
+      expect(getMaxLengthOfSubArray(mixedArray)).toBe(3)
+    })
+
+    test('should handle arrays with empty sub-arrays', () => {
+      const emptySubArrays = [[], [], [1, 2]]
+      expect(getMaxLengthOfSubArray(emptySubArrays)).toBe(2)
+    })
+
+    test('should handle arrays with nested arrays', () => {
+      const nestedArray = [[1, 2], [3, [4, 5]], [6, 7, 8]]
+      expect(getMaxLengthOfSubArray(nestedArray)).toBe(3)
+    })
+
+    test('should handle arrays with only one sub-array', () => {
+      const singleSubArray = [[1, 2, 3, 4, 5]]
+      expect(getMaxLengthOfSubArray(singleSubArray)).toBe(5)
+    })
+
+    test('should handle arrays with all empty sub-arrays', () => {
+      const allEmptySubArrays = [[], [], []]
+      expect(getMaxLengthOfSubArray(allEmptySubArrays)).toBe(0)
+    })
+  })
+
+  describe('when unsuccessful', () => {
+    test('should return 0 for an empty array', () => {
+      const emptyArray = []
+      expect(getMaxLengthOfSubArray(emptyArray)).toBe(0)
+    })
+
+    test('should return 0 for non-array input', () => {
+      expect(getMaxLengthOfSubArray('not an array')).toBe(0)
+      expect(getMaxLengthOfSubArray(123)).toBe(0)
+      expect(getMaxLengthOfSubArray(null)).toBe(0)
+      expect(getMaxLengthOfSubArray(undefined)).toBe(0)
+    })
+  })
+})

--- a/serverless/src/shared/createCsvForScheme.js
+++ b/serverless/src/shared/createCsvForScheme.js
@@ -1,8 +1,10 @@
 import { createCsv } from './createCsv'
+import { generateCsvHeaders } from './generateCsvHeaders'
 import { getApplicationConfig } from './getConfig'
 import { getCsvHeaders } from './getCsvHeaders'
 import { getCsvMetadata } from './getCsvMetadata'
 import { getCsvPaths } from './getCsvPaths'
+import { getMaxLengthOfSubArray } from './getMaxLengthOfSubArray'
 
 /**
  * Creates a CSV file for a specified scheme.
@@ -36,11 +38,17 @@ export const createCsvForScheme = async (scheme) => {
     // Get CSV output metadata
     const csvMetadata = await getCsvMetadata(scheme)
     // Get CSV headers
-    const csvHeaders = await getCsvHeaders(scheme)
+    let csvHeaders = await getCsvHeaders(scheme)
     // Calculate CSV header count
     const csvHeadersCount = csvHeaders.length
     // Get CSV row data
     const paths = await getCsvPaths(scheme, csvHeadersCount)
+    // If no headers were retrieved, generate them based on the maximum number of columns in the paths
+    if (csvHeaders.length === 0) {
+      const maxColumns = getMaxLengthOfSubArray(paths)
+      csvHeaders = generateCsvHeaders(scheme, maxColumns)
+    }
+
     // Sort output
     paths.sort((line1, line2) => {
       // eslint-disable-next-line no-plusplus

--- a/serverless/src/shared/generateCsvHeaders.js
+++ b/serverless/src/shared/generateCsvHeaders.js
@@ -1,0 +1,44 @@
+/**
+ * Generates CSV headers based on the provided scheme and maximum number of columns.
+ *
+ * @param {string} scheme - The scheme to be included in the headers.
+ * @param {number} maxColumns - The maximum number of columns in the CSV.
+ * @returns {string[]} An array of CSV header strings.
+ *
+ * @example
+ * // Generate headers for a CSV with 2 columns
+ * const headers1 = generateCsvHeaders('MyScheme', 2);
+ * console.log(headers1);
+ * // Output: ['MyScheme', 'UUID']
+ *
+ * @example
+ * // Generate headers for a CSV with 5 columns
+ * const headers2 = generateCsvHeaders('AnotherScheme', 5);
+ * console.log(headers2);
+ * // Output: ['AnotherScheme', 'Level1', 'Level2', 'Level3', 'UUID']
+ *
+ * @example
+ * // Generate headers for a CSV with 3 columns
+ * const headers3 = generateCsvHeaders('TestScheme', 3);
+ * console.log(headers3);
+ * // Output: ['TestScheme', 'Level1', 'UUID']
+ */
+export const generateCsvHeaders = (scheme, maxColumns) => {
+  const uuid = 'UUID'
+
+  if (maxColumns === 2) {
+    return [scheme, uuid]
+  }
+
+  const headers = [scheme]
+  const levelCount = maxColumns - 2
+
+  // eslint-disable-next-line no-plusplus
+  for (let i = 1; i <= levelCount; i++) {
+    headers.push(`Level${i}`)
+  }
+
+  headers.push(uuid)
+
+  return headers
+}

--- a/serverless/src/shared/getMaxLengthOfSubArray.js
+++ b/serverless/src/shared/getMaxLengthOfSubArray.js
@@ -1,0 +1,52 @@
+/**
+ * Finds the maximum length of sub-arrays in a given two-dimensional array.
+ *
+ * @param {Array} array - The input two-dimensional array.
+ * @returns {number} The length of the longest sub-array.
+ *
+ * @example
+ * // Regular 2D array
+ * const regularArray = [[1, 2, 3], [4, 5], [6, 7, 8, 9]];
+ * console.log(getMaxLengthOfSubArray(regularArray));
+ * // Output: 4
+ *
+ * @example
+ * // Array with mixed types
+ * const mixedArray = [[1, 2], 'string', [3, 4, 5]];
+ * console.log(getMaxLengthOfSubArray(mixedArray));
+ * // Output: 3
+ *
+ * @example
+ * // Empty array
+ * const emptyArray = [];
+ * console.log(getMaxLengthOfSubArray(emptyArray));
+ * // Output: 0
+ *
+ * @example
+ * // Array with empty sub-arrays
+ * const emptySubArrays = [[], [], [1, 2]];
+ * console.log(getMaxLengthOfSubArray(emptySubArrays));
+ * // Output: 2
+ *
+ * @example
+ * // Non-array input
+ * console.log(getMaxLengthOfSubArray('not an array'));
+ * // Output: 0
+ */
+export const getMaxLengthOfSubArray = (array) => {
+  // Check if the input is an array and not empty
+  if (!Array.isArray(array) || array.length === 0) {
+    // If not, return 0 as there are no sub-arrays
+    return 0
+  }
+
+  // Use map to create an array of sub-array lengths
+  // For each element in the array:
+  //   - If it's an array, take its length
+  //   - If it's not an array, consider its length as 0
+  const subArrayLengths = array.map((subArray) => (Array.isArray(subArray) ? subArray.length : 0))
+
+  // Use the spread operator to pass all lengths as separate arguments to Math.max
+  // Math.max then returns the largest number, which is the length of the longest sub-array
+  return Math.max(...subArrayLengths)
+}


### PR DESCRIPTION
# Overview

### What is the feature?

Generate CSV headers in case no headers defined for scheme

### What is the Solution?

Generate CSV headers

### What areas of the application does this impact?

CSV output for a scheme which doesn't have CSV headers defined

# Testing

Example https://cmr.sit.earthdata.nasa.gov/kms/concept/concept_scheme/PlatformType?format=csv

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
