### PR TITLE
KMS-593: KMS API for downloading CSV is no longer working.

### DIFF
--- a/serverless/src/shared/__tests__/getCsvPaths.test.js
+++ b/serverless/src/shared/__tests__/getCsvPaths.test.js
@@ -28,10 +28,16 @@ describe('getCsvPaths', () => {
   describe('when successful', () => {
     test('should return reversed keywords array', async () => {
       // Mock the imported functions
-      getRootConceptForScheme.mockResolvedValue({
-        prefLabel: { value: 'Root' },
-        subject: { value: 'http://example.com/root' }
-      })
+      getRootConceptForScheme.mockResolvedValue([
+        {
+          prefLabel: { value: 'Root1' },
+          subject: { value: 'http://example.com/root1' }
+        },
+        {
+          prefLabel: { value: 'Root2' },
+          subject: { value: 'http://example.com/root2' }
+        }
+      ])
 
       getNarrowersMap.mockResolvedValue({})
       getLongNamesMap.mockResolvedValue({})
@@ -43,19 +49,61 @@ describe('getCsvPaths', () => {
 
       const result = await getCsvPaths('testScheme', 3, 'draft')
 
-      expect(result).toEqual(['Keyword3', 'Keyword2', 'Keyword1'])
+      expect(result).toEqual(['Keyword3', 'Keyword2', 'Keyword1', 'Keyword3', 'Keyword2', 'Keyword1'])
       expect(getRootConceptForScheme).toHaveBeenCalledWith('testScheme', 'draft')
       expect(getNarrowersMap).toHaveBeenCalledWith('testScheme', 'draft')
       expect(getLongNamesMap).toHaveBeenCalledWith('testScheme', 'draft')
       expect(getProviderUrlsMap).not.toHaveBeenCalled()
-      expect(buildHierarchicalCsvPaths).toHaveBeenCalled()
+      expect(buildHierarchicalCsvPaths).toHaveBeenCalledTimes(2)
+    })
+
+    test('should handle multiple roots correctly', async () => {
+      getRootConceptForScheme.mockResolvedValue([
+        {
+          prefLabel: { value: 'Root1' },
+          subject: { value: 'http://example.com/root1' }
+        },
+        {
+          prefLabel: { value: 'Root2' },
+          subject: { value: 'http://example.com/root2' }
+        },
+        {
+          prefLabel: { value: 'Root3' },
+          subject: { value: 'http://example.com/root3' }
+        }
+      ])
+
+      getNarrowersMap.mockResolvedValue({})
+      getLongNamesMap.mockResolvedValue({})
+      getProviderUrlsMap.mockResolvedValue({})
+
+      buildHierarchicalCsvPaths.mockImplementation((params) => {
+        if (params.n.prefLabel === 'Root1') {
+          params.paths.push('KeywordA1', 'KeywordA2')
+        } else if (params.n.prefLabel === 'Root2') {
+          params.paths.push('KeywordB1', 'KeywordB2')
+        } else if (params.n.prefLabel === 'Root3') {
+          params.paths.push('KeywordC1', 'KeywordC2')
+        }
+      })
+
+      const result = await getCsvPaths('testScheme', 3, 'draft')
+
+      expect(result).toEqual(['KeywordC2', 'KeywordC1', 'KeywordB2', 'KeywordB1', 'KeywordA2', 'KeywordA1'])
+      expect(getRootConceptForScheme).toHaveBeenCalledWith('testScheme', 'draft')
+      expect(getNarrowersMap).toHaveBeenCalledWith('testScheme', 'draft')
+      expect(getLongNamesMap).toHaveBeenCalledWith('testScheme', 'draft')
+      expect(getProviderUrlsMap).not.toHaveBeenCalled()
+      expect(buildHierarchicalCsvPaths).toHaveBeenCalledTimes(3)
     })
 
     test('should call getProviderUrlsMap when scheme is "providers"', async () => {
-      getRootConceptForScheme.mockResolvedValue({
-        prefLabel: { value: 'Root' },
-        subject: { value: 'http://example.com/root' }
-      })
+      getRootConceptForScheme.mockResolvedValue([
+        {
+          prefLabel: { value: 'Root' },
+          subject: { value: 'http://example.com/root' }
+        }
+      ])
 
       getNarrowersMap.mockResolvedValue({})
       getLongNamesMap.mockResolvedValue({})

--- a/serverless/src/shared/getCsvPaths.js
+++ b/serverless/src/shared/getCsvPaths.js
@@ -52,42 +52,37 @@ import { getRootConceptForScheme } from '@/shared/getRootConceptForScheme'
  * {@link buildHierarchicalCsvPaths}
  */
 export const getCsvPaths = async (scheme, csvHeadersCount, version) => {
-  // Get the root concept for the scheme
-  const root = await getRootConceptForScheme(scheme, version)
+  const keywords = []
+  const roots = await getRootConceptForScheme(scheme, version)
 
-  // Create a node object with root concept information
-  const node = {
-    prefLabel: root?.prefLabel?.value,
-    narrowerPrefLabel: root?.prefLabel?.value,
-    uri: root?.subject?.value
-  }
+  console.log('roots=', roots)
 
-  // Get maps for narrowers and long names
   const narrowersMap = await getNarrowersMap(scheme, version)
   const longNamesMap = await getLongNamesMap(scheme, version)
 
-  // Initialize providerUrlsMap
   let providerUrlsMap = []
-  // If the scheme is 'providers', get the provider URLs map
   if (scheme === 'providers') {
     providerUrlsMap = await getProviderUrlsMap(scheme, version)
   }
 
-  // Initialize an array to store keywords
-  const keywords = []
+  await Promise.all(roots.map(async (root) => {
+    const node = {
+      prefLabel: root?.prefLabel?.value,
+      narrowerPrefLabel: root?.prefLabel?.value,
+      uri: root?.subject?.value
+    }
 
-  // Traverse the graph to populate keywords
-  await buildHierarchicalCsvPaths({
-    csvHeadersCount,
-    providerUrlsMap,
-    longNamesMap,
-    scheme,
-    n: node,
-    map: narrowersMap,
-    path: [],
-    paths: keywords
-  })
+    await buildHierarchicalCsvPaths({
+      csvHeadersCount,
+      providerUrlsMap,
+      longNamesMap,
+      scheme,
+      n: node,
+      map: narrowersMap,
+      path: [],
+      paths: keywords
+    })
+  }))
 
-  // Return the reversed keywords array
   return keywords.reverse()
 }

--- a/serverless/src/shared/getCsvPaths.js
+++ b/serverless/src/shared/getCsvPaths.js
@@ -55,8 +55,6 @@ export const getCsvPaths = async (scheme, csvHeadersCount, version) => {
   const keywords = []
   const roots = await getRootConceptForScheme(scheme, version)
 
-  console.log('roots=', roots)
-
   const narrowersMap = await getNarrowersMap(scheme, version)
   const longNamesMap = await getLongNamesMap(scheme, version)
 


### PR DESCRIPTION
# Overview

### What is the feature?

The API for downloading CSV keywords was returning 0 results.

### What is the Solution?

The `getRootConceptForScheme` was recently changed to return an array of keywords, so we had to change `getCsvPaths` to account for this change.

### What areas of the application does this impact?

Downloading CSVs

# Testing

Try downloading a CSV report for any of our concept schemes, i.e..
https://cmr.sit.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords?format=csv

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
