### PR TITLE
KMS-626: Add version check, pass version parameters to shared methods…

### DIFF
--- a/serverless/src/getConceptScheme/__tests__/handler.test.js
+++ b/serverless/src/getConceptScheme/__tests__/handler.test.js
@@ -22,6 +22,16 @@ describe('getConceptScheme', () => {
     getApplicationConfig.mockReturnValue({ defaultResponseHeaders: { 'X-Custom-Header': 'Value' } })
   })
 
+  let consoleErrorSpy
+
+  beforeAll(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
   describe('When called with valid parameters', () => {
     test('should return a 200 status code and XML content', async () => {
       getConceptSchemeDetails.mockResolvedValue({

--- a/serverless/src/shared/__tests__/ensureBucketAndLifecycleRule.test.js
+++ b/serverless/src/shared/__tests__/ensureBucketAndLifecycleRule.test.js
@@ -3,6 +3,16 @@ import { CreateBucketCommand, HeadBucketCommand } from '@aws-sdk/client-s3'
 import { ensureBucketAndLifecycleRule } from '../ensureBucketAndLifeCycleRule' // Make sure to export this function in your handler file
 
 describe('ensureBucketAndLifecycleRule', () => {
+  let consoleLogSpy
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore()
+  })
+
   test('should create bucket and set lifecycle rule if bucket does not exist', async () => {
     const mockS3Client = {
       send: vi.fn()

--- a/serverless/src/shared/__tests__/generateCsvHeaders.test.js
+++ b/serverless/src/shared/__tests__/generateCsvHeaders.test.js
@@ -20,6 +20,15 @@ describe('generateCsvHeaders', () => {
     vi.clearAllMocks()
   })
 
+  let consoleErrorSpy
+  beforeAll(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
   test('should generate headers for 2 columns', async () => {
     // Mock the sparqlRequest response
     sparqlRequest.mockResolvedValue({

--- a/serverless/src/shared/__tests__/toLegacyJSON.test.js
+++ b/serverless/src/shared/__tests__/toLegacyJSON.test.js
@@ -13,6 +13,8 @@ describe('toLegacyJSON', () => {
   let mockConceptSchemeMap
   let mockPrefLabelMap
   let mockConceptToConceptSchemeShortNameMap
+  let keywordVersion
+  let versionCreationDate
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -65,6 +67,9 @@ describe('toLegacyJSON', () => {
       ['relatedUUID3', 'testRelatedScheme'],
       ['relatedUUID4', 'testRelatedScheme']
     ])
+
+    keywordVersion = '20.6'
+    versionCreationDate = '2025-01-31 11:22:12'
   })
 
   describe('when given a basic skos concept', () => {
@@ -73,7 +78,9 @@ describe('toLegacyJSON', () => {
         mockConcept,
         mockConceptSchemeMap,
         mockConceptToConceptSchemeShortNameMap,
-        mockPrefLabelMap
+        mockPrefLabelMap,
+        keywordVersion,
+        versionCreationDate
       )
 
       expect(result).toEqual({

--- a/serverless/src/shared/__tests__/toLegacyXML.test.js
+++ b/serverless/src/shared/__tests__/toLegacyXML.test.js
@@ -36,6 +36,9 @@ describe('toLegacyXML', () => {
     ['http://example.com/sciencekeyword', 'Test Science Keyword']
   ])
 
+  const keywordVersion = '10.0'
+  const versionCreationDate = '2023-06-01'
+
   describe('when processing a basic concept', () => {
     test('should correctly transform basic concept properties', () => {
       const concept = {
@@ -44,13 +47,15 @@ describe('toLegacyXML', () => {
         'dcterms:modified': '2023-01-01 12:00:00'
       }
 
-      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme')
+      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme', keywordVersion, versionCreationDate)
 
       expect(result.concept['@uuid']).toBe('http://example.com/concept')
       expect(result.concept.prefLabel).toBe('Test Concept')
       expect(result.concept.lastModifiedDate).toBe('2023-01-01')
       expect(result.concept.conceptScheme['@name']).toBe('testScheme')
       expect(result.concept.conceptScheme['@longName']).toBe('Test Scheme')
+      expect(result.concept.keywordVersion).toBe('10.0')
+      expect(result.concept.schemeVersion).toBe('2023-06-01')
     })
   })
 
@@ -70,12 +75,14 @@ describe('toLegacyXML', () => {
         ]
       }
 
-      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme')
+      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme', keywordVersion, versionCreationDate)
 
       expect(result.concept.broader.conceptBrief['@prefLabel']).toBe('Broader Concept')
       expect(result.concept.narrower.conceptBrief).toHaveLength(2)
       expect(result.concept.narrower.conceptBrief[0]['@prefLabel']).toBe('Narrower Concept 1')
       expect(result.concept.narrower.conceptBrief[1]['@prefLabel']).toBe('Narrower Concept 2')
+      expect(result.concept.keywordVersion).toBe('10.0')
+      expect(result.concept.schemeVersion).toBe('2023-06-01')
     })
   })
 
@@ -102,7 +109,7 @@ describe('toLegacyXML', () => {
         }
       }
 
-      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme')
+      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme', keywordVersion, versionCreationDate)
 
       expect(result.concept.altLabels.altLabel).toHaveLength(2)
       expect(result.concept.altLabels.altLabel[0]).toEqual({
@@ -114,6 +121,8 @@ describe('toLegacyXML', () => {
       expect(result.concept.definition['@reference']).toBe('Test Reference')
       expect(result.concept.resources.resource['@type']).toBe('testType')
       expect(result.concept.resources.resource['#text']).toBe('http://example.com/resource')
+      expect(result.concept.keywordVersion).toBe('10.0')
+      expect(result.concept.schemeVersion).toBe('2023-06-01')
     })
   })
 
@@ -131,7 +140,7 @@ describe('toLegacyXML', () => {
 
       }
 
-      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme')
+      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme', keywordVersion, versionCreationDate)
       expect(result.concept.related.weightedRelation).toHaveLength(3)
       expect(result.concept.related.weightedRelation[0]['@type']).toBe('has_instrument')
       expect(result.concept.related.weightedRelation[0]['@prefLabel']).toBe('Test Instrument')
@@ -139,6 +148,8 @@ describe('toLegacyXML', () => {
       expect(result.concept.related.weightedRelation[1]['@prefLabel']).toBe('Test Sensor')
       expect(result.concept.related.weightedRelation[2]['@type']).toBe('is_on_platform')
       expect(result.concept.related.weightedRelation[2]['@prefLabel']).toBe('Test Platform')
+      expect(result.concept.keywordVersion).toBe('10.0')
+      expect(result.concept.schemeVersion).toBe('2023-06-01')
     })
 
     test('should correctly handle skos:related relations', () => {
@@ -152,10 +163,12 @@ describe('toLegacyXML', () => {
 
       }
 
-      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme')
+      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme', keywordVersion, versionCreationDate)
       expect(result.concept.related.weightedRelation).toHaveLength(1)
       expect(result.concept.related.weightedRelation[0]['@type']).not.toBeDefined()
       expect(result.concept.related.weightedRelation[0]['@prefLabel']).toBe('Test Science Keyword')
+      expect(result.concept.keywordVersion).toBe('10.0')
+      expect(result.concept.schemeVersion).toBe('2023-06-01')
     })
   })
 
@@ -178,7 +191,7 @@ describe('toLegacyXML', () => {
       `
       }
 
-      const resultSingle = toLegacyXML(conceptSingleNote, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme')
+      const resultSingle = toLegacyXML(conceptSingleNote, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme', keywordVersion, versionCreationDate)
 
       expect(resultSingle.concept.changeNotes.changeNote).toEqual({
         '@date': '2020-01-06',
@@ -207,7 +220,7 @@ describe('toLegacyXML', () => {
         'skos:prefLabel': { _text: 'Test Concept' }
       }
 
-      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme')
+      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme', keywordVersion, versionCreationDate)
 
       expect(result.concept.altLabels).toBeNull()
       expect(result.concept.definition).toBeUndefined()
@@ -217,6 +230,8 @@ describe('toLegacyXML', () => {
       expect(result.concept.resources).toBeUndefined()
       expect(result.concept.changeNotes).toBeUndefined()
       expect(result.concept.lastModifiedDate).toBeUndefined()
+      expect(result.concept.keywordVersion).toBe('10.0')
+      expect(result.concept.schemeVersion).toBe('2023-06-01')
     })
   })
 
@@ -227,7 +242,7 @@ describe('toLegacyXML', () => {
         'skos:prefLabel': { _text: 'Test Concept' }
       }
 
-      expect(() => toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'nonExistentScheme'))
+      expect(() => toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'nonExistentScheme', keywordVersion, versionCreationDate))
         .toThrow('No matching scheme found for: nonExistentScheme')
     })
   })
@@ -240,10 +255,12 @@ describe('toLegacyXML', () => {
         'skos:narrower': { '@rdf:resource': 'http://example.com/narrower1' }
       }
 
-      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme')
+      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme', keywordVersion, versionCreationDate)
 
       expect(result.concept.narrower.conceptBrief).toHaveLength(1)
       expect(result.concept.narrower.conceptBrief[0]['@prefLabel']).toBe('Narrower Concept 1')
+      expect(result.concept.keywordVersion).toBe('10.0')
+      expect(result.concept.schemeVersion).toBe('2023-06-01')
     })
   })
 
@@ -255,11 +272,13 @@ describe('toLegacyXML', () => {
         'gcmd:hasInstrument': { '@rdf:resource': 'http://example.com/instrument' }
       }
 
-      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme')
+      const result = toLegacyXML(concept, mockConceptSchemeDetails, mockCsvHeaders, mockConceptToConceptSchemeShortNameMap, mockPrefLabelMap, 'testScheme', keywordVersion, versionCreationDate)
 
       expect(result.concept.related.weightedRelation).toHaveLength(1)
       expect(result.concept.related.weightedRelation[0]['@type']).toBe('has_instrument')
       expect(result.concept.related.weightedRelation[0]['@prefLabel']).toBe('Test Instrument')
+      expect(result.concept.keywordVersion).toBe('10.0')
+      expect(result.concept.schemeVersion).toBe('2023-06-01')
     })
   })
 })

--- a/serverless/src/shared/toLegacyJSON.js
+++ b/serverless/src/shared/toLegacyJSON.js
@@ -11,6 +11,8 @@
  * @param {Map<string, string>} conceptSchemeMap - A map of concept scheme short names to their long names.
  * @param {Map<string, string>} conceptToConceptSchemeShortNameMap - A map of concept IRIs to their scheme short names.
  * @param {Map<string, string>} prefLabelMap - A map of concept IRIs to their preferred labels.
+ * @param {string} keywordVersion - The version of the keyword set.
+ * @param {string} versionCreationDate - The creation date of the version, used as the scheme version.
  * @returns {Object} The transformed legacy JSON object.
  * @throws {Error} If there's an error during the conversion process.
  *
@@ -37,8 +39,17 @@
  *   const conceptSchemeMap = new Map([['scheme1', 'Scheme One'], ...]);
  *   const conceptToConceptSchemeShortNameMap = new Map([['http://example.com/concept/1', 'scheme1'], ...]);
  *   const prefLabelMap = new Map([['http://example.com/concept/1', 'Concept One'], ...]);
+ *   const keywordVersion = '10.0';
+ *   const versionCreationDate = '2023-06-01'
  *
- *   const legacyJSON = toLegacyJSON(concept, conceptSchemeMap, conceptToConceptSchemeShortNameMap, prefLabelMap);
+ *   const legacyJSON = toLegacyJSON(
+ *     concept,
+ *     conceptSchemeMap,
+ *     conceptToConceptSchemeShortNameMap,
+ *     prefLabelMap,
+ *     keywordVersion,
+ *     versionCreationDate
+ *   )
  *   console.log('Transformed legacy JSON:', legacyJSON);
  * } catch (error) {
  *   console.error('Error converting to legacy JSON:', error);
@@ -55,7 +66,9 @@ export const toLegacyJSON = (
   concept,
   conceptSchemeMap,
   conceptToConceptSchemeShortNameMap,
-  prefLabelMap
+  prefLabelMap,
+  keywordVersion,
+  versionCreationDate
 ) => {
   // Helper function to determine if there are multiple altLabels and assist in translating the different types
   const processAltLabels = (altLabels) => {
@@ -91,8 +104,8 @@ export const toLegacyJSON = (
     // Transform the data
     const transformedData = {
       termsOfUse: 'https://cdn.earthdata.nasa.gov/conduit/upload/5182/KeywordsCommunityGuide_Baseline_v1_SIGNED_FINAL.pdf',
-      keywordVersion: '20.6',
-      schemeVersion: '2025-01-31 11:22:12', // Corrolates with the change of keywordVersion
+      keywordVersion,
+      schemeVersion: versionCreationDate, // Corrolates with the change of keywordVersion
       viewer: `https://gcmd.earthdata.nasa.gov/KeywordViewer/scheme/${schemeShortName}/${uuid}`,
       lastModifiedDate: concept['dcterms:modified'],
       uuid,

--- a/serverless/src/shared/toLegacyXML.js
+++ b/serverless/src/shared/toLegacyXML.js
@@ -17,6 +17,8 @@ import { createChangeNote } from '@/shared/createChangeNote'
  * @param {Map<string, string>} conceptToConceptSchemeShortNameMap - A map of concept IRIs to their scheme short names.
  * @param {Map<string, string>} prefLabelMap - A map of concept IRIs to their preferred labels for the specific version.
  * @param {string} schemeShortName - The short name of the concept scheme.
+ * @param {string} keywordVersion - The version of the keyword set.
+ * @param {string} versionCreationDate - The creation date of the version, used as the scheme version.
  * @returns {Object} An object representing the legacy XML structure of the concept.
  * @throws {Error} If no matching scheme is found for the provided schemeShortName.
  *
@@ -26,13 +28,18 @@ import { createChangeNote } from '@/shared/createChangeNote'
  * const publishedSchemeDetails = [ ... ]; // Concept scheme details for the published version
  * const publishedCsvHeaders = [ ... ]; // CSV headers for the published version
  * const publishedPrefLabelMap = new Map([ ... ]); // Preferred label map for the published version
+ * const schemeShortName = 'sciencekeywords';
+ * const keywordVersion = '10.0';
+ * const versionCreationDate = '2023-06-01';
  *
  * const legacyXML = toLegacyXML(
  *   publishedConcept,
  *   publishedSchemeDetails,
  *   publishedCsvHeaders,
  *   publishedPrefLabelMap,
- *   'sciencekeywords'
+ *   schemeShortName,
+ *   keywordVersion,
+ *   versionCreationDate
  * );
  * console.log(JSON.stringify(legacyXML, null, 2));
  *
@@ -47,7 +54,9 @@ export const toLegacyXML = (
   csvHeaders,
   conceptToConceptSchemeShortNameMap,
   prefLabelMap,
-  schemeShortName
+  schemeShortName,
+  keywordVersion,
+  versionCreationDate
 ) => {
   // Helper function to retrieve parsed information in concept_schemes xml
 // Helper function to retrieve parsed information in concept_schemes xml
@@ -80,7 +89,7 @@ export const toLegacyXML = (
 
   // Finding the appropriate shortName and longName for scheme
   const matchingSchemeDetails = findMatchingConceptScheme(schemeShortName, conceptSchemeDetails)
-  const { schemeLongName, schemeVersionDate } = matchingSchemeDetails
+  const { schemeLongName } = matchingSchemeDetails
 
   const conceptObj = {
     concept: {
@@ -90,8 +99,8 @@ export const toLegacyXML = (
       '@uuid': uuid,
       '@xsi:noNamespaceSchemaLocation': 'https://gcmd.earthdata.nasa.gov/static/kms/kms.xsd',
       termsOfUse: 'https://cdn.earthdata.nasa.gov/conduit/upload/5182/KeywordsCommunityGuide_Baseline_v1_SIGNED_FINAL.pdf',
-      keywordVersion: '20.8',
-      schemeVersion: schemeVersionDate,
+      keywordVersion,
+      schemeVersion: versionCreationDate,
       viewer: `https://gcmd.earthdata.nasa.gov/KeywordViewer/scheme/${schemeShortName}/${uuid}`,
       // eslint-disable-next-line no-underscore-dangle
       prefLabel: concept['skos:prefLabel']._text,


### PR DESCRIPTION
… to create outputs, suppress output when tests run

# Overview

### What is the feature?

Use version and version creation date for rdf, xml and json outputs.   

### What is the Solution?

Remove hard coded values, use version attributes for outputs.

### What areas of the application does this impact?

/concept/<uuid>, all formats

# Testing

1. Output of rdf, xml and json have same version label and scheme version (version creation date)
https://cmr.earthdata.nasa.gov/kms/concept/c47f6052-634e-40ef-a5ac-13f69f6f4c2a
https://cmr.earthdata.nasa.gov/kms/concept/c47f6052-634e-40ef-a5ac-13f69f6f4c2a?format=json
https://cmr.earthdata.nasa.gov/kms/concept/c47f6052-634e-40ef-a5ac-13f69f6f4c2a?format=xml

2. To test version check, add version=xyz to query parameters.
3. Test run shouldn't print out errors in the console when tests passed.

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
