### PR TITLE
KMS-585: Updates to support logging of changenotes for reciprocal relationships.

### DIFF
--- a/serverless/src/deleteConcept/handler.js
+++ b/serverless/src/deleteConcept/handler.js
@@ -46,6 +46,9 @@
  *   }
  * }
  */
+import { addChangeNotes } from '@/shared/addChangeNotes'
+import { captureRelations } from '@/shared/captureRelations'
+import { compareRelations } from '@/shared/compareRelations'
 import { conceptIdExists } from '@/shared/conceptIdExists'
 import { deleteTriples } from '@/shared/deleteTriples'
 import { ensureReciprocal } from '@/shared/ensureReciprocal'
@@ -90,6 +93,8 @@ export const deleteConcept = async (event) => {
     // Start transaction
     transactionUrl = await startTransaction()
 
+    const beforeRelations = await captureRelations(conceptId, version, transactionUrl)
+
     // Get the existing concept data
     const oldRdfXml = await getConceptById(conceptId, version)
 
@@ -107,6 +112,17 @@ export const deleteConcept = async (event) => {
 
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`)
+    }
+
+    // Capture relations after update
+    const afterRelations = await captureRelations(conceptId, version, transactionUrl)
+
+    // Compare before and after relations
+    const { addedRelations, removedRelations } = compareRelations(beforeRelations, afterRelations)
+
+    // Generate and add change notes
+    if (addedRelations.length > 0 || removedRelations.length > 0) {
+      await addChangeNotes(addedRelations, removedRelations, version, transactionUrl)
     }
 
     // Commit transaction

--- a/serverless/src/shared/__tests__/addChangeNotes.test.js
+++ b/serverless/src/shared/__tests__/addChangeNotes.test.js
@@ -1,0 +1,276 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi
+} from 'vitest'
+
+import { sparqlRequest } from '@/shared/sparqlRequest'
+
+import { addChangeNotes } from '../addChangeNotes'
+
+// Mock the sparqlRequest function
+vi.mock('@/shared/sparqlRequest')
+
+describe('addChangeNotes', () => {
+  const mockVersion = 'draft'
+  const mockTransactionUrl = 'http://example.com/transaction/1'
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    // Mock the current date
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2023-06-01'))
+  })
+
+  test('should add change notes for added relations', async () => {
+    const addedRelations = [
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123',
+        relation: 'broader',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/456'
+      }
+    ]
+    const removedRelations = []
+
+    sparqlRequest.mockResolvedValue({ ok: true })
+
+    await addChangeNotes(addedRelations, removedRelations, mockVersion, mockTransactionUrl)
+
+    expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.stringContaining('Date=2023-06-01 User Id=system System Note=Added broader relation from <123> to <456>')
+    }))
+  })
+
+  test('should add change notes for removed relations', async () => {
+    const addedRelations = []
+    const removedRelations = [
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123',
+        relation: 'related',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/789'
+      }
+    ]
+
+    sparqlRequest.mockResolvedValue({ ok: true })
+
+    await addChangeNotes(addedRelations, removedRelations, mockVersion, mockTransactionUrl)
+
+    expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.stringContaining('Date=2023-06-01 User Id=system System Note=Removed related relation from <123> to <789>')
+    }))
+  })
+
+  test('should handle both added and removed relations', async () => {
+    const addedRelations = [
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123',
+        relation: 'broader',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/456'
+      }
+    ]
+    const removedRelations = [
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123',
+        relation: 'related',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/789'
+      }
+    ]
+
+    sparqlRequest.mockResolvedValue({ ok: true })
+
+    await addChangeNotes(addedRelations, removedRelations, mockVersion, mockTransactionUrl)
+
+    expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.stringContaining('Added broader relation from <123> to <456>')
+    }))
+
+    expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.stringContaining('Removed related relation from <123> to <789>')
+    }))
+  })
+
+  test('should use correct SPARQL query structure', async () => {
+    const addedRelations = [
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123',
+        relation: 'broader',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/456'
+      }
+    ]
+    const removedRelations = []
+
+    sparqlRequest.mockResolvedValue({ ok: true })
+
+    await addChangeNotes(addedRelations, removedRelations, mockVersion, mockTransactionUrl)
+
+    expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
+      method: 'POST',
+      contentType: 'application/sparql-update',
+      accept: 'application/json',
+      body: expect.stringMatching(/PREFIX skos:.*WITH.*INSERT.*WHERE \{ \}/s),
+      version: mockVersion,
+      transaction: {
+        transactionUrl: mockTransactionUrl,
+        action: 'UPDATE'
+      }
+    }))
+  })
+
+  test('should throw error when sparqlRequest fails', async () => {
+    const addedRelations = [
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123',
+        relation: 'broader',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/456'
+      }
+    ]
+    const removedRelations = []
+
+    sparqlRequest.mockResolvedValue({
+      ok: false,
+      status: 500
+    })
+
+    await expect(addChangeNotes(addedRelations, removedRelations, mockVersion, mockTransactionUrl))
+      .rejects.toThrow('Failed to add change notes: 500')
+  })
+
+  test('should handle empty arrays of relations', async () => {
+    sparqlRequest.mockResolvedValue({ ok: true })
+
+    await addChangeNotes([], [], mockVersion, mockTransactionUrl)
+
+    expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.not.stringContaining('System Note=')
+    }))
+  })
+
+  test('should correctly extract UUIDs from URIs', async () => {
+    const addedRelations = [
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123-456-789',
+        relation: 'broader',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/987-654-321'
+      }
+    ]
+    const removedRelations = []
+
+    sparqlRequest.mockResolvedValue({ ok: true })
+
+    await addChangeNotes(addedRelations, removedRelations, mockVersion, mockTransactionUrl)
+
+    expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.stringContaining('from <123-456-789> to <987-654-321>')
+    }))
+  })
+
+  test('should handle multiple change notes', async () => {
+    const addedRelations = [
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123',
+        relation: 'broader',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/456'
+      },
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/789',
+        relation: 'narrower',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/012'
+      }
+    ]
+    const removedRelations = [
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/345',
+        relation: 'related',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/678'
+      }
+    ]
+
+    sparqlRequest.mockResolvedValue({ ok: true })
+
+    await addChangeNotes(addedRelations, removedRelations, mockVersion, mockTransactionUrl)
+
+    const sparqlCall = sparqlRequest.mock.calls[0][0]
+    expect(sparqlCall.body).toContain('Added broader relation from <123> to <456>')
+    expect(sparqlCall.body).toContain('Added narrower relation from <789> to <012>')
+    expect(sparqlCall.body).toContain('Removed related relation from <345> to <678>')
+  })
+
+  test('should use the correct version in the SPARQL query', async () => {
+    const addedRelations = [
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123',
+        relation: 'broader',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/456'
+      }
+    ]
+    const removedRelations = []
+    const testVersion = 'published'
+
+    sparqlRequest.mockResolvedValue({ ok: true })
+
+    await addChangeNotes(addedRelations, removedRelations, testVersion, mockTransactionUrl)
+
+    expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.stringContaining(`WITH <https://gcmd.earthdata.nasa.gov/kms/version/${testVersion}>`),
+      version: testVersion
+    }))
+  })
+
+  test('should handle relations with special characters', async () => {
+    const addedRelations = [
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123',
+        relation: 'has_part',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/456'
+      }
+    ]
+    const removedRelations = []
+
+    sparqlRequest.mockResolvedValue({ ok: true })
+
+    await addChangeNotes(addedRelations, removedRelations, mockVersion, mockTransactionUrl)
+
+    expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.stringContaining('Added has_part relation from <123> to <456>')
+    }))
+  })
+
+  test('should escape double quotes in change notes', async () => {
+    const addedRelations = [
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123',
+        relation: 'broader',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/456"with"quotes'
+      }
+    ]
+    const removedRelations = []
+
+    sparqlRequest.mockResolvedValue({ ok: true })
+
+    await addChangeNotes(addedRelations, removedRelations, mockVersion, mockTransactionUrl)
+
+    expect(sparqlRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('Added broader relation from <123> to <456"with"quotes>')
+      })
+    )
+  })
+
+  test('should handle network errors', async () => {
+    const addedRelations = [
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123',
+        relation: 'broader',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/456'
+      }
+    ]
+    const removedRelations = []
+
+    sparqlRequest.mockRejectedValue(new Error('Network error'))
+
+    await expect(addChangeNotes(addedRelations, removedRelations, mockVersion, mockTransactionUrl))
+      .rejects.toThrow('Network error')
+  })
+})

--- a/serverless/src/shared/__tests__/captureRelations.test.js
+++ b/serverless/src/shared/__tests__/captureRelations.test.js
@@ -1,0 +1,261 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi
+} from 'vitest'
+
+import { sparqlRequest } from '@/shared/sparqlRequest'
+
+import { captureRelations } from '../captureRelations'
+
+// Mock the sparqlRequest function
+vi.mock('@/shared/sparqlRequest')
+
+describe('captureRelations', () => {
+  const mockConceptId = '123e4567-e89b-12d3-a456-426614174000'
+  const mockVersion = 'draft'
+  const mockTransactionUrl = 'http://example.com/transaction/1'
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  test('should capture outgoing and incoming relations', async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        results: {
+          bindings: [
+            {
+              from: { value: `https://gcmd.earthdata.nasa.gov/kms/concept/${mockConceptId}` },
+              relation: { value: 'http://www.w3.org/2004/02/skos/core#broader' },
+              to: { value: 'https://gcmd.earthdata.nasa.gov/kms/concept/456' }
+            },
+            {
+              from: { value: 'https://gcmd.earthdata.nasa.gov/kms/concept/789' },
+              relation: { value: 'http://www.w3.org/2004/02/skos/core#narrower' },
+              to: { value: `https://gcmd.earthdata.nasa.gov/kms/concept/${mockConceptId}` }
+            }
+          ]
+        }
+      })
+    }
+
+    sparqlRequest.mockResolvedValue(mockResponse)
+
+    const result = await captureRelations(mockConceptId, mockVersion, mockTransactionUrl)
+
+    expect(sparqlRequest).toHaveBeenCalledWith({
+      method: 'POST',
+      contentType: 'application/sparql-query',
+      accept: 'application/sparql-results+json',
+      body: expect.any(String),
+      version: mockVersion,
+      transaction: {
+        transactionUrl: mockTransactionUrl,
+        action: 'QUERY'
+      }
+    })
+
+    expect(result).toEqual([
+      {
+        from: `https://gcmd.earthdata.nasa.gov/kms/concept/${mockConceptId}`,
+        relation: 'broader',
+        to: 'https://gcmd.earthdata.nasa.gov/kms/concept/456'
+      },
+      {
+        from: 'https://gcmd.earthdata.nasa.gov/kms/concept/789',
+        relation: 'narrower',
+        to: `https://gcmd.earthdata.nasa.gov/kms/concept/${mockConceptId}`
+      }
+    ])
+  })
+
+  test('should handle empty result set', async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        results: {
+          bindings: []
+        }
+      })
+    }
+
+    sparqlRequest.mockResolvedValue(mockResponse)
+
+    const result = await captureRelations(mockConceptId, mockVersion)
+
+    expect(result).toEqual([])
+  })
+
+  test('should throw error on failed request', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 500
+    }
+
+    sparqlRequest.mockResolvedValue(mockResponse)
+
+    await expect(captureRelations(mockConceptId, mockVersion)).rejects.toThrow('Failed to fetch relations: 500')
+  })
+
+  test('should handle transaction URL correctly', async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        results: {
+          bindings: []
+        }
+      })
+    }
+
+    sparqlRequest.mockResolvedValue(mockResponse)
+
+    await captureRelations(mockConceptId, mockVersion, mockTransactionUrl)
+
+    expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
+      transaction: {
+        transactionUrl: mockTransactionUrl,
+        action: 'QUERY'
+      }
+    }))
+  })
+
+  test('should handle null transaction URL correctly', async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        results: {
+          bindings: []
+        }
+      })
+    }
+
+    sparqlRequest.mockResolvedValue(mockResponse)
+
+    await captureRelations(mockConceptId, mockVersion, null)
+
+    expect(sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
+      transaction: null
+    }))
+  })
+
+  test('should extract relation name correctly', async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        results: {
+          bindings: [
+            {
+              from: { value: `https://gcmd.earthdata.nasa.gov/kms/concept/${mockConceptId}` },
+              relation: { value: 'http://gcmd.nasa.gov/schema/gcmd#hasInstrument' },
+              to: { value: 'https://gcmd.earthdata.nasa.gov/kms/concept/456' }
+            }
+          ]
+        }
+      })
+    }
+
+    sparqlRequest.mockResolvedValue(mockResponse)
+
+    const result = await captureRelations(mockConceptId, mockVersion)
+
+    expect(result[0].relation).toBe('hasInstrument')
+  })
+
+  test('should handle all types of relations', async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        results: {
+          bindings: [
+            {
+              from: { value: `https://gcmd.earthdata.nasa.gov/kms/concept/${mockConceptId}` },
+              relation: { value: 'http://www.w3.org/2004/02/skos/core#broader' },
+              to: { value: 'https://gcmd.earthdata.nasa.gov/kms/concept/1' }
+            },
+            {
+              from: { value: `https://gcmd.earthdata.nasa.gov/kms/concept/${mockConceptId}` },
+              relation: { value: 'http://www.w3.org/2004/02/skos/core#narrower' },
+              to: { value: 'https://gcmd.earthdata.nasa.gov/kms/concept/2' }
+            },
+            {
+              from: { value: `https://gcmd.earthdata.nasa.gov/kms/concept/${mockConceptId}` },
+              relation: { value: 'http://www.w3.org/2004/02/skos/core#related' },
+              to: { value: 'https://gcmd.earthdata.nasa.gov/kms/concept/3' }
+            },
+            {
+              from: { value: `https://gcmd.earthdata.nasa.gov/kms/concept/${mockConceptId}` },
+              relation: { value: 'http://gcmd.nasa.gov/schema/gcmd#hasInstrument' },
+              to: { value: 'https://gcmd.earthdata.nasa.gov/kms/concept/4' }
+            },
+            {
+              from: { value: `https://gcmd.earthdata.nasa.gov/kms/concept/${mockConceptId}` },
+              relation: { value: 'http://gcmd.nasa.gov/schema/gcmd#isOnPlatform' },
+              to: { value: 'https://gcmd.earthdata.nasa.gov/kms/concept/5' }
+            }
+          ]
+        }
+      })
+    }
+
+    sparqlRequest.mockResolvedValue(mockResponse)
+
+    const result = await captureRelations(mockConceptId, mockVersion)
+
+    expect(result).toHaveLength(5)
+    expect(result.map((r) => r.relation)).toEqual(['broader', 'narrower', 'related', 'hasInstrument', 'isOnPlatform'])
+  })
+
+  test('should handle malformed SPARQL response', async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        // Missing 'results' key
+        bindings: []
+      })
+    }
+
+    sparqlRequest.mockResolvedValue(mockResponse)
+
+    await expect(captureRelations(mockConceptId, mockVersion)).rejects.toThrow()
+  })
+
+  test('should handle network errors', async () => {
+    sparqlRequest.mockRejectedValue(new Error('Network error'))
+
+    await expect(captureRelations(mockConceptId, mockVersion)).rejects.toThrow('Network error')
+  })
+
+  test('should use correct SPARQL query', async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        results: {
+          bindings: []
+        }
+      })
+    }
+
+    sparqlRequest.mockResolvedValue(mockResponse)
+
+    await captureRelations(mockConceptId, mockVersion)
+
+    const expectedQueryParts = [
+      'PREFIX skos: <http://www.w3.org/2004/02/skos/core#>',
+      'PREFIX gcmd: <http://gcmd.nasa.gov/schema/gcmd#>',
+      'SELECT ?from ?relation ?to',
+      `<https://gcmd.earthdata.nasa.gov/kms/concept/${mockConceptId}> ?relation ?to`,
+      `?from ?relation <https://gcmd.earthdata.nasa.gov/kms/concept/${mockConceptId}>`,
+      'FILTER(?relation IN (skos:broader, skos:narrower, skos:related, gcmd:hasInstrument, gcmd:isOnPlatform))'
+    ]
+
+    const calledQuery = sparqlRequest.mock.calls[0][0].body
+
+    expectedQueryParts.forEach((part) => {
+      expect(calledQuery).toContain(part)
+    })
+  })
+})

--- a/serverless/src/shared/__tests__/compareRelations.test.js
+++ b/serverless/src/shared/__tests__/compareRelations.test.js
@@ -1,0 +1,319 @@
+import {
+  describe,
+  expect,
+  test
+} from 'vitest'
+
+import { compareRelations } from '../compareRelations'
+
+describe('compareRelations', () => {
+  test('should correctly identify added relations', () => {
+    const beforeRelations = [
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      },
+      {
+        from: 'concept1',
+        relation: 'related',
+        to: 'concept3'
+      }
+    ]
+    const afterRelations = [
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      },
+      {
+        from: 'concept1',
+        relation: 'related',
+        to: 'concept3'
+      },
+      {
+        from: 'concept1',
+        relation: 'narrower',
+        to: 'concept4'
+      }
+    ]
+
+    const result = compareRelations(beforeRelations, afterRelations)
+
+    expect(result.addedRelations).toEqual([
+      {
+        from: 'concept1',
+        relation: 'narrower',
+        to: 'concept4'
+      }
+    ])
+
+    expect(result.removedRelations).toEqual([])
+  })
+
+  test('should correctly identify removed relations', () => {
+    const beforeRelations = [
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      },
+      {
+        from: 'concept1',
+        relation: 'related',
+        to: 'concept3'
+      }
+    ]
+    const afterRelations = [
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      }
+    ]
+
+    const result = compareRelations(beforeRelations, afterRelations)
+
+    expect(result.addedRelations).toEqual([])
+    expect(result.removedRelations).toEqual([
+      {
+        from: 'concept1',
+        relation: 'related',
+        to: 'concept3'
+      }
+    ])
+  })
+
+  test('should handle both added and removed relations', () => {
+    const beforeRelations = [
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      },
+      {
+        from: 'concept1',
+        relation: 'related',
+        to: 'concept3'
+      }
+    ]
+    const afterRelations = [
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      },
+      {
+        from: 'concept1',
+        relation: 'narrower',
+        to: 'concept4'
+      }
+    ]
+
+    const result = compareRelations(beforeRelations, afterRelations)
+
+    expect(result.addedRelations).toEqual([
+      {
+        from: 'concept1',
+        relation: 'narrower',
+        to: 'concept4'
+      }
+    ])
+
+    expect(result.removedRelations).toEqual([
+      {
+        from: 'concept1',
+        relation: 'related',
+        to: 'concept3'
+      }
+    ])
+  })
+
+  test('should handle empty before relations', () => {
+    const beforeRelations = []
+    const afterRelations = [
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      }
+    ]
+
+    const result = compareRelations(beforeRelations, afterRelations)
+
+    expect(result.addedRelations).toEqual([
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      }
+    ])
+
+    expect(result.removedRelations).toEqual([])
+  })
+
+  test('should handle empty after relations', () => {
+    const beforeRelations = [
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      }
+    ]
+    const afterRelations = []
+
+    const result = compareRelations(beforeRelations, afterRelations)
+
+    expect(result.addedRelations).toEqual([])
+    expect(result.removedRelations).toEqual([
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      }
+    ])
+  })
+
+  test('should handle no changes in relations', () => {
+    const relations = [
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      },
+      {
+        from: 'concept1',
+        relation: 'related',
+        to: 'concept3'
+      }
+    ]
+
+    const result = compareRelations(relations, relations)
+
+    expect(result.addedRelations).toEqual([])
+    expect(result.removedRelations).toEqual([])
+  })
+
+  test('should handle completely different before and after relations', () => {
+    const beforeRelations = [
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      },
+      {
+        from: 'concept1',
+        relation: 'related',
+        to: 'concept3'
+      }
+    ]
+    const afterRelations = [
+      {
+        from: 'concept1',
+        relation: 'narrower',
+        to: 'concept4'
+      },
+      {
+        from: 'concept1',
+        relation: 'related',
+        to: 'concept5'
+      }
+    ]
+
+    const result = compareRelations(beforeRelations, afterRelations)
+
+    expect(result.addedRelations).toEqual(afterRelations)
+    expect(result.removedRelations).toEqual(beforeRelations)
+  })
+
+  test('should handle relations with different order', () => {
+    const beforeRelations = [
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      },
+      {
+        from: 'concept1',
+        relation: 'related',
+        to: 'concept3'
+      }
+    ]
+    const afterRelations = [
+      {
+        from: 'concept1',
+        relation: 'related',
+        to: 'concept3'
+      },
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      }
+    ]
+
+    const result = compareRelations(beforeRelations, afterRelations)
+
+    expect(result.addedRelations).toEqual([])
+    expect(result.removedRelations).toEqual([])
+  })
+
+  test('should handle relations with different case', () => {
+    const beforeRelations = [
+      {
+        from: 'concept1',
+        relation: 'Broader',
+        to: 'concept2'
+      }
+    ]
+    const afterRelations = [
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      }
+    ]
+
+    const result = compareRelations(beforeRelations, afterRelations)
+
+    expect(result.addedRelations).toEqual([
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2'
+      }
+    ])
+
+    expect(result.removedRelations).toEqual([
+      {
+        from: 'concept1',
+        relation: 'Broader',
+        to: 'concept2'
+      }
+    ])
+  })
+
+  test('should handle relations with extra properties', () => {
+    const beforeRelations = [
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2',
+        extra: 'data'
+      }
+    ]
+    const afterRelations = [
+      {
+        from: 'concept1',
+        relation: 'broader',
+        to: 'concept2',
+        newExtra: 'newData'
+      }
+    ]
+
+    const result = compareRelations(beforeRelations, afterRelations)
+
+    expect(result.addedRelations).toEqual([])
+    expect(result.removedRelations).toEqual([])
+  })
+})

--- a/serverless/src/shared/addChangeNotes.js
+++ b/serverless/src/shared/addChangeNotes.js
@@ -1,0 +1,83 @@
+import { sparqlRequest } from '@/shared/sparqlRequest'
+
+/**
+ * Adds SKOS change notes to concepts based on added and removed relations.
+ *
+ * @async
+ * @function addChangeNotes
+ * @param {Array<Object>} addedRelations - Array of relation objects that were added
+ * @param {Array<Object>} removedRelations - Array of relation objects that were removed
+ * @param {string} version - The version of the concept (e.g., 'draft', 'published')
+ * @param {string} transactionUrl - The URL of the current transaction
+ * @throws {Error} If there's an issue adding the change notes to the triplestore
+ *
+ * @example
+ * const addedRelations = [
+ *   { from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123', relation: 'broader', to: 'https://gcmd.earthdata.nasa.gov/kms/concept/456' }
+ * ];
+ * const removedRelations = [
+ *   { from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123', relation: 'related', to: 'https://gcmd.earthdata.nasa.gov/kms/concept/789' }
+ * ];
+ * await addChangeNotes(addedRelations, removedRelations, 'draft', 'http://example.com/transaction/1');
+ *
+ * @description
+ * This function generates SKOS change notes for each added and removed relation, and adds them to the respective concepts in the triplestore.
+ * The change notes include the date, user ID (set to 'system'), and a description of the change.
+ * The function performs the following steps:
+ * 1. Generates change note strings for added and removed relations
+ * 2. Constructs a SPARQL query to insert these change notes
+ * 3. Executes the SPARQL query within the specified transaction
+ *
+ * The change note format is:
+ * "Date=YYYY-MM-DD User Id=system System Note=Added/Removed [relation] relation from <[fromUuid]> to <[toUuid]>"
+ *
+ * Note: This function assumes that the relations are represented by full URIs and extracts the UUID from these URIs for the change note.
+ */
+export const addChangeNotes = async (addedRelations, removedRelations, version, transactionUrl) => {
+  function extractUuid(uri) {
+    return uri.split('/').pop()
+  }
+
+  const currentDate = new Date().toISOString().split('T')[0]
+
+  const changeNotes = [
+    ...addedRelations.map((relation) => ({
+      from: relation.from,
+      note: `Date=${currentDate} User Id=system System Note=Added ${relation.relation} relation from <${extractUuid(relation.from)}> to <${extractUuid(relation.to)}>`
+    })),
+    ...removedRelations.map((relation) => ({
+      from: relation.from,
+      note: `Date=${currentDate} User Id=system System Note=Removed ${relation.relation} relation from <${extractUuid(relation.from)}> to <${extractUuid(relation.to)}>`
+    }))
+  ]
+
+  const changeNotesQueries = changeNotes.map((changeNote) => `
+    <${changeNote.from}> skos:changeNote "${changeNote.note}" .
+  `).join('\n')
+
+  const query = `
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+    WITH <https://gcmd.earthdata.nasa.gov/kms/version/${version}>
+    INSERT {
+      ${changeNotesQueries}
+    } 
+    WHERE { }
+  `
+
+  const response = await sparqlRequest({
+    method: 'POST',
+    contentType: 'application/sparql-update',
+    accept: 'application/json',
+    body: query,
+    version,
+    transaction: {
+      transactionUrl,
+      action: 'UPDATE'
+    }
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to add change notes: ${response.status}`)
+  }
+}

--- a/serverless/src/shared/captureRelations.js
+++ b/serverless/src/shared/captureRelations.js
@@ -1,0 +1,84 @@
+import { sparqlRequest } from '@/shared/sparqlRequest'
+
+/**
+ * Captures all relevant relations for a given concept.
+ * This function queries the triplestore to retrieve both outgoing and incoming relations
+ * for a specified concept.
+ *
+ * @async
+ * @function captureRelations
+ * @param {string} conceptId - The UUID of the concept for which to capture relations
+ * @param {string} version - The version of the concept (e.g., 'draft', 'published')
+ * @param {string|null} [transactionUrl=null] - The transaction URL if within a transaction, null otherwise
+ * @returns {Promise<Array<Object>>} A promise that resolves to an array of relation objects
+ * @throws {Error} If there's an issue fetching the relations from the triplestore
+ *
+ * @example
+ * // Capture relations for a concept
+ * const relations = await captureRelations('123e4567-e89b-12d3-a456-426614174000', 'draft');
+ *
+ * // Example of a returned relation object
+ * // {
+ * //   from: 'https://gcmd.earthdata.nasa.gov/kms/concept/123e4567-e89b-12d3-a456-426614174000',
+ * //   relation: 'broader',
+ * //   to: 'https://gcmd.earthdata.nasa.gov/kms/concept/789a1234-b56c-78d9-e012-345678901234'
+ * // }
+ *
+ * @description
+ * This function performs a SPARQL query to retrieve all relevant relations (broader, narrower,
+ * related, hasInstrument, isOnPlatform) for the specified concept. It captures both outgoing
+ * relations (where the concept is the subject) and incoming relations (where the concept is
+ * the object). The function returns an array of relation objects, each containing 'from',
+ * 'relation', and 'to' properties.
+ */
+export const captureRelations = async (conceptId, version, transactionUrl = null) => {
+  function extractRelationName(uri) {
+    return uri.split('#').pop()
+  }
+
+  const query = `
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    PREFIX gcmd: <http://gcmd.nasa.gov/schema/gcmd#>
+    
+    SELECT ?from ?relation ?to
+    WHERE {
+      {
+        # Outgoing relations
+        <https://gcmd.earthdata.nasa.gov/kms/concept/${conceptId}> ?relation ?to .
+        BIND(<https://gcmd.earthdata.nasa.gov/kms/concept/${conceptId}> AS ?from)
+        FILTER(?relation IN (skos:broader, skos:narrower, skos:related, gcmd:hasInstrument, gcmd:isOnPlatform))
+      }
+      UNION
+      {
+        # Incoming relations
+        ?from ?relation <https://gcmd.earthdata.nasa.gov/kms/concept/${conceptId}> .
+        BIND(<https://gcmd.earthdata.nasa.gov/kms/concept/${conceptId}> AS ?to)
+        FILTER(?relation IN (skos:broader, skos:narrower, skos:related, gcmd:hasInstrument, gcmd:isOnPlatform))
+      }
+    }
+  `
+
+  const response = await sparqlRequest({
+    method: 'POST',
+    contentType: 'application/sparql-query',
+    accept: 'application/sparql-results+json',
+    body: query,
+    version,
+    transaction: transactionUrl ? {
+      transactionUrl,
+      action: 'QUERY'
+    } : null
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch relations: ${response.status}`)
+  }
+
+  const data = await response.json()
+
+  return data.results.bindings.map((binding) => ({
+    from: binding.from.value,
+    relation: extractRelationName(binding.relation.value),
+    to: binding.to.value
+  }))
+}

--- a/serverless/src/shared/compareRelations.js
+++ b/serverless/src/shared/compareRelations.js
@@ -1,0 +1,67 @@
+/**
+ * Compares two sets of relations to determine which relations were added and which were removed.
+ *
+ * @function compareRelations
+ * @param {Array<Object>} beforeRelations - Array of relation objects before the update
+ * @param {Array<Object>} afterRelations - Array of relation objects after the update
+ * @returns {Object} An object containing arrays of added and removed relations
+ * @property {Array<Object>} addedRelations - Array of relation objects that were added
+ * @property {Array<Object>} removedRelations - Array of relation objects that were removed
+ *
+ * @example
+ * const beforeRelations = [
+ *   { from: 'concept1', relation: 'broader', to: 'concept2' },
+ *   { from: 'concept1', relation: 'related', to: 'concept3' }
+ * ];
+ * const afterRelations = [
+ *   { from: 'concept1', relation: 'broader', to: 'concept2' },
+ *   { from: 'concept1', relation: 'narrower', to: 'concept4' }
+ * ];
+ * const result = compareRelations(beforeRelations, afterRelations);
+ * // result = {
+ * //   addedRelations: [{ from: 'concept1', relation: 'narrower', to: 'concept4' }],
+ * //   removedRelations: [{ from: 'concept1', relation: 'related', to: 'concept3' }]
+ * // }
+ *
+ * @description
+ * This function compares two sets of relations (before and after an update) to determine
+ * which relations were added and which were removed. It does this by:
+ * 1. Iterating through the 'after' relations and checking if each exists in the 'before' set.
+ *    If not, it's considered an added relation.
+ * 2. Iterating through the 'before' relations and checking if each still exists in the 'after' set.
+ *    If not, it's considered a removed relation.
+ * The function assumes that each relation object has 'from', 'relation', and 'to' properties.
+ */
+export const compareRelations = (beforeRelations, afterRelations) => {
+  const addedRelations = []
+  const removedRelations = []
+
+  // Check for added relations
+  afterRelations.forEach((afterRelation) => {
+    const exists = beforeRelations.some(
+      (beforeRelation) => beforeRelation.from === afterRelation.from
+      && beforeRelation.relation === afterRelation.relation
+      && beforeRelation.to === afterRelation.to
+    )
+    if (!exists) {
+      addedRelations.push(afterRelation)
+    }
+  })
+
+  // Check for removed relations
+  beforeRelations.forEach((beforeRelation) => {
+    const stillExists = afterRelations.some(
+      (afterRelation) => afterRelation.from === beforeRelation.from
+      && afterRelation.relation === beforeRelation.relation
+      && afterRelation.to === beforeRelation.to
+    )
+    if (!stillExists) {
+      removedRelations.push(beforeRelation)
+    }
+  })
+
+  return {
+    addedRelations,
+    removedRelations
+  }
+}

--- a/serverless/src/shared/operations/queries/__tests__/getConceptsQuery.test.js
+++ b/serverless/src/shared/operations/queries/__tests__/getConceptsQuery.test.js
@@ -11,9 +11,9 @@ import { getConceptsQuery } from '../getConceptsQuery'
 describe('getConceptsQuery', () => {
   describe('when concept scheme is provided', () => {
     test('should include the concept scheme in the query', () => {
-      const conceptScheme = 'https://example.com/scheme'
+      const conceptScheme = 'scheme'
       const query = getConceptsQuery(conceptScheme)
-      expect(query).toContain(`?s skos:inScheme <${conceptScheme}>`)
+      expect(query).toContain('?s skos:inScheme <https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/scheme>')
     })
   })
 

--- a/serverless/src/shared/operations/queries/getConceptsQuery.js
+++ b/serverless/src/shared/operations/queries/getConceptsQuery.js
@@ -8,7 +8,7 @@ WHERE {
     SELECT DISTINCT ?s
     WHERE {
       ?s a skos:Concept .
-      ${conceptScheme ? `?s skos:inScheme <${conceptScheme}> .` : ''}
+      ${conceptScheme ? `?s skos:inScheme <https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/${conceptScheme}> .` : ''}
       ${pattern ? `
       ?s skos:prefLabel ?prefLabel .
       FILTER(CONTAINS(LCASE(?prefLabel), LCASE("${pattern}")))


### PR DESCRIPTION
# Overview

### What is the feature?

Support adding skos:changeNote to any reciprocal relationships added when creating, updating and deleting skos:Concepts

### What is the Solution?

The handlers for createConcept, updateConcept, and deleteConcept now have logic to compare any relationships
that might have been added removed when creating, updating, or deleting a skos:Concept.   It will then add a skos:changeNote and include details of what was updated.

### What areas of the application does this impact?

Creating, Updating, and Deleting skos:Concepts

# Testing

Easier to test with MMT, trying adding a narrower, look at the broader concept to see a change log item.
Try other relationships like adding broader, adding a related.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
