### PR TITLE
KMS-535b: Fixing non-default export

### DIFF
--- a/serverless/src/shared/__tests__/createChangeNote.test.js
+++ b/serverless/src/shared/__tests__/createChangeNote.test.js
@@ -4,7 +4,7 @@ import {
   test
 } from 'vitest'
 
-import createChangeNote from '../createChangeNote'
+import { createChangeNote } from '../createChangeNote'
 
 describe('createChangeNote', () => {
   describe('when processing a single change note item', () => {

--- a/serverless/src/shared/createChangeNote.js
+++ b/serverless/src/shared/createChangeNote.js
@@ -61,4 +61,4 @@ const createChangeNote = (note) => {
   return changeNote
 }
 
-module.exports = createChangeNote
+export default createChangeNote

--- a/serverless/src/shared/createChangeNote.js
+++ b/serverless/src/shared/createChangeNote.js
@@ -22,7 +22,7 @@
  *     }
  *   }
  */
-const createChangeNote = (note) => {
+export const createChangeNote = (note) => {
   const lines = note.split('\n').map((line) => line.trim())
   const changeNote = {
     changeNoteItems: {
@@ -60,5 +60,3 @@ const createChangeNote = (note) => {
 
   return changeNote
 }
-
-export default createChangeNote

--- a/serverless/src/shared/toLegacyXML.js
+++ b/serverless/src/shared/toLegacyXML.js
@@ -1,4 +1,4 @@
-import createChangeNote from './createChangeNote'
+import { createChangeNote } from './createChangeNote'
 
 // Helper function to retrieve parsed information in concept_schemes xml
 function findMatchingConceptScheme(schemeShortName, conceptSchemes) {


### PR DESCRIPTION
# Overview

### What is the feature?

Bamboo is not building because createChangeNote was not a default export.

### What is the Solution?

Summarize what you changed.

createChangeNote changed from module.exports = createChangeNote to export default createChangeNote

List impacted areas.

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Step 1
2. Step 2...

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
