### PR TITLE
KMS-619: Set max_page_size to 1000 because of 6mb limit in Lambda payload

### DIFF
--- a/serverless/src/getConcepts/__tests__/handler.test.js
+++ b/serverless/src/getConcepts/__tests__/handler.test.js
@@ -176,7 +176,7 @@ describe('getConcepts', () => {
 
       expect(getFilteredTriples).toHaveBeenCalledWith({
         pageNum: 1,
-        pageSize: 2000,
+        pageSize: 1000,
         pattern: 'matching',
         conceptScheme: undefined,
         version: 'published'
@@ -220,7 +220,7 @@ describe('getConcepts', () => {
       expect(getFilteredTriples).toHaveBeenCalledWith({
         conceptScheme: 'scheme1',
         pageNum: 1,
-        pageSize: 2000,
+        pageSize: 1000,
         pattern: undefined,
         version: 'published'
       })
@@ -273,7 +273,7 @@ describe('getConcepts', () => {
       expect(getFilteredTriples).toHaveBeenCalledWith({
         conceptScheme: 'scheme1',
         pageNum: 1,
-        pageSize: 2000,
+        pageSize: 1000,
         pattern: 'matching',
         version: 'published'
       })
@@ -531,7 +531,7 @@ describe('getConcepts', () => {
       const body = JSON.parse(result.body)
       expect(body).toHaveProperty('hits', 2)
       expect(body).toHaveProperty('page_num', 1)
-      expect(body).toHaveProperty('page_size', 2000)
+      expect(body).toHaveProperty('page_size', 1000)
       expect(body).toHaveProperty('concepts')
       expect(body.concepts).toHaveLength(2)
       expect(body.concepts[0]).toEqual({
@@ -612,15 +612,15 @@ describe('getConcepts', () => {
 
       expect(result.statusCode).toBe(400)
       expect(JSON.parse(result.body)).toEqual({
-        error: 'Invalid page_size parameter. Must be between 1 and 2000.'
+        error: 'Invalid page_size parameter. Must be between 1 and 1000.'
       })
     })
 
     test('returns 400 when requested number of concepts exceeds maximum', async () => {
       const event = {
         queryStringParameters: {
-          page_num: '26',
-          page_size: '2000'
+          page_num: '52',
+          page_size: '1000'
         }
       }
       const result = await getConcepts(event)
@@ -667,7 +667,7 @@ describe('getConcepts', () => {
 
       expect(result.headers['X-Total-Count']).toBe('0')
       expect(result.headers['X-Page-Number']).toBe('1')
-      expect(result.headers['X-Page-Size']).toBe('2000')
+      expect(result.headers['X-Page-Size']).toBe('1000')
       expect(result.headers['X-Total-Pages']).toBe('0')
       expect(result.body).not.toContain('<skos:Concept')
     })
@@ -712,7 +712,7 @@ describe('getConcepts', () => {
 
       expect(result.statusCode).toBe(400)
       expect(JSON.parse(result.body)).toEqual({
-        error: 'Invalid page_size parameter. Must be between 1 and 2000.'
+        error: 'Invalid page_size parameter. Must be between 1 and 1000.'
       })
     })
 
@@ -726,7 +726,7 @@ describe('getConcepts', () => {
 
       expect(result.statusCode).toBe(400)
       expect(JSON.parse(result.body)).toEqual({
-        error: 'Invalid page_size parameter. Must be between 1 and 2000.'
+        error: 'Invalid page_size parameter. Must be between 1 and 1000.'
       })
     })
   })

--- a/serverless/src/getConcepts/handler.js
+++ b/serverless/src/getConcepts/handler.js
@@ -19,6 +19,8 @@ import { processTriples } from '@/shared/processTriples'
 import { toLegacyJSON } from '@/shared/toLegacyJSON'
 import { toSkosJson } from '@/shared/toSkosJson'
 
+const MAX_PAGE_SIZE = 1000
+
 /**
  * Retrieves multiple SKOS Concepts and returns them in the specified format.
  *
@@ -34,7 +36,7 @@ import { toSkosJson } from '@/shared/toSkosJson'
  * @param {string} [event.pathParameters.pattern] - The pattern to filter concepts by.
  * @param {Object} [event.queryStringParameters] - The query string parameters from the API Gateway event.
  * @param {string} [event.queryStringParameters.page_num='1'] - The page number for pagination.
- * @param {string} [event.queryStringParameters.page_size='2000'] - The page size for pagination (max 2000).
+ * @param {string} [event.queryStringParameters.page_size='1000'] - The page size for pagination (max 1000).
  * @param {string} [event.queryStringParameters.format='rdf'] - The output format (rdf, json, xml, or csv).
  * @param {string} [event.queryStringParameters.version='published'] - The version of the concepts to retrieve.
  * @param {string} [event.path] - The path of the API request.
@@ -93,7 +95,7 @@ export const getConcepts = async (event, context) => {
   const { defaultResponseHeaders, maxTotalConceptsLimit = 50000 } = getApplicationConfig()
   const { queryStringParameters } = event
   const { conceptScheme, pattern } = event?.pathParameters || {}
-  const { page_num: pageNumStr = '1', page_size: pageSizeStr = '2000', format = 'rdf' } = event?.queryStringParameters || {}
+  const { page_num: pageNumStr = '1', page_size: pageSizeStr = MAX_PAGE_SIZE.toString(), format = 'rdf' } = event?.queryStringParameters || {}
   const version = queryStringParameters?.version || 'published'
 
   // Convert page_num and page_size to integers
@@ -117,12 +119,12 @@ export const getConcepts = async (event, context) => {
   }
 
   if (Number.isNaN(pageSize)
-  || pageSize < 1 || pageSize > 2000
+  || pageSize < 1 || pageSize > MAX_PAGE_SIZE
   || pageSize !== Number(pageSizeStr)) {
     return {
       headers: defaultResponseHeaders,
       statusCode: 400,
-      body: JSON.stringify({ error: 'Invalid page_size parameter. Must be between 1 and 2000.' })
+      body: JSON.stringify({ error: 'Invalid page_size parameter. Must be between 1 and 1000.' })
     }
   }
 


### PR DESCRIPTION
…load

# Overview

### What is the feature?

Lower max_page_size to 1000 for getConcepts because of 6mb limit of Lambda payload. 

### What is the Solution?

Set max_pay_size to 1000 (was 2000)

### What areas of the application does this impact?

getConcepts, formats rdf, json, xml

# Testing

https://cmr.sit.earthdata.nasa.gov/kms/concepts/concept_scheme/platforms?format=rdf should work. Accepting page_size parameter is at max 1000. Use higher number to see error message.

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
