### PR TITLE
KMS-620: Fix issue with related keywords in json format showing wrong preflabel

### DIFF
--- a/serverless/src/shared/__tests__/toLegacyJSON.test.js
+++ b/serverless/src/shared/__tests__/toLegacyJSON.test.js
@@ -214,7 +214,7 @@ describe('toLegacyJSON', () => {
       expect(result.related).toEqual([
         {
           uuid: 'relatedUUID1',
-          prefLabel: 'Test PrefLabel',
+          prefLabel: 'Related PrefLabel 1',
           scheme: {
             shortName: 'testRelatedScheme',
             longName: 'Test Related Scheme'
@@ -223,7 +223,7 @@ describe('toLegacyJSON', () => {
         },
         {
           uuid: 'relatedUUID2',
-          prefLabel: 'Test PrefLabel',
+          prefLabel: 'Related PrefLabel 2',
           scheme: {
             shortName: 'testRelatedScheme',
             longName: 'Test Related Scheme'
@@ -252,7 +252,7 @@ describe('toLegacyJSON', () => {
       expect(result.related).toEqual([
         {
           uuid: 'relatedUUID1',
-          prefLabel: 'Test PrefLabel',
+          prefLabel: 'Related PrefLabel 1',
           scheme: {
             shortName: 'testRelatedScheme',
             longName: 'Test Related Scheme'
@@ -261,7 +261,7 @@ describe('toLegacyJSON', () => {
         },
         {
           uuid: 'relatedUUID2',
-          prefLabel: 'Test PrefLabel',
+          prefLabel: 'Related PrefLabel 2',
           scheme: {
             shortName: 'testRelatedScheme',
             longName: 'Test Related Scheme'
@@ -467,7 +467,7 @@ describe('toLegacyJSON', () => {
       expect(result.related).toEqual([
         {
           uuid: 'relatedUUID1',
-          prefLabel: 'Test PrefLabel',
+          prefLabel: 'Related PrefLabel 1',
           scheme: {
             shortName: 'testRelatedScheme',
             longName: 'Test Related Scheme'
@@ -476,7 +476,7 @@ describe('toLegacyJSON', () => {
         },
         {
           uuid: 'relatedUUID3',
-          prefLabel: 'Test PrefLabel',
+          prefLabel: 'Related PrefLabel 3',
           scheme: {
             shortName: 'testRelatedScheme',
             longName: 'Test Related Scheme'
@@ -485,7 +485,7 @@ describe('toLegacyJSON', () => {
         },
         {
           uuid: 'relatedUUID2',
-          prefLabel: 'Test PrefLabel',
+          prefLabel: 'Related PrefLabel 2',
           scheme: {
             shortName: 'testRelatedScheme',
             longName: 'Test Related Scheme'
@@ -510,7 +510,7 @@ describe('toLegacyJSON', () => {
       expect(result.related).toEqual([
         {
           uuid: 'relatedUUID4',
-          prefLabel: 'Test PrefLabel',
+          prefLabel: 'Related PrefLabel 4',
           scheme: {
             shortName: 'testRelatedScheme',
             longName: 'Test Related Scheme'

--- a/serverless/src/shared/toLegacyJSON.js
+++ b/serverless/src/shared/toLegacyJSON.js
@@ -155,7 +155,7 @@ export const toLegacyJSON = (
 
           const result = {
             uuid: relationUuid,
-            prefLabel: prefLabelMap.get(uuid),
+            prefLabel: prefLabelMap.get(relationUuid),
             scheme: {
               shortName: relatedShortName,
               longName: relatedLongName


### PR DESCRIPTION
# Overview

### What is the feature?

Fix issue related keywords in json format showing wrong preflabel

### What is the Solution?

Use preflabel of related keywords

### What areas of the application does this impact?

single concept in json format

# Testing

Compare:
https://cmr.sit.earthdata.nasa.gov/kms/concept/68820e6c-4047-4830-99a8-57e13cc5699d?version=draft&format=json
with:
http://localhost:4001/dev/concept/68820e6c-4047-4830-99a8-57e13cc5699d?version=draft&format=json

### Attachments
N/A
# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
