### PR TITLE
KMS-539: AMI update to /ngap/amis/image_id_ecs_al2023_x86

### DIFF
--- a/infrastructure/rdfdb/cdk/lib/ecs-stack.js
+++ b/infrastructure/rdfdb/cdk/lib/ecs-stack.js
@@ -134,7 +134,7 @@ const custom = require('aws-cdk-lib/custom-resources')
 
     const autoScalingGroup = new autoscaling.AutoScalingGroup(this, 'rdf4jAutoScalingGroup', {
       instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MEDIUM),
-      machineImage: ecs.EcsOptimizedImage.amazonLinux2(),
+      machineImage: ec2.MachineImage.fromSsmParameter('/ngap/amis/image_id_ecs_al2023_x86'),
       minCapacity: 1,
       maxCapacity: 1,
       vpc: this.vpc,

--- a/infrastructure/rdfdb/cdk/scripts/ebs-mount-script.sh
+++ b/infrastructure/rdfdb/cdk/scripts/ebs-mount-script.sh
@@ -5,36 +5,15 @@ set -x
 echo "Starting EBS mount script"
 
 # Install AWS CLI
-echo "Installing AWS CLI..."
-
-# Specify the version and its corresponding SHA256 hash
-AWS_CLI_VERSION="2.13.8"
-AWS_CLI_SHA256="8b3e3f8f57c8c3c3492fa3e3a436f1fa115cdc983fde3801bdc1c2feb3517531"
-
-# Download the specific version
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip"
-
-# Verify the integrity of the downloaded file
-COMPUTED_SHA256=$(sha256sum awscliv2.zip | cut -d' ' -f1)
-
-if [ "$COMPUTED_SHA256" != "$AWS_CLI_SHA256" ]; then
-    echo "SHA256 mismatch. Expected $AWS_CLI_SHA256, got $COMPUTED_SHA256"
-    exit 1
-fi
-
-echo "SHA256 verification passed"
-yum install -y unzip
-
-unzip awscliv2.zip
-./aws/install
-echo "AWS CLI installed successfully"
+yum install -y unzip aws-cli
 
 DEVICE="/dev/xvdf"
 MOUNT_POINT="/mnt/rdf4j-data"
 
 # Get instance ID and region
-INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
-REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/region)
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" -s)
+INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id -s)
+REGION=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/region -s)
 
 echo "Instance ID: $INSTANCE_ID"
 echo "Region: $REGION"


### PR DESCRIPTION
# Overview

### What is the feature?

Update AMI to use /ngap/amis/image_id_ecs_al2023_x86

### What is the Solution?

Had to update ecs stack to fetch the ami from ssm parameter.  There were also some issues with retrieving the instance id in this update, so now retrieving it based on best practices.

### What areas of the application does this impact?

Deployment of ECS stack.

# Testing

Go to AWS, view EC2 instances and verify the AMI is current now.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
