### PR TITLE
KMS-517: Now passes version when constructing getConcepts

### DIFF
--- a/serverless/src/getConcepts/handler.js
+++ b/serverless/src/getConcepts/handler.js
@@ -117,15 +117,15 @@ export const getConcepts = async (event) => {
     const startIndex = (pageNum - 1) * pageSize
     const endIndex = Math.min(startIndex + pageSize, totalConcepts)
     const conceptURIs = fullURIs.slice(startIndex, endIndex)
-    const prefLabelMap = await createPrefLabelMap()
-    const conceptToConceptSchemeShortNameMap = await createConceptToConceptSchemeShortNameMap()
+    const prefLabelMap = await createPrefLabelMap(version)
+    const conceptToConceptSchemeShortNameMap = await createConceptToConceptSchemeShortNameMap(version)
 
     let responseBody
     let contentType
 
     // Handle different formats based on queryStringParameter 'format'
     if (format.toLowerCase() === 'json') {
-      const conceptSchemeMap = await createConceptSchemeMap()
+      const conceptSchemeMap = await createConceptSchemeMap(event)
       const jsonResponse = {
         hits: totalConcepts,
         page_num: pageNum,

--- a/serverless/src/shared/createConceptSchemeMap.js
+++ b/serverless/src/shared/createConceptSchemeMap.js
@@ -30,7 +30,7 @@ import getConceptSchemes from '@/getConceptSchemes/handler'
  * }
  */
 
-export const createConceptSchemeMap = () => getConceptSchemes()
+export const createConceptSchemeMap = (event) => getConceptSchemes(event)
   .then((conceptSchemes) => {
     const xmlConceptSchemes = conceptSchemes.body
     const parser = new XMLParser({

--- a/serverless/src/shared/createConceptToConceptSchemeShortNameMap.js
+++ b/serverless/src/shared/createConceptToConceptSchemeShortNameMap.js
@@ -17,7 +17,7 @@ import { sparqlRequest } from './sparqlRequest'
  *   console.error('Failed to create short name map:', error);
  * }
  */
-export const createConceptToConceptSchemeShortNameMap = async () => {
+export const createConceptToConceptSchemeShortNameMap = async (version) => {
   const query = `
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     SELECT ?concept ?schemeShortName
@@ -33,7 +33,8 @@ export const createConceptToConceptSchemeShortNameMap = async () => {
       method: 'POST',
       body: query,
       contentType: 'application/sparql-query',
-      accept: 'application/sparql-results+json'
+      accept: 'application/sparql-results+json',
+      version
     })
 
     if (!response.ok) {


### PR DESCRIPTION
# Overview

### What is the feature?

In getConcepts, I failed to handle merge conflicts properly and should have updated some of the methods to include a version.

### What is the Solution?

Updated getConcepts to pass in a version to any helper functions.

### What areas of the application does this impact?

getConcepts

# Testing

Previously, https://cmr.sit.earthdata.nasa.gov/kms/concepts was failing, it should work after this fix.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
