### PR TITLE
KMS-613: Fixed CSV for instruments.

### DIFF
--- a/serverless/src/shared/__tests__/formatCsvPath.test.js
+++ b/serverless/src/shared/__tests__/formatCsvPath.test.js
@@ -18,14 +18,14 @@ describe('formatPath', () => {
             expect(result).toEqual(['a', 'b', 'c'])
           })
 
-          test('should pad the path with spaces when path length is less than maxLevel and not a leaf', () => {
-            const result = formatCsvPath(scheme, 6, ['a', 'b'], false)
-            expect(result).toEqual(['a', 'b', ' ', ' '])
+          test('should pad spaces to the end when path is shorter than maxLevel and not a leaf', () => {
+            const result = formatCsvPath('instruments', 6, ['Instrument1'], false)
+            expect(result).toEqual(['Instrument1', ' ', ' ', ' '])
           })
 
-          test('should insert a space at maxLevel - 2 when path length is less than maxLevel and is a leaf', () => {
-            const result = formatCsvPath(scheme, 6, ['a', 'b', 'c'], true)
-            expect(result).toEqual(['a', 'b', ' ', 'c'])
+          test('should pad spaces before short name when path is shorter than maxLevel and is a leaf', () => {
+            const result = formatCsvPath('instruments', 6, ['Instrument1', 'ShortName'], true)
+            expect(result).toEqual(['Instrument1', ' ', ' ', 'ShortName'])
           })
         })
       })

--- a/serverless/src/shared/formatCsvPath.js
+++ b/serverless/src/shared/formatCsvPath.js
@@ -33,28 +33,22 @@
 export const formatCsvPath = (scheme, csvHeadersCount, path, isLeaf) => {
   // Handle 'platforms', 'instruments', and 'projects' schemes
   if (['platforms', 'instruments', 'projects'].includes(scheme.toLowerCase())) {
-    const maxLevel = csvHeadersCount - 2
+    const maxLevel = csvHeadersCount - 2 // Max level up to long name, uuid
 
     // Return if path length matches maxLevel
     if (maxLevel === path.length) {
       return path
     }
 
-    // Add spaces to non-leaf nodes if path is shorter than maxLevel
-    if ((maxLevel > path.length) && !isLeaf) {
-      while (maxLevel > path.length) {
-        path.push(' ')
+    while (maxLevel > path.length) {
+      if (!isLeaf) {
+        path.push(' ') // Add space to end
+      } else {
+        path.splice(path.length - 1, 0, ' ') // Add space before short name
       }
-
-      return path
     }
 
-    // Insert a space for leaf nodes if path is shorter than maxLevel
-    if ((maxLevel > path.length) && isLeaf) {
-      path.splice(maxLevel - 2, 0, ' ')
-
-      return path
-    }
+    return path
   }
 
   // Handle 'sciencekeywords', 'chronounits', 'locations', 'discipline', 'rucontenttype', and 'measurementname' schemes


### PR DESCRIPTION
# Overview

### What is the feature?

For Instruments, KMS 2.0 was not correct in its CSV generation.
For example,
"InSitu/Laboratory Instruments","Biological Sampling","Biopsy","","","5b96d8ad-e034-4561-acfb-b2769051e837"
The CSV has Category,Class,Type,Subtype,Short_Name,Long_Name,UUID
So it has 7 columns, and the short name should be the 3rd column from the right.
The padding should be added before the short name.   So it should look like this:
"In Situ/Laboratory Instruments","Biological Sampling"," "," ","Biopsy"," ","5b96d8ad-e034-4561-acfb-b2769051e837"

### What is the Solution?

Updated the logic to properly pad CSV for columns missing, particularly before the short name.

### What areas of the application does this impact?

CSV output:
https://cmr.sit.earthdata.nasa.gov/kms/concept_scheme/instruments

# Testing

Verify this CSV looks good.
https://cmr.sit.earthdata.nasa.gov/kms/concept_scheme/instruments

Run that attached script against SIT, the compare results should be must cleaner now.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
