### PR TITLE
KMS-612: Fixed issues with CSV column names

### DIFF
--- a/serverless/src/shared/__tests__/createCsvForScheme.test.js
+++ b/serverless/src/shared/__tests__/createCsvForScheme.test.js
@@ -128,7 +128,7 @@ describe('createCsvForScheme', () => {
       expect(getCsvHeaders).toHaveBeenCalledWith(scheme, version)
       expect(getCsvPaths).toHaveBeenCalledWith(scheme, 0, version) // Called with 0 since initial headers were empty
       expect(getMaxLengthOfSubArray).toHaveBeenCalledWith(mockPaths)
-      expect(generateCsvHeaders).toHaveBeenCalledWith(scheme, 3)
+      expect(generateCsvHeaders).toHaveBeenCalledWith(scheme, version, 3)
       expect(createCsv).toHaveBeenCalledWith(mockMetadata, mockGeneratedHeaders, mockPaths)
     })
   })

--- a/serverless/src/shared/__tests__/createCsvForScheme.test.js
+++ b/serverless/src/shared/__tests__/createCsvForScheme.test.js
@@ -131,6 +131,40 @@ describe('createCsvForScheme', () => {
       expect(generateCsvHeaders).toHaveBeenCalledWith(scheme, version, 3)
       expect(createCsv).toHaveBeenCalledWith(mockMetadata, mockGeneratedHeaders, mockPaths)
     })
+
+    test('should handle "granuledataformat" scheme correctly', async () => {
+      const scheme = 'granuledataformat'
+      const version = 'draft'
+      const mockDefaultHeaders = { 'Default-Header': 'value' }
+      const mockMetadata = { some: 'metadata' }
+      const mockHeaders = ['Header1', 'Header2']
+      const mockPaths = ['path1', 'path2']
+      const mockCsvContent = 'csv,content'
+
+      getApplicationConfig.mockReturnValue({ defaultResponseHeaders: mockDefaultHeaders })
+      getCsvMetadata.mockResolvedValue(mockMetadata)
+      getCsvHeaders.mockResolvedValue(mockHeaders)
+      getCsvPaths.mockResolvedValue(mockPaths)
+      createCsv.mockResolvedValue(mockCsvContent)
+
+      const result = await createCsvForScheme(scheme, version)
+
+      expect(result).toEqual({
+        statusCode: 200,
+        body: mockCsvContent,
+        headers: {
+          ...mockDefaultHeaders,
+          'Content-Type': 'text/csv',
+          'Content-Disposition': 'attachment; filename=dataformat.csv'
+        }
+      })
+
+      // Check if the functions were called with 'dataformat' instead of 'granuledataformat'
+      expect(getCsvMetadata).toHaveBeenCalledWith('dataformat', version)
+      expect(getCsvHeaders).toHaveBeenCalledWith('dataformat', version)
+      expect(getCsvPaths).toHaveBeenCalledWith('dataformat', mockHeaders.length, version)
+      expect(createCsv).toHaveBeenCalledWith(mockMetadata, mockHeaders, mockPaths)
+    })
   })
 
   describe('when unsuccessful', () => {

--- a/serverless/src/shared/__tests__/generateCsvHeaders.test.js
+++ b/serverless/src/shared/__tests__/generateCsvHeaders.test.js
@@ -1,25 +1,79 @@
-import { describe, expect } from 'vitest'
+import {
+  describe,
+  expect,
+  test,
+  vi
+} from 'vitest'
+
+import { sparqlRequest } from '@/shared/sparqlRequest'
 
 import { generateCsvHeaders } from '../generateCsvHeaders'
 
+// Mock the sparqlRequest function
+vi.mock('@/shared/sparqlRequest', () => ({
+  sparqlRequest: vi.fn()
+}))
+
 describe('generateCsvHeaders', () => {
-  test('should generate headers for 2 columns', () => {
-    const headers = generateCsvHeaders('MyScheme', 2)
+  beforeEach(() => {
+    // Clear all mocks before each test
+    vi.clearAllMocks()
+  })
+
+  test('should generate headers for 2 columns', async () => {
+    // Mock the sparqlRequest response
+    sparqlRequest.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        results: {
+          bindings: [{ notation: { value: 'MyScheme' } }]
+        }
+      })
+    })
+
+    const headers = await generateCsvHeaders('MyScheme', 'v1', 2)
     expect(headers).toEqual(['MyScheme', 'UUID'])
   })
 
-  test('should generate headers for 5 columns', () => {
-    const headers = generateCsvHeaders('AnotherScheme', 5)
+  test('should generate headers for 5 columns', async () => {
+    sparqlRequest.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        results: {
+          bindings: [{ notation: { value: 'AnotherScheme' } }]
+        }
+      })
+    })
+
+    const headers = await generateCsvHeaders('AnotherScheme', 'v1', 5)
     expect(headers).toEqual(['AnotherScheme', 'Level1', 'Level2', 'Level3', 'UUID'])
   })
 
-  test('should generate headers for 3 columns', () => {
-    const headers = generateCsvHeaders('TestScheme', 3)
+  test('should generate headers for 3 columns', async () => {
+    sparqlRequest.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        results: {
+          bindings: [{ notation: { value: 'TestScheme' } }]
+        }
+      })
+    })
+
+    const headers = await generateCsvHeaders('TestScheme', 'v1', 3)
     expect(headers).toEqual(['TestScheme', 'Level1', 'UUID'])
   })
 
-  test('should handle large number of columns', () => {
-    const headers = generateCsvHeaders('LargeScheme', 10)
+  test('should handle large number of columns', async () => {
+    sparqlRequest.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        results: {
+          bindings: [{ notation: { value: 'LargeScheme' } }]
+        }
+      })
+    })
+
+    const headers = await generateCsvHeaders('LargeScheme', 'v1', 10)
     expect(headers).toEqual([
       'LargeScheme',
       'Level1',
@@ -32,5 +86,20 @@ describe('generateCsvHeaders', () => {
       'Level8',
       'UUID'
     ])
+  })
+
+  test('should throw an error when sparqlRequest fails', async () => {
+    sparqlRequest.mockRejectedValue(new Error('SPARQL request failed'))
+
+    await expect(generateCsvHeaders('FailScheme', 'v1', 3)).rejects.toThrow('SPARQL request failed')
+  })
+
+  test('should throw an error when response is not ok', async () => {
+    sparqlRequest.mockResolvedValue({
+      ok: false,
+      status: 500
+    })
+
+    await expect(generateCsvHeaders('ErrorScheme', 'v1', 3)).rejects.toThrow('HTTP error! status: 500')
   })
 })

--- a/serverless/src/shared/__tests__/getConceptSchemeDetails.test.js
+++ b/serverless/src/shared/__tests__/getConceptSchemeDetails.test.js
@@ -55,7 +55,7 @@ describe('getConceptSchemeDetails', () => {
 
       expect(sparqlRequestModule.sparqlRequest).toHaveBeenCalledWith(expect.objectContaining({
         method: 'POST',
-        body: expect.stringContaining('FILTER(?notation = "ChainedOperations")'),
+        body: expect.stringContaining('FILTER(LCASE(STR(?notation)) = LCASE("ChainedOperations"))'),
         contentType: 'application/sparql-query',
         accept: 'application/sparql-results+json'
       }))

--- a/serverless/src/shared/__tests__/getCsvMetadata.test.js
+++ b/serverless/src/shared/__tests__/getCsvMetadata.test.js
@@ -70,37 +70,6 @@ describe('getCsvMetadata', () => {
 
       expect(result[1]).toBe('Revision: undefined')
     })
-
-    test('should handle case when scheme is granuledataformat', async () => {
-      const mockResponse = {
-        ok: true,
-        json: vi.fn().mockResolvedValue({
-          results: {
-            bindings: [
-              {
-                modified: { value: '2023-06-14' }
-              }
-            ]
-          }
-        })
-      }
-      sparqlRequest.mockResolvedValue(mockResponse)
-
-      const result = await getCsvMetadata('granuledataformat', 'published')
-
-      expect(result).toEqual([
-        'Keyword Version: N',
-        'Revision: 2023-06-14',
-        `Timestamp: ${format(new Date('2023-06-15T12:00:00Z'), 'yyyy-MM-dd HH:mm:ss')}`,
-        'Terms Of Use: https://cdn.earthdata.nasa.gov/conduit/upload/5182/KeywordsCommunityGuide_Baseline_v1_SIGNED_FINAL.pdf',
-        'The most up to date XML representations can be found here: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/dataformat/?format=xml'
-      ])
-
-      // Check if sparqlRequest was called with 'dataformat' instead of 'granuledataformat'
-      expect(result).toEqual(expect.arrayContaining([
-        expect.stringContaining('concept_scheme/dataformat/?format=xml')
-      ]))
-    })
   })
 
   describe('when unsuccessful', () => {

--- a/serverless/src/shared/__tests__/getCsvMetadata.test.js
+++ b/serverless/src/shared/__tests__/getCsvMetadata.test.js
@@ -70,6 +70,37 @@ describe('getCsvMetadata', () => {
 
       expect(result[1]).toBe('Revision: undefined')
     })
+
+    test('should handle case when scheme is granuledataformat', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          results: {
+            bindings: [
+              {
+                modified: { value: '2023-06-14' }
+              }
+            ]
+          }
+        })
+      }
+      sparqlRequest.mockResolvedValue(mockResponse)
+
+      const result = await getCsvMetadata('granuledataformat', 'published')
+
+      expect(result).toEqual([
+        'Keyword Version: N',
+        'Revision: 2023-06-14',
+        `Timestamp: ${format(new Date('2023-06-15T12:00:00Z'), 'yyyy-MM-dd HH:mm:ss')}`,
+        'Terms Of Use: https://cdn.earthdata.nasa.gov/conduit/upload/5182/KeywordsCommunityGuide_Baseline_v1_SIGNED_FINAL.pdf',
+        'The most up to date XML representations can be found here: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/dataformat/?format=xml'
+      ])
+
+      // Check if sparqlRequest was called with 'dataformat' instead of 'granuledataformat'
+      expect(result).toEqual(expect.arrayContaining([
+        expect.stringContaining('concept_scheme/dataformat/?format=xml')
+      ]))
+    })
   })
 
   describe('when unsuccessful', () => {

--- a/serverless/src/shared/createCsvForScheme.js
+++ b/serverless/src/shared/createCsvForScheme.js
@@ -46,7 +46,7 @@ export const createCsvForScheme = async (scheme, version) => {
     // If no headers were retrieved, generate them based on the maximum number of columns in the paths
     if (csvHeaders.length === 0) {
       const maxColumns = getMaxLengthOfSubArray(paths)
-      csvHeaders = generateCsvHeaders(scheme, maxColumns)
+      csvHeaders = await generateCsvHeaders(scheme, version, maxColumns)
     }
 
     // Sort output

--- a/serverless/src/shared/createCsvForScheme.js
+++ b/serverless/src/shared/createCsvForScheme.js
@@ -35,6 +35,11 @@ import { getMaxLengthOfSubArray } from './getMaxLengthOfSubArray'
 export const createCsvForScheme = async (scheme, version) => {
   const { defaultResponseHeaders } = getApplicationConfig()
   try {
+    if (scheme.toLowerCase() === 'granuledataformat') {
+    // eslint-disable-next-line no-param-reassign
+      scheme = 'dataformat'
+    }
+
     // Get CSV output metadata
     const csvMetadata = await getCsvMetadata(scheme, version)
     // Get CSV headers

--- a/serverless/src/shared/getCsvMetadata.js
+++ b/serverless/src/shared/getCsvMetadata.js
@@ -53,6 +53,11 @@ import { sparqlRequest } from '@/shared/sparqlRequest'
  * {@link sparqlRequest}
  */
 export const getCsvMetadata = async (scheme, version) => {
+  if (scheme.toLowerCase() === 'granuledataformat') {
+    // eslint-disable-next-line no-param-reassign
+    scheme = 'dataformat'
+  }
+
   let updateDate = 'N/A'
   try {
     // Make a SPARQL request to fetch concept scheme details
@@ -60,10 +65,7 @@ export const getCsvMetadata = async (scheme, version) => {
       method: 'POST',
       contentType: 'application/sparql-query',
       accept: 'application/sparql-results+json',
-      body: getConceptSchemeDetailsQuery({
-        scheme,
-        version
-      }),
+      body: getConceptSchemeDetailsQuery(scheme),
       version
     })
 

--- a/serverless/src/shared/getCsvMetadata.js
+++ b/serverless/src/shared/getCsvMetadata.js
@@ -53,11 +53,6 @@ import { sparqlRequest } from '@/shared/sparqlRequest'
  * {@link sparqlRequest}
  */
 export const getCsvMetadata = async (scheme, version) => {
-  if (scheme.toLowerCase() === 'granuledataformat') {
-    // eslint-disable-next-line no-param-reassign
-    scheme = 'dataformat'
-  }
-
   let updateDate = 'N/A'
   try {
     // Make a SPARQL request to fetch concept scheme details

--- a/serverless/src/shared/operations/queries/getConceptSchemeDetailsQuery.js
+++ b/serverless/src/shared/operations/queries/getConceptSchemeDetailsQuery.js
@@ -10,6 +10,6 @@ WHERE {
           skos:notation ?notation ;
           dcterms:modified ?modified .
   OPTIONAL { ?scheme gcmd:csvHeaders ?csvHeaders }
-  ${schemeName ? `FILTER(?notation = "${schemeName}")` : ''}
+  ${schemeName ? `FILTER(LCASE(STR(?notation)) = LCASE("${schemeName}"))` : ''}
 }
 `


### PR DESCRIPTION
# Overview

### What is the feature?

When we cutover KMS to UAT, CMR was having ingest issues due to column names in the CSV being different than what was in KMS 1.0.   These include:
`processing-levels`, `mime-type`, `granule-data-format`, and `measurement-name`
The rest of the keywords downloaded and parsed fine, it was just the above.   

### What is the Solution?

Couple issues we found: 
1) The URL https://cmr.sit.earthdata.nasa.gov/kms/concepts/concept_scheme/measurementname?format=csv has a lowercase scheme name.   In KMS, it is propercase.  The lookup for csv headers needed to do a case insensitive match.

2) If KMS doesn't have any csv headers, KMS defaults to a generated set of headers (schemename|level1|level2|etc), when writing the csv header, we needed to make sure we use the proper case form of the scheme name.
curl "https://cmr.sit.earthdata.nasa.gov/kms/concepts/concept_scheme/mimetype?format=csv" | head 
"mimetype","UUID" <-- wrong
"application/geo+json","aa595aba-86bf-4cc6-8ab5-26ee4de68eeb"
"application/gml+xml","40bdf6e5-780c-43e2-ab8e-e5dfae4bd779"

"MimeType","UUID" <--- correct
"application/geo+json","aa595aba-86bf-4cc6-8ab5-26ee4de68eeb"
"application/gml+xml","40bdf6e5-780c-43e2-ab8e-e5dfae4bd779"

3) There was a "hack" in the old KMS 1.0 that if the request scheme name was `granuledataformat`, it should use `dataformat` for the scheme name lookup.

### What areas of the application does this impact?

CSV headers

# Testing

curl "http://localhost:4001/dev/concepts/concept_scheme/mimetype?format=csv" | head 
curl "http://localhost:4001/dev/concepts/concept_scheme/processinglevelid?format=csv" | head 
curl "http://localhost:4001/dev/concepts/concept_scheme/granuledataformat?format=csv" | head 
curl "http://localhost:4001/dev/concepts/concept_scheme/measurementname?format=csv" | head 

and compare that with production, i.e., 
curl "https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/mimetype?format=csv" | head 
etc.

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
