### PR TITLE
KMS-633: Now supports instance refresh for AMI updates

### DIFF
--- a/bin/refresh_asg.sh
+++ b/bin/refresh_asg.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Auto Scaling Group Instance Refresh Script for RDF4J Single-Writer Setup
+# 
+# Purpose: This script performs a controlled refresh of a single instance in an Auto Scaling Group (ASG)
+# associated with an ECS cluster running an RDF4J database. It's designed specifically to maintain
+# a single-instance environment, which is crucial for RDF4J's 1-writer constraint.
+#
+# Key Features:
+# - Ensures only one instance is running at any time, adhering to RDF4J's single-writer requirement
+# - Performs a complete shutdown of the existing instance before starting a new one
+# - Minimizes downtime while maintaining data integrity
+# - Waits for ECS services to stabilize, ensuring the RDF4J database is fully operational
+# - Useful for applying AMI updates or other instance-level changes that require a full instance replacement
+#
+# IMPORTANT: This script is tailored for an RDF4J setup that requires exactly one instance to be running
+# at all times due to the database's 1-writer limitation. Modifying this script to allow multiple instances
+# could lead to data corruption or inconsistencies in the RDF4J database.
+
+set -e
+
+# Function to log messages with timestamp
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - $1"
+}
+
+# Get the Auto Scaling Group name
+get_asg_name() {
+    aws ecs list-clusters --query "clusterArns[?contains(@, 'rdf4jEcs')]" --output text | \
+    xargs aws ecs describe-clusters --clusters --query "clusters[0].capacityProviders[0]" --output text | \
+    xargs aws ecs describe-capacity-providers --capacity-providers --query "capacityProviders[0].autoScalingGroupProvider.autoScalingGroupArn" --output text | \
+    awk -F/ '{print $NF}'
+}
+
+ASG_NAME=$(get_asg_name)
+log "Using Auto Scaling Group: $ASG_NAME"
+
+# Get the ECS cluster name
+CLUSTER_NAME=$(aws ecs list-clusters --query "clusterArns[?contains(@, 'rdf4jEcs')]" --output text | awk -F/ '{print $NF}')
+SERVICE_NAME=$(aws ecs list-services --cluster $CLUSTER_NAME --query "serviceArns[0]" --output text | awk -F/ '{print $NF}')
+
+# Set everything to 0
+log "Setting min, max, and desired capacity to 0..."
+aws autoscaling update-auto-scaling-group --auto-scaling-group-name $ASG_NAME --min-size 0 --max-size 0 --desired-capacity 0
+
+# Wait for instances to be terminated
+log "Waiting for instances to be terminated..."
+while true; do
+    INSTANCE_COUNT=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names $ASG_NAME --query "length(AutoScalingGroups[0].Instances)" --output text)
+    if [ "$INSTANCE_COUNT" -eq 0 ]; then
+        log "All instances terminated"
+        break
+    fi
+    log "Instances still running: $INSTANCE_COUNT"
+    sleep 30
+done
+
+# Wait for a bit to ensure everything is shut down
+sleep 60
+
+# Set everything back to 1
+log "Setting min, max, and desired capacity back to 1..."
+aws autoscaling update-auto-scaling-group --auto-scaling-group-name $ASG_NAME --min-size 1 --max-size 1 --desired-capacity 1
+
+# Wait for new instance to be in service
+log "Waiting for new instance to be in service..."
+while true; do
+    INSTANCE_COUNT=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names $ASG_NAME --query "length(AutoScalingGroups[0].Instances[?LifecycleState=='InService'])" --output text)
+    if [ "$INSTANCE_COUNT" -eq 1 ]; then
+        log "New instance is now in service"
+        break
+    fi
+    log "Waiting for instance to be in service..."
+    sleep 30
+done
+
+# Wait for ECS service to be stable
+log "Waiting for ECS service to be stable..."
+aws ecs wait services-stable --cluster $CLUSTER_NAME --services $SERVICE_NAME
+
+log "Refresh process completed. New instance is now in service and ECS tasks should be running."

--- a/cdk/rdfdb/lib/EcsStack.ts
+++ b/cdk/rdfdb/lib/EcsStack.ts
@@ -3,7 +3,6 @@ import * as path from 'path'
 
 import {
   CfnOutput,
-  Duration,
   Fn,
   RemovalPolicy,
   Stack,
@@ -195,14 +194,6 @@ export class EcsStack extends Stack {
       },
       userData,
       role: this.role
-    })
-
-    // Add a lifecycle hook to ensure instances are launched in the correct AZ
-    autoScalingGroup.addLifecycleHook('EbsAzHook', {
-      lifecycleTransition: autoscaling.LifecycleTransition.INSTANCE_LAUNCHING,
-      defaultResult: autoscaling.DefaultResult.ABANDON,
-      heartbeatTimeout: Duration.minutes(5),
-      notificationMetadata: JSON.stringify({ targetAz: this.ebsVolumeAz })
     })
 
     // Add the security groups of the VPC endpoints to the Auto Scaling Group


### PR DESCRIPTION
# Overview

### What is the feature?

Fix issue where instant refresh never completes.

### What is the Solution?

 Simplify ASG and Add Instance Refresh Script

1. ASG Changes:
   - Removed 'EbsAzHook' lifecycle hook
   - Simplified instance launch process
   - Rationale: CDK handles AZ placement; reduces complexity so hook not necessary

2. New RDF4J Instance Refresh Script:
   - Purpose: Controlled instance refresh for single-instance RDF4J setup
   - Process: Shutdown old instance, start new one, verify ECS stability
   - Ensures only one instance runs at a time (RDF4J 1-writer constraint)
   - Use cases: AMI updates, config changes, controlled restarts

Impact: Streamlined infrastructure, resolved termination issues, 
        safer instance management for RDF4J database.

### What areas of the application does this impact?

AMI updates that occur every 90 days.

# Testing

cd kms/bin
./refresh_asg.sh

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
