### PR TITLE
KMS-601: sparql queries should perform a case insenstive search on concept scheme

### DIFF
--- a/serverless/src/shared/formatCsvPath.js
+++ b/serverless/src/shared/formatCsvPath.js
@@ -32,7 +32,7 @@
  */
 export const formatCsvPath = (scheme, csvHeadersCount, path, isLeaf) => {
   // Handle 'platforms', 'instruments', and 'projects' schemes
-  if (['platforms', 'instruments', 'projects'].includes(scheme)) {
+  if (['platforms', 'instruments', 'projects'].includes(scheme.toLowerCase())) {
     const maxLevel = csvHeadersCount - 2
 
     // Return if path length matches maxLevel
@@ -58,7 +58,7 @@ export const formatCsvPath = (scheme, csvHeadersCount, path, isLeaf) => {
   }
 
   // Handle 'sciencekeywords', 'chronounits', 'locations', 'discipline', 'rucontenttype', and 'measurementname' schemes
-  if (['sciencekeywords', 'chronounits', 'locations', 'discipline', 'rucontenttype', 'measurementname'].includes(scheme)) {
+  if (['sciencekeywords', 'chronounits', 'locations', 'discipline', 'rucontenttype', 'measurementname'].includes(scheme.toLowerCase())) {
     const maxLevel = csvHeadersCount - 1
 
     // Return if path length matches maxLevel
@@ -77,7 +77,7 @@ export const formatCsvPath = (scheme, csvHeadersCount, path, isLeaf) => {
   }
 
   // Handle 'providers' scheme
-  if (['providers'].includes(scheme)) {
+  if (['providers'].includes(scheme.toLowerCase())) {
     const maxLevel = csvHeadersCount - 3
 
     // Return if path length matches maxLevel

--- a/serverless/src/shared/getCsvPaths.js
+++ b/serverless/src/shared/getCsvPaths.js
@@ -59,7 +59,7 @@ export const getCsvPaths = async (scheme, csvHeadersCount, version) => {
   const longNamesMap = await getLongNamesMap(scheme, version)
 
   let providerUrlsMap = []
-  if (scheme === 'providers') {
+  if (scheme.toLowerCase() === 'providers') {
     providerUrlsMap = await getProviderUrlsMap(scheme, version)
   }
 

--- a/serverless/src/shared/isCsvProviderUrlFlag.js
+++ b/serverless/src/shared/isCsvProviderUrlFlag.js
@@ -1,23 +1,24 @@
 /**
- * Determines if a given scheme is a CSV provider URL flag.
+ * Array of valid CSV provider schemes.
+ * Currently only includes 'providers', but can be expanded in the future.
+ */
+const validSchemes = ['providers']
+
+/**
+ * Checks if the given scheme is a valid CSV provider URL flag.
  *
- * @param {string} scheme - The scheme to check.
- * @returns {boolean} True if the scheme is a CSV provider URL flag, false otherwise.
- *
- * @example
- * // Returns true
- * isCsvProviderUrlFlag('providers');
- *
- * @example
- * // Returns false
- * isCsvProviderUrlFlag('other');
+ * @param {any} scheme - The scheme to check.
+ * @returns {boolean} True if the scheme is a string and matches a valid scheme (case-insensitive), false otherwise.
  */
 export const isCsvProviderUrlFlag = (scheme) => {
-  // Check if the scheme is in the array of valid CSV provider schemes
-  if (['providers'].includes(scheme)) {
+  // Check if scheme is a string and is in the array of valid CSV provider schemes
+  if (typeof scheme === 'string' && validSchemes.includes(scheme.toLowerCase())) {
     return true
   }
 
-  // If the scheme is not in the array, return false
+  // If the scheme is not a string or not in the array, return false
   return false
 }
+
+// You might want to export validSchemes if it's used elsewhere in your application
+export { validSchemes }

--- a/serverless/src/shared/operations/queries/__tests__/getNarrowerConceptsQuery.test.js
+++ b/serverless/src/shared/operations/queries/__tests__/getNarrowerConceptsQuery.test.js
@@ -5,34 +5,37 @@ import prefixes from '@/shared/constants/prefixes'
 import { getNarrowerConceptsQuery } from '../getNarrowerConceptsQuery'
 
 describe('getNarrowerConceptsQuery', () => {
+  // Helper function to remove all whitespace
+  const removeWhitespace = (str) => str.replace(/\s+/g, '')
+
   test('should return the correct query without a scheme', () => {
     const result = getNarrowerConceptsQuery()
-    expect(result).toEqual(`
-  ${prefixes}
-  SELECT ?subject ?prefLabel ?narrower ?narrowerPrefLabel
-  WHERE {
-    ?subject skos:prefLabel ?prefLabel .
-    ?subject skos:narrower ?narrower .
-    ?narrower skos:prefLabel ?narrowerPrefLabel .
-    
-  }
-`)
+    const expected = `
+      ${prefixes}
+      SELECT ?subject ?prefLabel ?narrower ?narrowerPrefLabel
+      WHERE {
+        ?subject skos:prefLabel ?prefLabel .
+        ?subject skos:narrower ?narrower .
+        ?narrower skos:prefLabel ?narrowerPrefLabel .
+      }
+    `
+    expect(removeWhitespace(result)).toEqual(removeWhitespace(expected))
   })
 
   test('should return the correct query with a scheme', () => {
     const scheme = 'test_scheme'
     const result = getNarrowerConceptsQuery(scheme)
-    expect(result).toEqual(`
-  ${prefixes}
-  SELECT ?subject ?prefLabel ?narrower ?narrowerPrefLabel
-  WHERE {
-    ?subject skos:prefLabel ?prefLabel .
-    ?subject skos:narrower ?narrower .
-    ?narrower skos:prefLabel ?narrowerPrefLabel .
-    
-    ?subject skos:inScheme <https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/test_scheme> .
-    
-  }
-`)
+    const expected = `
+      ${prefixes}
+      SELECT ?subject ?prefLabel ?narrower ?narrowerPrefLabel
+      WHERE {
+        ?subject skos:prefLabel ?prefLabel .
+        ?subject skos:narrower ?narrower .
+        ?narrower skos:prefLabel ?narrowerPrefLabel .
+        ?subject skos:inScheme ?schemeUri .
+        FILTER(LCASE(STR(?schemeUri)) = LCASE(STR(<https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/test_scheme>)))
+      }
+    `
+    expect(removeWhitespace(result)).toEqual(removeWhitespace(expected))
   })
 })

--- a/serverless/src/shared/operations/queries/__tests__/getRootConceptsBySchemeQuery.test.js
+++ b/serverless/src/shared/operations/queries/__tests__/getRootConceptsBySchemeQuery.test.js
@@ -10,15 +10,16 @@ describe('getRootConceptsBySchemeQuery', () => {
   test('should generate a query without scheme filter when no scheme is provided', () => {
     const query = getRootConceptsBySchemeQuery()
     expect(query).toContain('SELECT ?subject ?prefLabel')
-    expect(query).not.toContain('?subject skos:inScheme <https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/')
+    expect(query).not.toContain('?subject skos:inScheme ?schemeUri')
     expect(query).toContain('FILTER EXISTS {\n        ?subject skos:inScheme ?scheme .\n      }')
   })
 
-  test('should generate a query with scheme filter when a scheme is provided', () => {
+  test('should generate a query with case-insensitive scheme filter when a scheme is provided', () => {
     const scheme = 'testScheme'
     const query = getRootConceptsBySchemeQuery(scheme)
     expect(query).toContain('SELECT ?subject ?prefLabel')
-    expect(query).toContain(`?subject skos:inScheme <https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/${scheme}>`)
+    expect(query).toContain('?subject skos:inScheme ?schemeUri')
+    expect(query).toContain(`FILTER(LCASE(STR(?schemeUri)) = LCASE(STR(<https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/${scheme}>)))`)
     expect(query).not.toContain('FILTER EXISTS {\n        ?subject skos:inScheme ?scheme .\n      }')
   })
 

--- a/serverless/src/shared/operations/queries/getLongNamesQuery.js
+++ b/serverless/src/shared/operations/queries/getLongNamesQuery.js
@@ -4,7 +4,8 @@ export const getLongNamesQuery = (scheme) => `
   ${prefixes}
   SELECT ?subject ?longName
   WHERE {
-    ?subject skos:inScheme <https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/${scheme}> .
+    ?subject skos:inScheme ?schemeUri .
+    FILTER(LCASE(STR(?schemeUri)) = LCASE(STR(<https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/${scheme}>)))
     ?subject gcmd:altLabel ?blankNode .
     ?blankNode gcmd:category "primary"@en .
     ?blankNode gcmd:text ?longName .

--- a/serverless/src/shared/operations/queries/getNarrowerConceptsQuery.js
+++ b/serverless/src/shared/operations/queries/getNarrowerConceptsQuery.js
@@ -8,7 +8,8 @@ export const getNarrowerConceptsQuery = (scheme) => `
     ?subject skos:narrower ?narrower .
     ?narrower skos:prefLabel ?narrowerPrefLabel .
     ${scheme ? `
-    ?subject skos:inScheme <https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/${scheme}> .
+    ?subject skos:inScheme ?schemeUri .
+    FILTER(LCASE(STR(?schemeUri)) = LCASE(STR(<https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/${scheme}>)))
     ` : ''}
   }
 `

--- a/serverless/src/shared/operations/queries/getProviderUrlsQuery.js
+++ b/serverless/src/shared/operations/queries/getProviderUrlsQuery.js
@@ -4,7 +4,8 @@ export const getProviderUrlsQuery = (scheme) => `
   ${prefixes}
     SELECT ?subject ?bp ?bo
     WHERE {
-      ?subject skos:inScheme <https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/${scheme}> .
+      ?subject skos:inScheme ?schemeUri .
+      FILTER(LCASE(STR(?schemeUri)) = LCASE(STR(<https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/${scheme}>)))
       ?subject gcmd:resource ?blankNode .
       ?blankNode ?bp ?bo
     }

--- a/serverless/src/shared/operations/queries/getRootConceptsBySchemeQuery.js
+++ b/serverless/src/shared/operations/queries/getRootConceptsBySchemeQuery.js
@@ -6,7 +6,8 @@ export const getRootConceptsBySchemeQuery = (scheme) => `
   WHERE {
     ?subject skos:prefLabel ?prefLabel .
     ${scheme ? `
-      ?subject skos:inScheme <https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/${scheme}> .
+      ?subject skos:inScheme ?schemeUri .
+      FILTER(LCASE(STR(?schemeUri)) = LCASE(STR(<https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/${scheme}>)))
     ` : ''}
     FILTER NOT EXISTS {
       ?subject skos:broader ?broaderConcept .


### PR DESCRIPTION
# Overview

### What is the feature?

During integration testing we noticed the CMR is performing csv downloads using lowercase concept schemes and KMS is matching on case.   This update is to fix things so that it performs a case insensitive search on scheme.

### What is the Solution?

Updated all sparql queries to perform a case insensitive search.

### What areas of the application does this impact?

https://cmr.sit.earthdata.nasa.gov/kms/concepts/concept_scheme/measurementname?format=csv

# Testing

This url should work now:
https://cmr.sit.earthdata.nasa.gov/kms/concepts/concept_scheme/measurementname?format=csv

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
