### PR TITLE
KMS-577: Changes necessary to deploy to UAT.

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -10,7 +10,10 @@ set -eux
 config="`cat static.config.json`"
 
 # update keys for deployment
+config="`jq '.application.version = $newValue' --arg newValue ${RELEASE_VERSION} <<< $config`"
 config="`jq '.application.env = $newValue' --arg newValue $bamboo_STAGE_NAME <<< $config`"
+config="`jq '.edl.host = $newValue' --arg newValue $bamboo_EDL_HOST <<< $config`"
+config="`jq '.edl.uid = $newValue' --arg newValue $bamboo_EDL_UID <<< $config`"
 
 # overwrite static.config.json with new values
 echo $config > tmp.$$.json && mv tmp.$$.json static.config.json

--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -37,7 +37,6 @@ COPY . /build
 WORKDIR /build
 RUN npm ci --omit=dev && npm run build
 EOF
-export bamboo_STAGE_NAME=sit
 dockerTag=kms-$bamboo_STAGE_NAME
 docker build -t $dockerTag .
 
@@ -48,7 +47,7 @@ dockerRun() {
         --env "AWS_SECRET_ACCESS_KEY=$bamboo_AWS_SECRET_ACCESS_KEY" \
         --env "AWS_SESSION_TOKEN=$bamboo_AWS_SESSION_TOKEN" \
         --env "LAMBDA_TIMEOUT=$bamboo_LAMBDA_TIMEOUT" \
-        --env "NODE_ENV=sit" \
+        --env "NODE_ENV=$bamboo_STAGE_NAME" \
         --env "NODE_OPTIONS=--max_old_space_size=4096" \
         --env "SUBNET_ID_A=$bamboo_SUBNET_ID_A" \
         --env "SUBNET_ID_B=$bamboo_SUBNET_ID_B" \

--- a/infrastructure/rdfdb/cdk/bin/deploy_to_ecr.sh
+++ b/infrastructure/rdfdb/cdk/bin/deploy_to_ecr.sh
@@ -14,13 +14,13 @@ REPO_URI=$(aws ecr describe-repositories --repository-names $REPO_NAME --region 
 # Authenticate Docker to ECR
 aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $REPO_URI
 
-# Build Docker image
-docker build -t $REPO_NAME $DOCKER_FILE_PATH
+# Set up a new builder instance
+docker buildx create --name amd64builder --use
 
-# Tag the image
-docker tag $REPO_NAME:latest $REPO_URI:latest
+# Build and push Docker image for amd64 architecture
+docker buildx build --platform=linux/amd64 -t $REPO_URI:latest --push $DOCKER_FILE_PATH
 
-# Push the image to ECR
-docker push $REPO_URI:latest
+echo "Docker image built and pushed to $REPO_URI:latest"
 
-echo "Docker image pushed to $REPO_URI:latest"
+# Clean up the builder
+docker buildx rm amd64builder

--- a/infrastructure/rdfdb/cdk/docker/scripts/create_repository.sh
+++ b/infrastructure/rdfdb/cdk/docker/scripts/create_repository.sh
@@ -10,8 +10,8 @@ create_repository() {
 
   if [ ! -d "${RDF4J_DATA_DIR}/server/repositories/kms" ]; then
     # Create the repository
-    echo "Repository 'kms' does not exist. Creating it..."
-    curl -u rdf4j:rdf4j -X PUT -H "Content-Type: application/x-turtle" --data-binary '
+    echo "Repository 'kms' does not exist. Creating it...   Using ${RDF4J_USER_NAME}:${RDF4J_PASSWORD}"
+    curl -u ${RDF4J_USER_NAME}:${RDF4J_PASSWORD} -X PUT -H "Content-Type: application/x-turtle" --data-binary '
 #
 # RDF4J configuration template for a main-memory repository
 #

--- a/infrastructure/rdfdb/cdk/lib/ebs-stack.js
+++ b/infrastructure/rdfdb/cdk/lib/ebs-stack.js
@@ -26,7 +26,7 @@ class EbsStack extends Stack {
   createEbsVolume() {
     return new ec2.Volume(this, 'rdf4jVolume', {
       availabilityZone: this.vpc.availabilityZones[0],
-      size: Size.gibibytes(16),
+      size: Size.gibibytes(parseInt(process.env.EBS_VOLUME_SIZE || '32', 10)),
       volumeType: ec2.EbsDeviceVolumeType.GP3,
       encrypted: true,
       removalPolicy: RemovalPolicy.RETAIN

--- a/infrastructure/rdfdb/cdk/lib/ecs-stack.js
+++ b/infrastructure/rdfdb/cdk/lib/ecs-stack.js
@@ -143,15 +143,6 @@ const custom = require('aws-cdk-lib/custom-resources')
         availabilityZones: [this.getEbsVolumeAz()]
       },
       userData,
-      blockDevices: [
-        {
-          deviceName: '/dev/xvda',
-          volume: autoscaling.BlockDeviceVolume.ebs(32, {
-            volumeType: autoscaling.EbsDeviceVolumeType.GP2,
-            deleteOnTermination: false
-          })
-        }
-      ],
       role: this.role
     })
 

--- a/static.config.json
+++ b/static.config.json
@@ -1,1 +1,15 @@
-{ "application": { "env": "sit", "version": "development", "defaultResponseHeaders": { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Headers": "*", "Access-Control-Allow-Credentials": true } }, "edl": { "host": "https://sit.urs.earthdata.nasa.gov", "uid": "mmt_test" } }
+{
+  "application": {
+    "env": "sit",
+    "version": "development",
+    "defaultResponseHeaders": {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Headers": "*",
+      "Access-Control-Allow-Credentials": true
+    }
+  },
+  "edl": {
+    "host": "https://sit.urs.earthdata.nasa.gov",
+    "uid": "mmt_test"
+  }
+}


### PR DESCRIPTION
# Overview

### What is the feature?

This PR reflects updates to the code needed when trying to deploy the KMS application and RDF DB to UAT.

### What is the Solution?

These changes include:

Deploy RDF DB changes:
1) Changes to the docker file to build and push the container image using `--platform=linux/amd64`, which is what AWS expects.   I found out that building and pushing the image on my Mac built the wrong platform, it was building an arm machine type instead.
2) Made EBS volume size configurable.
3) I noticed it was creating 2 EBS volumes, there was some leftover code in the ECS stack that was not needed, as the EBS Volume stack is responsible for creating the volume.
4) The script used to create the RDF db repo didn't use env variable for the RDF DB username/password.

Changes for Deploying the KMS application included:
1) The code needed to use bamboo env variables for EDL user id and EDL host name, which is used when authenticating with launchpad.
2) There was a hardcoded env (sit) being used in the deploy-bamboo.sh script, it needed to use $bamboo_STAGE_NAME instead.

### What areas of the application does this impact?

Deployment of RDF db and application to UAT.

# Testing

README includes steps for deploying the RDF DB and KMS Application manually.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
