### PR TITLE
KMS-514: Added authentication to CRUD apis

### DIFF
--- a/serverless-configs/aws-functions.yml
+++ b/serverless-configs/aws-functions.yml
@@ -124,22 +124,19 @@ deleteConcept:
           name: edlAuthorizer
           type: request
           resultTtlInSeconds: 0
-deleteAll:
-  handler: serverless/src/deleteAll/handler.default
-  timeout: ${env:LAMBDA_TIMEOUT, '30'}
 recreateDatabase:
   handler: serverless/src/recreateDatabase/handler.default
   timeout: ${env:LAMBDA_TIMEOUT, '900'}
+  path: recreateDatabase
   events:
     - http:
         method: delete
         cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
-        path: deleteAll
+        path: recreateDatabase
         authorizer:
           name: edlAuthorizer
           type: request
           resultTtlInSeconds: 0
-        path: recreateDatabase
 exportRdfToS3:
   handler: serverless/src/exportRdfToS3/handler.default
   timeout: ${env:LAMBDA_TIMEOUT, '900'}

--- a/serverless-configs/aws-functions.yml
+++ b/serverless-configs/aws-functions.yml
@@ -1,3 +1,6 @@
+edlAuthorizer:
+    handler: serverless/src/edlAuthorizer/handler.default
+    timeout: ${env:LAMBDA_TIMEOUT, '30'}
 errorLogger:
   handler: serverless/src/errorLogger/handler.default
   timeout: ${env:LAMBDA_TIMEOUT, '30'}
@@ -79,6 +82,11 @@ createConcept:
         method: post
         cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
         path: concept
+        authorizer:
+          name: edlAuthorizer
+          type: request
+          resultTtlInSeconds: 0
+        
 createConcepts:
   handler: serverless/src/createConcepts/handler.default
   timeout: ${env:LAMBDA_TIMEOUT, '30'}
@@ -87,6 +95,10 @@ createConcepts:
         method: post
         cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
         path: concepts
+        authorizer:
+          name: edlAuthorizer
+          type: request
+          resultTtlInSeconds: 0
 updateConcept:
   handler: serverless/src/updateConcept/handler.default
   timeout: ${env:LAMBDA_TIMEOUT, '30'}
@@ -95,6 +107,11 @@ updateConcept:
         method: put
         cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
         path: concept
+        authorizer:
+          name: edlAuthorizer
+          type: request
+          resultTtlInSeconds: 0
+
 deleteConcept:
   handler: serverless/src/deleteConcept/handler.default
   timeout: ${env:LAMBDA_TIMEOUT, '30'}
@@ -103,6 +120,13 @@ deleteConcept:
         method: delete
         cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
         path: concept/{conceptId}
+        authorizer:
+          name: edlAuthorizer
+          type: request
+          resultTtlInSeconds: 0
+deleteAll:
+  handler: serverless/src/deleteAll/handler.default
+  timeout: ${env:LAMBDA_TIMEOUT, '30'}
 recreateDatabase:
   handler: serverless/src/recreateDatabase/handler.default
   timeout: ${env:LAMBDA_TIMEOUT, '900'}
@@ -110,6 +134,11 @@ recreateDatabase:
     - http:
         method: delete
         cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
+        path: deleteAll
+        authorizer:
+          name: edlAuthorizer
+          type: request
+          resultTtlInSeconds: 0
         path: recreateDatabase
 exportRdfToS3:
   handler: serverless/src/exportRdfToS3/handler.default

--- a/serverless-configs/aws-functions.yml
+++ b/serverless-configs/aws-functions.yml
@@ -111,7 +111,6 @@ updateConcept:
           name: edlAuthorizer
           type: request
           resultTtlInSeconds: 0
-
 deleteConcept:
   handler: serverless/src/deleteConcept/handler.default
   timeout: ${env:LAMBDA_TIMEOUT, '30'}
@@ -127,7 +126,6 @@ deleteConcept:
 recreateDatabase:
   handler: serverless/src/recreateDatabase/handler.default
   timeout: ${env:LAMBDA_TIMEOUT, '900'}
-  path: recreateDatabase
   events:
     - http:
         method: delete

--- a/serverless.yml
+++ b/serverless.yml
@@ -23,6 +23,7 @@ provider:
     RDF4J_SERVICE_URL: ${env:RDF4J_SERVICE_URL, cf:rdf4jLoadBalancerStack.RDF4JServiceUrl, 'http://localhost:8080'} 
     RDF4J_USER_NAME: ${env:RDF4J_USER_NAME, 'rdf4j'}
     RDF4J_PASSWORD: ${env:RDF4J_PASSWORD, 'rdf4j'}
+    EDL_PASSWORD: ${env:EDL_PASSWORD, ''}
   # Prevent Serverless from attempting to modify the deployment bucket policy as NGAP does not allow it
   deploymentBucket:
     skipPolicySetup: true

--- a/serverless/src/edlAuthorizer/__tests__/handler.test.js
+++ b/serverless/src/edlAuthorizer/__tests__/handler.test.js
@@ -1,0 +1,68 @@
+import fetchEdlProfile from '@/shared/fetchEdlProfile'
+
+import edlAuthorizer from '../handler'
+
+vi.mock('@/shared/fetchEdlProfile')
+
+describe('edlAuthorizer', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV }
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  describe('when the token is for a valid user', () => {
+    test('returns a valid policy', async () => {
+      fetchEdlProfile.mockImplementation(() => ({
+        email: 'test.user@localhost',
+        first_name: 'Test',
+        last_name: 'User',
+        uid: 'mock_user'
+      }))
+
+      const event = {
+        headers: {
+          Authorization: 'mock-token'
+        }
+      }
+
+      const response = await edlAuthorizer(event, {})
+
+      expect(response).toEqual({
+        principalId: 'mock_user'
+      })
+    })
+  })
+
+  describe('when running offline', () => {
+    test('returns a valid policy', async () => {
+      process.env.IS_OFFLINE = true
+
+      const event = {
+        headers: {
+          Authorization: 'ABC-1'
+        }
+      }
+
+      const response = await edlAuthorizer(event, {})
+
+      expect(response).toEqual({
+        principalId: 'mock_user'
+      })
+    })
+  })
+
+  describe('when the supplied token is invalid', () => {
+    test('returns unauthorized', async () => {
+      fetchEdlProfile.mockImplementationOnce(() => false)
+
+      await expect(
+        edlAuthorizer({}, {})
+      ).rejects.toThrow('Unauthorized')
+    })
+  })
+})

--- a/serverless/src/edlAuthorizer/handler.js
+++ b/serverless/src/edlAuthorizer/handler.js
@@ -1,0 +1,28 @@
+import { downcaseKeys } from '@/shared/downcaseKeys'
+import fetchEdlProfile from '@/shared/fetchEdlProfile'
+import { generatePolicy } from '@/shared/generatePolicy'
+
+/**
+ * Custom authorizer for API Gateway authentication
+ * @param {Object} event Details about the HTTP request that it received
+ * @param {Object} context Methods and properties that provide information about the invocation, function, and execution environment
+ */
+const edlAuthorizer = async (event) => {
+  const {
+    headers = {},
+    methodArn
+  } = event
+
+  const { authorization: launchpadToken = '' } = downcaseKeys(headers)
+
+  const profile = await fetchEdlProfile(launchpadToken)
+  const { uid } = profile
+
+  if (uid) {
+    return generatePolicy(uid, 'Allow', methodArn)
+  }
+
+  throw new Error('Unauthorized')
+}
+
+export default edlAuthorizer

--- a/serverless/src/shared/__tests__/createCsvForScheme.test.js
+++ b/serverless/src/shared/__tests__/createCsvForScheme.test.js
@@ -27,6 +27,7 @@ describe('createCsvForScheme', () => {
   beforeEach(() => {
     // Reset all mocks before each test
     vi.resetAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
   describe('when successful', () => {

--- a/serverless/src/shared/__tests__/dowcaseKeys.test.js
+++ b/serverless/src/shared/__tests__/dowcaseKeys.test.js
@@ -1,0 +1,39 @@
+import { downcaseKeys } from '../downcaseKeys'
+
+describe('downcaseKeys', () => {
+  test('returns an empty object when undefined is provided', () => {
+    const returnObject = downcaseKeys(undefined)
+
+    expect(returnObject).toMatchObject({})
+  })
+
+  test('downcases keys', () => {
+    const returnObject = downcaseKeys({
+      KEY: 'value'
+    })
+
+    expect(returnObject).toMatchObject({
+      key: 'value'
+    })
+  })
+
+  test('downcases camel cased keys', () => {
+    const returnObject = downcaseKeys({
+      hyphenatedKey: 'value'
+    })
+
+    expect(returnObject).toMatchObject({
+      hyphenatedkey: 'value'
+    })
+  })
+
+  test('downcases hyphenated keys', () => {
+    const returnObject = downcaseKeys({
+      'Hyphenated-Key': 'value'
+    })
+
+    expect(returnObject).toMatchObject({
+      'hyphenated-key': 'value'
+    })
+  })
+})

--- a/serverless/src/shared/__tests__/fetchEdlClientToken.test.js
+++ b/serverless/src/shared/__tests__/fetchEdlClientToken.test.js
@@ -28,7 +28,7 @@ describe('Retrieving EDL Client Token', () => {
     expect(fetch).toHaveBeenCalledWith('https://localtest.urs.earthdata.nasa.gov/oauth/token', {
       body: 'grant_type=client_credentials',
       headers: {
-        Authorization: 'Basic bW10X3Rlc3Q6dGVzdA==',
+        Authorization: 'Basic a21zX3Rlc3Q6dGVzdA=',
         'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
       },
       method: 'POST'

--- a/serverless/src/shared/__tests__/fetchEdlClientToken.test.js
+++ b/serverless/src/shared/__tests__/fetchEdlClientToken.test.js
@@ -6,7 +6,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.spyOn(getConfig, 'getEdlConfig').mockImplementation(() => ({
     host: 'https://localtest.urs.earthdata.nasa.gov',
-    uid: 'mmt_test'
+    uid: 'kms_test'
   }))
 
   process.env.EDL_PASSWORD = 'test'

--- a/serverless/src/shared/__tests__/fetchEdlClientToken.test.js
+++ b/serverless/src/shared/__tests__/fetchEdlClientToken.test.js
@@ -1,0 +1,50 @@
+import * as getConfig from '@/shared/getConfig'
+
+import fetchEdlClientToken from '../fetchEdlClientToken'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(getConfig, 'getEdlConfig').mockImplementation(() => ({
+    host: 'https://localtest.urs.earthdata.nasa.gov',
+    uid: 'mmt_test'
+  }))
+
+  process.env.EDL_PASSWORD = 'test'
+})
+
+global.fetch = vi.fn(() => Promise.resolve({
+  json: () => Promise.resolve({
+    access_token: 'mock_token',
+    token_type: 'Bearer',
+    expires_in: 1296000
+  })
+}))
+
+describe('Retrieving EDL Client Token', () => {
+  test('returns token', async () => {
+    const token = await fetchEdlClientToken()
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith('https://localtest.urs.earthdata.nasa.gov/oauth/token', {
+      body: 'grant_type=client_credentials',
+      headers: {
+        Authorization: 'Basic bW10X3Rlc3Q6dGVzdA==',
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+      },
+      method: 'POST'
+    })
+
+    expect(token).toEqual('mock_token')
+  })
+
+  test('returns undefined when the response from EDL is an error', async () => {
+    fetch.mockImplementationOnce(() => Promise.reject(new Error('Error calling EDL')))
+
+    const token = await fetchEdlClientToken()
+      .catch((error) => {
+        expect(error.message).toEqual('Error calling EDL')
+      })
+
+    expect(token).toEqual(undefined)
+  })
+})

--- a/serverless/src/shared/__tests__/fetchEdlClientToken.test.js
+++ b/serverless/src/shared/__tests__/fetchEdlClientToken.test.js
@@ -28,7 +28,7 @@ describe('Retrieving EDL Client Token', () => {
     expect(fetch).toHaveBeenCalledWith('https://localtest.urs.earthdata.nasa.gov/oauth/token', {
       body: 'grant_type=client_credentials',
       headers: {
-        Authorization: 'Basic a21zX3Rlc3Q6dGVzdA=',
+        Authorization: 'Basic a21zX3Rlc3Q6dGVzdA==',
         'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
       },
       method: 'POST'

--- a/serverless/src/shared/__tests__/fetchEdlProfile.test.js
+++ b/serverless/src/shared/__tests__/fetchEdlProfile.test.js
@@ -74,6 +74,7 @@ describe('fetchEdlProfile', () => {
 
   describe('when the token is ABC-1', () => {
     test('returns the users profile', async () => {
+      process.env.IS_OFFLINE = true
       const profile = await fetchEdlProfile('ABC-1')
 
       expect(profile).toEqual({
@@ -83,6 +84,7 @@ describe('fetchEdlProfile', () => {
       })
 
       expect(fetch).toHaveBeenCalledTimes(0)
+      process.env.IS_OFFLINE = false
     })
   })
 

--- a/serverless/src/shared/__tests__/fetchEdlProfile.test.js
+++ b/serverless/src/shared/__tests__/fetchEdlProfile.test.js
@@ -1,0 +1,105 @@
+import fetchEdlClientToken from '../fetchEdlClientToken'
+import fetchEdlProfile from '../fetchEdlProfile'
+
+vi.mock('../fetchEdlClientToken', () => ({ default: vi.fn() }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+
+  fetchEdlClientToken.mockImplementation(() => ('mock_token'))
+})
+
+describe('fetchEdlProfile', () => {
+  describe('when the user exists', () => {
+    test('returns the users profile', async () => {
+      global.fetch = vi.fn(() => Promise.resolve({
+        json: () => Promise.resolve({
+          nams_auid: 'user.name',
+          uid: 'user.name',
+          first_name: 'User',
+          last_name: 'Name'
+        })
+      }))
+
+      const profile = await fetchEdlProfile('mock-token')
+
+      expect(profile).toEqual({
+        auid: 'user.name',
+        uid: 'user.name',
+        name: 'User Name'
+      })
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(fetch).toHaveBeenCalledWith('https://sit.urs.earthdata.nasa.gov/api/nams/edl_user', {
+        body: 'token=mock-token',
+        headers: {
+          Authorization: 'Bearer mock_token',
+          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+        },
+        method: 'POST'
+      })
+    })
+  })
+
+  describe('when the user does not have name fields', () => {
+    test('returns the users profile', async () => {
+      global.fetch = vi.fn(() => Promise.resolve({
+        json: () => Promise.resolve({
+          nams_auid: 'user.name',
+          uid: 'user.name',
+          first_name: undefined,
+          last_name: undefined
+        })
+      }))
+
+      const profile = await fetchEdlProfile('mock-token')
+
+      expect(profile).toEqual({
+        auid: 'user.name',
+        uid: 'user.name',
+        name: 'user.name'
+      })
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(fetch).toHaveBeenCalledWith('https://sit.urs.earthdata.nasa.gov/api/nams/edl_user', {
+        body: 'token=mock-token',
+        headers: {
+          Authorization: 'Bearer mock_token',
+          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+        },
+        method: 'POST'
+      })
+    })
+  })
+
+  describe('when the token is ABC-1', () => {
+    test('returns the users profile', async () => {
+      const profile = await fetchEdlProfile('ABC-1')
+
+      expect(profile).toEqual({
+        auid: 'admin',
+        name: 'Admin User',
+        uid: 'admin'
+      })
+
+      expect(fetch).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('when the response from EDL is an error', () => {
+    test('returns undefined', async () => {
+      fetch.mockImplementationOnce(() => Promise.reject(new Error('Error calling EDL')))
+      const consoleMock = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      const token = await fetchEdlProfile('mock-token')
+        .catch((error) => {
+          expect(error.message).toEqual('Error calling EDL')
+        })
+
+      expect(consoleMock).toHaveBeenCalledTimes(1)
+      expect(consoleMock).toHaveBeenCalledWith('fetchEdlProfile Error: ', new Error('Error calling EDL'))
+
+      expect(token).toEqual(undefined)
+    })
+  })
+})

--- a/serverless/src/shared/__tests__/formatCsvPath.test.js
+++ b/serverless/src/shared/__tests__/formatCsvPath.test.js
@@ -1,6 +1,12 @@
 import { formatCsvPath } from '../formatCsvPath'
 
 describe('formatPath', () => {
+  beforeEach(() => {
+    // Reset all mocks before each test
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
   describe('when successful', () => {
     describe('platforms, instruments, projects schemes', () => {
       const schemes = ['platforms', 'instruments', 'projects']

--- a/serverless/src/shared/__tests__/generatePolicy.test.js
+++ b/serverless/src/shared/__tests__/generatePolicy.test.js
@@ -1,0 +1,43 @@
+import { generatePolicy } from '../generatePolicy'
+
+describe('generatePolicy', () => {
+  describe('when a jwtToken is provided', () => {
+    test('policy includes the provided token', () => {
+      const response = generatePolicy('testuser', {}, 'test-resource')
+
+      expect(response).toEqual({
+        policyDocument: {
+          Statement: [
+            {
+              Action: 'execute-api:Invoke',
+              Effect: {},
+              Resource: 'test-resource'
+            }
+          ],
+          Version: '2012-10-17'
+        },
+        principalId: 'testuser'
+      })
+    })
+  })
+
+  describe('when no resource is provided', () => {
+    test('policy does not include a policy document', () => {
+      const response = generatePolicy('testuser', undefined, {}, undefined)
+
+      expect(response).toEqual({
+        principalId: 'testuser'
+      })
+    })
+  })
+
+  describe('when no effect is provided', () => {
+    test('policy does not include a policy document', () => {
+      const response = generatePolicy('testuser', undefined, undefined, 'test-resource')
+
+      expect(response).toEqual({
+        principalId: 'testuser'
+      })
+    })
+  })
+})

--- a/serverless/src/shared/__tests__/getCsvHeaders.test.js
+++ b/serverless/src/shared/__tests__/getCsvHeaders.test.js
@@ -16,6 +16,7 @@ describe('getCsvHeaders', () => {
   beforeEach(() => {
     // Clear all mocks before each test
     vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
   afterEach(() => {

--- a/serverless/src/shared/__tests__/getCsvMetadata.test.js
+++ b/serverless/src/shared/__tests__/getCsvMetadata.test.js
@@ -21,6 +21,7 @@ describe('getCsvMetadata', () => {
     vi.resetAllMocks()
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2023-06-15T12:00:00Z'))
+    vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
   afterEach(() => {

--- a/serverless/src/shared/__tests__/getNarrowersMap.test.js
+++ b/serverless/src/shared/__tests__/getNarrowersMap.test.js
@@ -14,6 +14,10 @@ vi.mock('../sparqlRequest', () => ({
 }))
 
 describe('getNarrowersMap', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
   afterEach(() => {
     vi.clearAllMocks()
   })

--- a/serverless/src/shared/__tests__/getProviderUrlsMap.test.js
+++ b/serverless/src/shared/__tests__/getProviderUrlsMap.test.js
@@ -11,6 +11,7 @@ import * as sparqlRequestModule from '../sparqlRequest'
 describe('getProviderUrlsMap', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
   describe('when successful', () => {

--- a/serverless/src/shared/downcaseKeys.js
+++ b/serverless/src/shared/downcaseKeys.js
@@ -1,0 +1,12 @@
+/**
+ * Downcase all keys of an object
+ * @param {Object} obj Object to transform
+ * @returns Object with all keys downcased
+ */
+export const downcaseKeys = (obj = {}) => {
+  const entries = Object.entries(obj)
+
+  return Object.fromEntries(
+    entries.map(([key, value]) => [key.toLowerCase(), value])
+  )
+}

--- a/serverless/src/shared/fetchEdlClientToken.js
+++ b/serverless/src/shared/fetchEdlClientToken.js
@@ -1,0 +1,30 @@
+import { getEdlConfig } from '@/shared/getConfig'
+
+/**
+ * The EDL client token is used for retrieving/modifying user/groups in URS.
+ * @returns the EDL client token
+ */
+const fetchEdlClientToken = async () => {
+  const { host, uid } = getEdlConfig()
+
+  const { EDL_PASSWORD: password } = process.env
+
+  const url = `${host}/oauth/token`
+  const authorizationHeader = `Basic ${Buffer.from(`${uid}:${password}`).toString('base64')}`
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: authorizationHeader,
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+    },
+    body: 'grant_type=client_credentials'
+  })
+  const json = await response.json()
+
+  const accessToken = json.access_token
+
+  return accessToken
+}
+
+export default fetchEdlClientToken

--- a/serverless/src/shared/fetchEdlProfile.js
+++ b/serverless/src/shared/fetchEdlProfile.js
@@ -7,7 +7,11 @@ import fetchEdlClientToken from './fetchEdlClientToken'
  * @param {Object} headers Lambda event headers
  */
 const fetchEdlProfile = async (launchpadToken) => {
-  if (launchpadToken === 'ABC-1') {
+  const {
+    IS_OFFLINE
+  } = process.env
+
+  if (IS_OFFLINE && launchpadToken === 'ABC-1') {
     return {
       auid: 'admin',
       name: 'Admin User',

--- a/serverless/src/shared/fetchEdlProfile.js
+++ b/serverless/src/shared/fetchEdlProfile.js
@@ -1,0 +1,56 @@
+import { getEdlConfig } from '@/shared/getConfig'
+
+import fetchEdlClientToken from './fetchEdlClientToken'
+
+/**
+ * Returns the user's EDL profile based on the launchpad token provided
+ * @param {Object} headers Lambda event headers
+ */
+const fetchEdlProfile = async (launchpadToken) => {
+  if (launchpadToken === 'ABC-1') {
+    return {
+      auid: 'admin',
+      name: 'Admin User',
+      uid: 'admin'
+    }
+  }
+
+  const { host } = getEdlConfig()
+
+  const clientToken = await fetchEdlClientToken()
+
+  return fetch(`${host}/api/nams/edl_user`, {
+    body: `token=${launchpadToken}`,
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${clientToken}`,
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+    }
+  })
+    .then((response) => response.json())
+    .then((profile) => {
+      const {
+        first_name: firstName,
+        last_name: lastName
+      } = profile
+
+      let name = [firstName, lastName].filter(Boolean).join(' ')
+
+      if (name.trim().length === 0) {
+        name = profile.uid
+      }
+
+      return {
+        auid: profile.nams_auid,
+        name,
+        uid: profile.uid
+      }
+    })
+    .catch((error) => {
+      console.log('fetchEdlProfile Error: ', error)
+
+      return undefined
+    })
+}
+
+export default fetchEdlProfile

--- a/serverless/src/shared/generatePolicy.js
+++ b/serverless/src/shared/generatePolicy.js
@@ -1,0 +1,26 @@
+/**
+ * Generate AuthPolicy for the Authorizer
+ * @param {String} username username of authenticated uset
+ * @param {String} effect
+ * @param {Object} resource
+ */
+export const generatePolicy = (username, effect, resource) => {
+  const authResponse = {
+    principalId: username
+  }
+
+  if (effect && resource) {
+    const policyDocument = {}
+    policyDocument.Version = '2012-10-17'
+    policyDocument.Statement = []
+    const statementOne = {}
+    statementOne.Action = 'execute-api:Invoke'
+    statementOne.Effect = effect
+    statementOne.Resource = resource
+    policyDocument.Statement[0] = statementOne
+
+    authResponse.policyDocument = policyDocument
+  }
+
+  return authResponse
+}

--- a/serverless/src/shared/getConfig.js
+++ b/serverless/src/shared/getConfig.js
@@ -27,3 +27,4 @@ const applicationConfig = {
  *                                     Uses the RDF4J_SERVICE_URL environment variable.
  */
 export const getApplicationConfig = () => applicationConfig
+export const getEdlConfig = () => getConfig().edl

--- a/static.config.json
+++ b/static.config.json
@@ -7,5 +7,9 @@
       "Access-Control-Allow-Headers": "*",
       "Access-Control-Allow-Credentials": true
     }
+  },
+  "edl": {
+    "host": "https://sit.urs.earthdata.nasa.gov",
+    "uid": "mmt_test"
   }
 }


### PR DESCRIPTION
# Overview

### What is the feature?

Adding authentication when creating, updating, deleting concepts.

### What is the Solution?

Added `edlAuthorizer` to aws-functions.yml to any lambdas that write/delete data, this function will inspect the headers for a launchpad token and validate it against EDL.

### What areas of the application does this impact?

Any operations that involve writing concepts will be authenticated now.

# Testing

You'll need to comment out:
    noAuth: true in serverless.yml
Restart serverless offline, make sure you have EDL_PASSWORD set in your env (same as MMT one).
Try hitting endpoints that require authentication, these should fail if you don't supply a token.
To supply a token, you'll need to pass -H "Authorization: $TOKEN" to your calls.

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
