### PR TITLE
KMS-575: Fix to retrieve full path when keyword doens't have broader.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 secret.config.json
 tmp
 .env
+setup/data/export
 
 # VSCode Settings
 .vscode

--- a/serverless-configs/aws-functions.yml
+++ b/serverless-configs/aws-functions.yml
@@ -77,6 +77,7 @@ status:
         path: status
 getConcepts:
   handler: serverless/src/getConcepts/handler.default
+  provisionedConcurrency: 1
   timeout: ${env:LAMBDA_TIMEOUT, '900'}
   events:
     - http:

--- a/serverless/src/getCapabilities/__tests__/handler.test.js
+++ b/serverless/src/getCapabilities/__tests__/handler.test.js
@@ -11,7 +11,8 @@ import { getCapabilities } from '@/getCapabilities/handler'
 // Mock the getApplicationConfig function
 vi.mock('@/shared/getConfig', () => ({
   getApplicationConfig: vi.fn(() => ({
-    defaultResponseHeaders: { 'X-Custom-Header': 'CustomValue' }
+    defaultResponseHeaders: { 'X-Custom-Header': 'CustomValue' },
+    version: '1.2.3'
   }))
 }))
 
@@ -43,7 +44,7 @@ describe('getCapabilities', () => {
       // Check that the XML is well-formed and contains expected elements
       expect(result.body).toContain('<capabilities version="0.5">')
       expect(result.body).toContain('<software>')
-      expect(result.body).toContain('<version>n/a</version>')
+      expect(result.body).toContain('<version>1.2.3</version>')
       expect(result.body).toContain('<documentation>')
       expect(result.body).toContain('<termsOfUse>')
       expect(result.body).toContain('<urls>')

--- a/serverless/src/getCapabilities/__tests__/handler.test.js
+++ b/serverless/src/getCapabilities/__tests__/handler.test.js
@@ -43,8 +43,7 @@ describe('getCapabilities', () => {
       // Check that the XML is well-formed and contains expected elements
       expect(result.body).toContain('<capabilities version="0.5">')
       expect(result.body).toContain('<software>')
-      expect(result.body).toContain('<version>3.1.0</version>')
-      expect(result.body).toContain('<build>KMS-24.4.8-5</build>')
+      expect(result.body).toContain('<version>n/a</version>')
       expect(result.body).toContain('<documentation>')
       expect(result.body).toContain('<termsOfUse>')
       expect(result.body).toContain('<urls>')

--- a/serverless/src/getCapabilities/handler.js
+++ b/serverless/src/getCapabilities/handler.js
@@ -29,15 +29,14 @@ import { getApplicationConfig } from '@/shared/getConfig'
  * // </capabilities>
  */
 export const getCapabilities = async () => {
-  const { defaultResponseHeaders } = getApplicationConfig()
+  const { defaultResponseHeaders, version } = getApplicationConfig()
 
   try {
     const capabilities = {
       capabilities: {
         ':@': { version: '0.5' },
         software: {
-          version: { '#text': '3.1.0' },
-          build: { '#text': 'KMS-24.4.8-5' }
+          version: { '#text': version ?? 'n/a' }
         },
         documentation: { '#text': 'https://wiki.earthdata.nasa.gov/display/ED/KMS+User%27s+Guide' },
         termsOfUse: { '#text': 'https://cdn.earthdata.nasa.gov/conduit/upload/5182/KeywordsCommunityGuide_Baseline_v1_SIGNED_FINAL.pdf' },

--- a/serverless/src/shared/__tests__/buildFullPath.test.js
+++ b/serverless/src/shared/__tests__/buildFullPath.test.js
@@ -86,6 +86,22 @@ describe('buildFullPath', () => {
     })
   })
 
+  test('should handle a concept without a broader concept', async () => {
+    sparqlRequest.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        results: {
+          bindings: [{
+            prefLabel: { value: 'TOP LEVEL CONCEPT' }
+          }]
+        }
+      })
+    })
+
+    const result = await buildFullPath('top-level-concept')
+    expect(result).toBe('TOP LEVEL CONCEPT')
+  })
+
   describe('when unsuccessful', () => {
     test('should throw error on HTTP failure', async () => {
       sparqlRequest.mockResolvedValue({

--- a/serverless/src/shared/__tests__/filterKeywordTree.test.js
+++ b/serverless/src/shared/__tests__/filterKeywordTree.test.js
@@ -103,6 +103,56 @@ describe('filterKeywordTree', () => {
 
       expect(filterKeywordTree(treeWithoutChildren, 'Root')).toEqual(expected)
     })
+
+    describe('when filtering by uuid', () => {
+      const treeWithKeys = {
+        title: 'Root',
+        key: 'root-key',
+        children: [
+          {
+            title: 'Child 1',
+            key: 'child-1-key',
+            children: []
+          },
+          {
+            title: 'Child 2',
+            key: 'child-2-key',
+            children: [
+              {
+                title: 'Grandchild',
+                key: 'grandchild-key',
+                children: []
+              }
+            ]
+          }
+        ]
+      }
+
+      test('should filter tree based on node.key', () => {
+        const expected = {
+          title: 'Root',
+          key: 'root-key',
+          children: [
+            {
+              title: 'Child 2',
+              key: 'child-2-key',
+              children: [
+                {
+                  title: 'Grandchild',
+                  key: 'grandchild-key',
+                  children: []
+                }
+              ]
+            }
+          ]
+        }
+        expect(filterKeywordTree(treeWithKeys, 'grandchild-key')).toEqual(expected)
+      })
+
+      test('should return null when no keys match the filter', () => {
+        expect(filterKeywordTree(treeWithKeys, 'nonexistent-key')).toBeNull()
+      })
+    })
   })
 
   describe('When unsuccessful', () => {

--- a/serverless/src/shared/buildFullPath.js
+++ b/serverless/src/shared/buildFullPath.js
@@ -58,7 +58,7 @@ export const buildFullPath = async (conceptId, version) => {
 
     return {
       prefLabel: triples[0].prefLabel.value,
-      broader: triples[0].broader.value
+      broader: triples[0].broader?.value
     }
   }
 
@@ -69,9 +69,13 @@ export const buildFullPath = async (conceptId, version) => {
       return []
     }
 
-    const parentPath = await buildPathRecursive(conceptInfo.broader)
+    if (conceptInfo.broader) {
+      const parentPath = await buildPathRecursive(conceptInfo.broader)
 
-    return [...parentPath, conceptInfo.prefLabel]
+      return [...parentPath, conceptInfo.prefLabel]
+    }
+
+    return [conceptInfo.prefLabel]
   }
 
   const path = await buildPathRecursive(`${baseUri}${conceptId}`)

--- a/serverless/src/shared/filterKeywordTree.js
+++ b/serverless/src/shared/filterKeywordTree.js
@@ -65,7 +65,7 @@ export const filterKeywordTree = (node, filter) => {
       .filter((child) => child !== null)
     : []
 
-  if (matchesFilter(node.title, filter) || filteredChildren.length > 0) {
+  if (node.key === filter || matchesFilter(node.title, filter) || filteredChildren.length > 0) {
     return {
       ...node,
       children: filteredChildren

--- a/serverless/src/shared/operations/queries/getConceptPrefLabelAndBroaderIdQuery.js
+++ b/serverless/src/shared/operations/queries/getConceptPrefLabelAndBroaderIdQuery.js
@@ -3,7 +3,9 @@ import prefixes from '@/shared/constants/prefixes'
 export const getConceptPrefLabelAndBroaderIdQuery = (conceptIRI) => `
     ${prefixes}
     SELECT ?s ?prefLabel ?broader WHERE {
-     <${conceptIRI}> skos:prefLabel ?prefLabel .
-        <${conceptIRI}> skos:broader ?broader  
+      <${conceptIRI}> skos:prefLabel ?prefLabel .
+      OPTIONAL {
+        <${conceptIRI}> skos:broader ?broader .
+      }
     }
-    `
+`


### PR DESCRIPTION
# Overview

Fix to retrieve full path when keyword doesn't have broader terms (/concept_fullpaths/concept_uuid/{conceptId})
Also added support for keyword tree (/tree/concept_scheme/{conceptScheme}) to support searching by uuid as well as pattern.

**Please summarize the feature or fix.**

Changed the sparql query to make the broader optional and handle fetching full path for keywords without a broader as a special case.

For the keyword tree to support UUID searches, was just a matter of adding that to the list conditional for whether a node stays in the tree

### What areas of the application does this impact?

Keyword Form and  searching for a keyword in the tree using UUID.

# Testing

Test the form where keywords don't have a broader (chained operations).
http://localhost:4001/dev/kms/concept_fullpaths/concept_uuid/ee18f758-071a-4ac8-8cd6-b217270243ea

Try searching by UUID.
http://localhost:4001/dev/tree/concept_scheme/sciencekeywords?filter=aa35a52f-e3d9-41bd-abd2-ec7e1a8101d1

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
