### PR TITLE
KMS-616: Added limit to discourage bots from looping through excessive page number/page sizes.

### DIFF
--- a/serverless/src/getConcepts/__tests__/handler.test.js
+++ b/serverless/src/getConcepts/__tests__/handler.test.js
@@ -46,7 +46,11 @@ describe('getConcepts', () => {
     vi.resetAllMocks()
     vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.spyOn(console, 'log').mockImplementation(() => {})
-    getApplicationConfig.mockReturnValue({ defaultResponseHeaders: mockDefaultHeaders })
+    getApplicationConfig.mockReturnValue({
+      defaultResponseHeaders: mockDefaultHeaders,
+      maxTotalConceptsLimit: 50000
+    })
+
     createCsvForScheme.mockReset()
     createPrefLabelMap.mockResolvedValue(new Map())
     createConceptSchemeMap.mockResolvedValue(new Map())
@@ -609,6 +613,21 @@ describe('getConcepts', () => {
       expect(result.statusCode).toBe(400)
       expect(JSON.parse(result.body)).toEqual({
         error: 'Invalid page_size parameter. Must be between 1 and 2000.'
+      })
+    })
+
+    test('returns 400 when requested number of concepts exceeds maximum', async () => {
+      const event = {
+        queryStringParameters: {
+          page_num: '26',
+          page_size: '2000'
+        }
+      }
+      const result = await getConcepts(event)
+
+      expect(result.statusCode).toBe(400)
+      expect(JSON.parse(result.body)).toEqual({
+        error: 'Invalid page_size/page_num parameters (52000) exceeds the maximum allowed (50000).'
       })
     })
 

--- a/static.config.json
+++ b/static.config.json
@@ -6,7 +6,8 @@
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Headers": "*",
       "Access-Control-Allow-Credentials": true
-    }
+    },
+    "maxTotalConceptsLimit": 50000
   },
   "edl": {
     "host": "https://sit.urs.earthdata.nasa.gov",


### PR DESCRIPTION
# Overview

### What is the feature?

Added limit to max concepts to discourage bots from looping through excessive page number/page sizes.
It is causing KMS to perform unnecessary queries for total count given some search criteria.   

Examples queries in real world look like this:
https://cmr.earthdata.nasa.gov/kms/concepts/concept_scheme/DataFormat?format=rdf&page_num=12026&page_size=2000

### What is the Solution?

Now does a check page_num*page_size should not be > 50,000.   Total # of concepts is ~15K, so plenty of room to grow before this limit has to be changed.

Limit is configurable by changing static.config.json

### What areas of the application does this impact?

/kms/concepts endpoint.

# Testing

curl "http://localhost:4001/dev/concepts?page_size=2000&page_num=2000"
should result in an 400 error.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
