### PR TITLE
KMS-520: Update report date issue

### DIFF
--- a/serverless/src/getConceptUpdatesReport/__tests__/handler.test.js
+++ b/serverless/src/getConceptUpdatesReport/__tests__/handler.test.js
@@ -106,7 +106,13 @@ describe('createCsvReport', () => {
         newValue: 'New definition'
       }
     ]
-    const csv = createCsvReport(notes, null, 'Change Report')
+    const csv = createCsvReport({
+      changeNotes: notes,
+      userId: null,
+      title: 'Change Report',
+      startDate: '2023-06-01',
+      endDate: '2023-06-02'
+    })
     expect(csv).toContain('Change Report')
     expect(csv).toContain('"Date","User Id","Entity","Operation","System Note","Field","User Note","Old Value","New Value"')
     expect(csv).toContain('"2023-06-02","user2","Concept","Create","","Definition","","","New definition"')
@@ -134,14 +140,26 @@ describe('createCsvReport', () => {
         newValue: 'New definition'
       }
     ]
-    const csv = createCsvReport(notes, 'user1', 'Filtered Report')
+    const csv = createCsvReport({
+      changeNotes: notes,
+      userId: 'user1',
+      title: 'Filtered Report',
+      startDate: '2023-06-01',
+      endDate: '2023-06-02'
+    })
     expect(csv).toContain('Filtered Report')
     expect(csv).toContain('"2023-06-01","user1","Concept","Update","","Label","","Old","New"')
     expect(csv).not.toContain('user2')
   })
 
   test('should handle empty input', () => {
-    const csv = createCsvReport([], null, 'Empty Report')
+    const csv = createCsvReport({
+      changeNotes: [],
+      userId: null,
+      title: 'Empty Report',
+      startDate: '2023-06-01',
+      endDate: '2023-06-02'
+    })
     expect(csv).toContain('Empty Report')
     expect(csv).toContain('"Date","User Id","Entity","Operation","System Note","Field","User Note","Old Value","New Value"')
     const lines = csv.split('\n')
@@ -162,10 +180,17 @@ describe('createCsvReport', () => {
         newValue: 'New,value'
       }
     ]
-    const csv = createCsvReport(notes, null, 'Escaped Report')
-    expect(csv).toContain('"user,1"') // Comma in userId should be quoted
-    expect(csv).toContain('"Old ""quoted"" value"') // Double quotes should be escaped
-    expect(csv).toContain('"New,value"') // Comma in newValue should be quoted
+    const csv = createCsvReport({
+      changeNotes: notes,
+      userId: null,
+      title: 'Escaped Report',
+      startDate: '2023-06-01',
+      endDate: '2023-06-01'
+    })
+    const lines = csv.split('\n')
+    expect(lines[0]).toBe('Escaped Report')
+    expect(lines[1]).toBe('"Date","User Id","Entity","Operation","System Note","Field","User Note","Old Value","New Value"')
+    expect(lines[2]).toBe('"2023-06-01","user,1","Concept","Update","","Label","","Old ""quoted"" value","New,value"')
   })
 
   test('should sort notes by date, newest first', () => {
@@ -198,8 +223,16 @@ describe('createCsvReport', () => {
         newValue: ''
       }
     ]
-    const csv = createCsvReport(notes, null, 'Sorted Report')
+    const csv = createCsvReport({
+      changeNotes: notes,
+      userId: null,
+      title: 'Sorted Report',
+      startDate: '2023-06-01',
+      endDate: '2023-06-03'
+    })
     const lines = csv.split('\n')
+    expect(lines[0]).toBe('Sorted Report')
+    expect(lines[1]).toBe('"Date","User Id","Entity","Operation","System Note","Field","User Note","Old Value","New Value"')
     expect(lines[2]).toContain('"2023-06-03"') // Newest date should be first
     expect(lines[3]).toContain('"2023-06-02"')
     expect(lines[4]).toContain('"2023-06-01"') // Oldest date should be last
@@ -212,13 +245,24 @@ describe('createCsvReport', () => {
         userId: null,
         entity: undefined,
         operation: 'Update',
+        systemNote: null,
         field: 'Label',
+        userNote: undefined,
         oldValue: '',
         newValue: 'New'
       }
     ]
-    const csv = createCsvReport(notes, null, 'Null Value Report')
-    expect(csv).toContain('"2023-06-01","","","Update","","Label","","","New"')
+    const csv = createCsvReport({
+      changeNotes: notes,
+      userId: null,
+      title: 'Null Value Report',
+      startDate: '2023-06-01',
+      endDate: '2023-06-01'
+    })
+    const lines = csv.split('\n')
+    expect(lines[0]).toBe('Null Value Report')
+    expect(lines[1]).toBe('"Date","User Id","Entity","Operation","System Note","Field","User Note","Old Value","New Value"')
+    expect(lines[2]).toBe('"2023-06-01","","","Update","","Label","","","New"')
   })
 
   test('should handle custom headers and hit the default case', () => {
@@ -237,7 +281,14 @@ describe('createCsvReport', () => {
 
     const customHeaders = ['Date', 'User Id', 'Entity', 'Operation', 'Field', 'Old Value', 'New Value', 'Custom Field']
 
-    const csv = createCsvReport(notes, null, 'Custom Header Report', customHeaders)
+    const csv = createCsvReport({
+      changeNotes: notes,
+      userId: null,
+      title: 'Custom Header Report',
+      customHeaders,
+      startDate: '2023-06-01',
+      endDate: '2023-06-01'
+    })
     const lines = csv.split('\n')
 
     expect(lines[0]).toBe('Custom Header Report')

--- a/serverless/src/getConceptUpdatesReport/handler.js
+++ b/serverless/src/getConceptUpdatesReport/handler.js
@@ -5,10 +5,13 @@ import { getApplicationConfig } from '@/shared/getConfig'
 /**
  * Creates a CSV report from processed change notes.
  *
- * @param {Array} processedChangeNotes - Array of change note objects
- * @param {string|null} userId - Optional user ID to filter notes
- * @param {string} title - Title of the report
- * @param {Array<string>|null} customHeaders - Optional custom headers for the CSV
+ * @param {Object} options - The options for creating the CSV report
+ * @param {Array} options.changeNotes - Array of change note objects
+ * @param {string|null} options.userId - Optional user ID to filter notes
+ * @param {string} options.title - Title of the report
+ * @param {Array<string>|null} [options.customHeaders=null] - Optional custom headers for the CSV
+ * @param {string} options.startDate - Start date for filtering change notes (format: 'YYYY-MM-DD')
+ * @param {string} options.endDate - End date for filtering change notes (format: 'YYYY-MM-DD')
  * @returns {string} CSV formatted string
  *
  * @example
@@ -16,7 +19,13 @@ import { getApplicationConfig } from '@/shared/getConfig'
  *   { date: '2023-06-01', userId: 'user1', entity: 'Concept', operation: 'Update', field: 'Label', oldValue: 'Old', newValue: 'New' },
  *   { date: '2023-06-02', userId: 'user2', entity: 'Concept', operation: 'Create', field: 'Definition', oldValue: '', newValue: 'New definition' }
  * ];
- * const csv = createCsvReport(notes, null, 'Change Report');
+ * const csv = createCsvReport({
+ *   changeNotes: notes,
+ *   userId: null,
+ *   title: 'Change Report',
+ *   startDate: '2023-06-01',
+ *   endDate: '2023-06-30'
+ * });
  * console.log(csv);
  * // Output:
  * // Change Report
@@ -26,7 +35,14 @@ import { getApplicationConfig } from '@/shared/getConfig'
  *
  * // With custom headers
  * const customHeaders = ['Date', 'User', 'Action', 'Details'];
- * const customCsv = createCsvReport(notes, null, 'Custom Report', customHeaders);
+ * const customCsv = createCsvReport({
+ *   changeNotes: notes,
+ *   userId: null,
+ *   title: 'Custom Report',
+ *   customHeaders: customHeaders,
+ *   startDate: '2023-06-01',
+ *   endDate: '2023-06-30'
+ * });
  * console.log(customCsv);
  * // Output:
  * // Custom Report
@@ -34,7 +50,9 @@ import { getApplicationConfig } from '@/shared/getConfig'
  * // "2023-06-02","user2","Create","Definition: New definition"
  * // "2023-06-01","user1","Update","Label: Old -> New"
  */
-export const createCsvReport = (processedChangeNotes, userId, title, customHeaders = null) => {
+export const createCsvReport = ({
+  changeNotes, userId, title, customHeaders = null, startDate, endDate
+}) => {
   const headers = customHeaders || ['Date', 'User Id', 'Entity', 'Operation', 'System Note', 'Field', 'User Note', 'Old Value', 'New Value']
   const result = []
   result.push(title)
@@ -54,10 +72,15 @@ export const createCsvReport = (processedChangeNotes, userId, title, customHeade
   // Add the headers as the first row, with each header in quotes
   result.push(headers.map(quoteValue).join(','))
 
-  // Filter processedChangeNotes if userId is provided
-  const filteredNotes = userId
-    ? processedChangeNotes.filter((note) => note.userId === userId)
-    : processedChangeNotes
+  // Filter changeNotes based on date range and userId
+  const filteredNotes = changeNotes.filter((note) => {
+    const noteDate = new Date(note.date)
+    const start = new Date(startDate)
+    const end = new Date(endDate)
+    const isInDateRange = noteDate >= start && noteDate <= end
+
+    return isInDateRange && (userId ? note.userId === userId : true)
+  })
 
   // Sort the filtered notes by date, newest first
   filteredNotes.sort((a, b) => new Date(b.date) - new Date(a.date))
@@ -167,9 +190,7 @@ export const getConceptUpdatesReport = async (event) => {
 
   const changeNoteTriples = await getConceptChangeNoteTriples({
     version,
-    scheme,
-    startDate,
-    endDate
+    scheme
   })
 
   // Process change notes
@@ -180,7 +201,13 @@ export const getConceptUpdatesReport = async (event) => {
   })
 
   const title = `Keyword Change Report\nKeyword Version: ${version}, From: ${startDate}, To: ${endDate}`
-  const result = createCsvReport(processedChangeNotes, userId, title)
+  const result = createCsvReport({
+    changeNotes: processedChangeNotes,
+    userId,
+    title,
+    startDate,
+    endDate
+  })
   const fileName = `KeywordUpdateReport-${startDate}-${endDate}`
 
   // Set CSV response header

--- a/serverless/src/getConceptUpdatesReport/handler.js
+++ b/serverless/src/getConceptUpdatesReport/handler.js
@@ -74,6 +74,7 @@ export const createCsvReport = ({
 
   // Filter changeNotes based on date range and userId
   const filteredNotes = changeNotes.filter((note) => {
+    if (!note.date) return false
     const noteDate = new Date(note.date)
     const start = new Date(startDate)
     const end = new Date(endDate)

--- a/serverless/src/shared/__tests__/getConceptChangeNoteTriples.test.js
+++ b/serverless/src/shared/__tests__/getConceptChangeNoteTriples.test.js
@@ -1,4 +1,5 @@
 import {
+  afterEach,
   beforeEach,
   describe,
   expect,
@@ -12,7 +13,6 @@ import { sparqlRequest } from '../sparqlRequest'
 vi.mock('../sparqlRequest')
 
 describe('getConceptChangeNotes', () => {
-  // Add these lines at the beginning of your describe block
   let consoleErrorSpy
 
   beforeEach(() => {
@@ -48,9 +48,7 @@ describe('getConceptChangeNotes', () => {
 
     const result = await getConceptChangeNoteTriples({
       version: 'v1',
-      scheme: 'earth_science',
-      startDate: '2023-01-01',
-      endDate: '2023-12-31'
+      scheme: 'earth_science'
     })
 
     expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
@@ -121,9 +119,7 @@ describe('getConceptChangeNotes', () => {
 
     await getConceptChangeNoteTriples({
       version: 'v2',
-      scheme: 'test_scheme',
-      startDate: '2023-01-01',
-      endDate: '2023-12-31'
+      scheme: 'test_scheme'
     })
 
     expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
@@ -132,6 +128,33 @@ describe('getConceptChangeNotes', () => {
       accept: 'application/sparql-results+json',
       version: 'v2',
       body: expect.stringContaining('https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/test_scheme')
+    }))
+  })
+
+  test('calls sparqlRequest without scheme parameter', async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        results: {
+          bindings: [{
+            concept: 'Concept1',
+            changeNote: 'Note1'
+          }]
+        }
+      })
+    }
+    sparqlRequest.mockResolvedValue(mockResponse)
+
+    await getConceptChangeNoteTriples({
+      version: 'v2'
+    })
+
+    expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
+      method: 'POST',
+      contentType: 'application/sparql-query',
+      accept: 'application/sparql-results+json',
+      version: 'v2',
+      body: expect.not.stringContaining('https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/')
     }))
   })
 })

--- a/serverless/src/shared/getConceptChangeNoteTriples.js
+++ b/serverless/src/shared/getConceptChangeNoteTriples.js
@@ -5,23 +5,19 @@ import { sparqlRequest } from './sparqlRequest'
  * Fetches concept change notes based on provided parameters.
  *
  * @async
- * @function getConceptChangeNotes
+ * @function getConceptChangeNoteTriples
  * @param {Object} params - The parameters for fetching concept change notes.
  * @param {string} params.version - The version of the API to use.
  * @param {string} [params.scheme] - The scheme to filter the concepts by (optional).
- * @param {string} [params.startDate] - The start date for the date range (optional).
- * @param {string} [params.endDate] - The end date for the date range (optional).
  * @returns {Promise<Array>} A promise that resolves to an array of concept change notes.
  * @throws {Error} Throws an error if the request fails or no results are found.
  *
  * @example
  * // Fetch concept change notes for a specific date range and scheme
  * try {
- *   const notes = await getConceptChangeNotes({
+ *   const notes = await getConceptChangeNoteTriples({
  *     version: 'v1',
- *     scheme: 'earth_science',
- *     startDate: '2023-01-01',
- *     endDate: '2023-12-31'
+ *     scheme: 'earth_science'
  *   });
  *   console.log(notes);
  * } catch (error) {
@@ -31,7 +27,7 @@ import { sparqlRequest } from './sparqlRequest'
  * @example
  * // Fetch all concept change notes without date range or scheme
  * try {
- *   const allNotes = await getConceptChangeNotes({
+ *   const allNotes = await getConceptChangeNoteTriples({
  *     version: 'v1'
  *   });
  *   console.log(allNotes);
@@ -40,13 +36,11 @@ import { sparqlRequest } from './sparqlRequest'
  * }
  */
 export const getConceptChangeNoteTriples = async ({
-  version, scheme, startDate, endDate
+  version, scheme
 }) => {
-  const query = getConceptChangeNotesQuery({
-    startDate,
-    endDate,
-    scheme: scheme ? `https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/${scheme}` : null
-  })
+  const query = getConceptChangeNotesQuery(
+    scheme ? `https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/${scheme}` : null
+  )
 
   try {
     const response = await sparqlRequest({

--- a/serverless/src/shared/operations/queries/getConceptChangeNotesQuery.js
+++ b/serverless/src/shared/operations/queries/getConceptChangeNotesQuery.js
@@ -1,4 +1,4 @@
-export const getConceptChangeNotesQuery = ({ startDate, endDate, scheme }) => {
+export const getConceptChangeNotesQuery = (scheme) => {
   let schemeFilter = ''
   if (scheme) {
     schemeFilter = `?concept <http://www.w3.org/2004/02/skos/core#inScheme> <${scheme}> .`
@@ -8,13 +8,8 @@ export const getConceptChangeNotesQuery = ({ startDate, endDate, scheme }) => {
     SELECT DISTINCT ?concept ?p ?changeNote
 WHERE {
   ?concept a <http://www.w3.org/2004/02/skos/core#Concept> .
-  ?concept <http://purl.org/dc/terms/modified> ?modified .
   ?concept <http://www.w3.org/2004/02/skos/core#changeNote> ?changeNote .
   ${schemeFilter}
-  FILTER (
-    ?modified >= "${startDate}"^^xsd:string && 
-    ?modified <= "${endDate}"^^xsd:string
-  )
   BIND(<http://www.w3.org/2004/02/skos/core#changeNote> AS ?p)
 }
   `


### PR DESCRIPTION
# Overview

### What is the feature?

Change Notes in report shows wrong dates

### What is the Solution?

Fetch all notes and filter out instead of using update date

### What areas of the application does this impact?

Concept update reports

# Testing

URL to test, for example: http://localhost:4001/dev/concepts/operations/update_report?version=draft&startDate=2025-01-01&endDate=2025-03-15
report should not show dates outside of the given time interval 

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
