### PR TITLE
KMS-605: Added RDF_BUCKET_NAME as env variable for lambda.

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -63,6 +63,7 @@ dockerRun() {
         --env "SYNC_API_ENDPOINT=$bamboo_SYNC_API_ENDPOINT" \
         --env "CMR_BASE_URL=$bamboo_CMR_BASE_URL" \
         --env "CORS_ORIGIN=$bamboo_CORS_ORIGIN" \
+        --env "RDF_BUCKET_NAME=$bamboo_RDF_BUCKET_NAME" \
         $dockerTag "$@"
 }
 

--- a/serverless-configs/aws-functions.yml
+++ b/serverless-configs/aws-functions.yml
@@ -42,6 +42,8 @@ syncConceptData:
 exportRdfToS3:
   handler: serverless/src/exportRdfToS3/handler.default
   timeout: 900
+  environment:
+    RDF_BUCKET_NAME: ${env:RDF_BUCKET_NAME, 'kms-rdf-backup'}
   events:
     - schedule:
         name: exportRdfToS3ForPublished


### PR DESCRIPTION
# Overview

### What is the feature?

The `handler.js` that exports the rdf files to s3 buckets does not use the env variable for RDF_BUCKET_NAME.

### What is the Solution?

In order for lambda's to access env variables, we need an environment block and include the env var as part of this block in aws-functions.yml

### What areas of the application does this impact?

Export of RDF data to S3.

# Testing

Verify S3 writes to the s3 bucket:
kms-rdf-backup-sit
kms-rdf-backup-uat
kms-rdf-backup-ops

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
