### PR TITLE
KMS-600: Removed redundant prefixes

### DIFF
--- a/serverless/src/shared/operations/queries/getProviderUrlsQuery.js
+++ b/serverless/src/shared/operations/queries/getProviderUrlsQuery.js
@@ -2,8 +2,6 @@ import prefixes from '@/shared/constants/prefixes'
 
 export const getProviderUrlsQuery = (scheme) => `
   ${prefixes}
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-    PREFIX gcmd: <https://gcmd.earthdata.nasa.gov/kms#>
     SELECT ?subject ?bp ?bo
     WHERE {
       ?subject skos:inScheme <https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/${scheme}> .


### PR DESCRIPTION
What is the feature?

In testing CMR integration, they got a failure when trying to download:
https://cmr.sit.earthdata.nasa.gov/kms/concepts/concept_scheme/providers?format=csv

What is the Solution?

The issue was the result of multiple prefixes with the same name.

What areas of the application does this impact?

Downloading of the providers CSV.

Testing

After the fix, this should work:
https://cmr.sit.earthdata.nasa.gov/kms/concepts/concept_scheme/providers?format=csv

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
