### PR TITLE
KMS-605: Changes to be able to configure RDF_BUCKET_NAME in bamboo

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -63,6 +63,7 @@ dockerRun() {
         --env "SYNC_API_ENDPOINT=$bamboo_SYNC_API_ENDPOINT" \
         --env "CMR_BASE_URL=$bamboo_CMR_BASE_URL" \
         --env "CORS_ORIGIN=$bamboo_CORS_ORIGIN" \
+        --env "RDF_BUCKET_NAME=$bamboo_RDF_BUCKET_NAME" \
         $dockerTag "$@"
 }
 


### PR DESCRIPTION
# Overview

### What is the feature?

The RDF_BUCKET_NAME defaults to `kms-rdf-backup`.   Bucket names need to be globally unique across accounts, so as a result we are seeing errors when trying to write to kms-rdf-bucket in UAT and OPS due to the bucket name already being taken by SIT.

### What is the Solution?

The code already supports an env variable RDF_BUCKET_NAME, we just never passed the env variable through bamboo.   So these changes will allow us to configure it to something unique (i.e., `kms-rdf-backup-uat`)

### What areas of the application does this impact?

The nightly transfer of the latest published version to s3.

# Testing

I plan to change RDF_BUCKET_NAME to `kms-rdf-backup-sit`, so we should see a nightly export hitting that s3 bucket.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
