### PR TITLE
KMS-514: Fixed to now pass in EDL_PASSWORD

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -56,6 +56,7 @@ dockerRun() {
         --env "VPC_ID=$bamboo_VPC_ID" \
         --env "RDF4J_USER_NAME=$bamboo_RDF4J_USER_NAME" \
         --env "RDF4J_PASSWORD=$bamboo_RDF4J_PASSWORD" \
+        --env "EDL_PASSWORD=$bamboo_EDL_PASSWORD" \
         $dockerTag "$@"
 }
 


### PR DESCRIPTION
# Overview

### What is the feature?

Auth needs EDL_PASSWORD, so need to pass this in during deployment.

### What is the Solution?

Updated deploy_bamboo.sh to pass in EDL_PASSWORD and updated bamboo variables.

### What areas of the application does this impact?

creates/updates/deletes on KMS

# Testing

You'll need to comment out:
noAuth: true in serverless.yml
Restart serverless offline, make sure you have EDL_PASSWORD set in your env (same as MMT one).
Try hitting endpoints that require authentication, these should fail if you don't supply a token.
To supply a token, you'll need to pass -H "Authorization: $TOKEN" to your calls.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
