### PR TITLE
KMS-666: Consumer - Update Keywords in ECHO-10 native records

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ This:
 
 - loads `scripts/local/fixtures/metadata_correction_service.dif10.example.json`
 - applies the corrections locally through the DIF10 delegate
-- writes the corrected XML to `tmp/metadata_correction_smoke_output.xml`
+- writes the corrected XML to `tmp/metadata_correction_dif10_smoke_output.xml`
 
 The final writeback step is still stubbed, so this is a local mutation/integration check rather
 than a live CMR ingest test.

--- a/scripts/local/fixtures/metadata_correction_service.echo10.example.json
+++ b/scripts/local/fixtures/metadata_correction_service.echo10.example.json
@@ -1,0 +1,121 @@
+{
+  "collectionConceptId": "C1234567890-LOCAL",
+  "nativeFormat": "ECHO10",
+  "source": "local-smoke",
+  "corrections": [
+    {
+      "scheme": "sciencekeywords",
+      "action": "replace",
+      "oldKeywordObject": {
+        "Category": "EARTH SCIENCE",
+        "Topic": "TERRESTRIAL HYDROSPHERE",
+        "Term": "SNOW/ICE",
+        "VariableLevel1": "SNOW WATER EQUIVALENT",
+        "VariableLevel2": "SNOW ICE TEST",
+        "VariableLevel3": "WATER ICE TEST",
+        "DetailedVariable": "RAIN"
+      },
+      "newKeywordObject": {
+        "Category": "EARTH SCIENCE-UPDATED",
+        "Topic": "TERRESTRIAL HYDROSPHERE-UPDATED",
+        "Term": "SNOW/ICE-UPDATED",
+        "VariableLevel1": "SNOW WATER EQUIVALENT-UPDATED",
+        "VariableLevel2": "SNOW ICE TEST-UPDATED",
+        "VariableLevel3": "WATER ICE TEST-UPDATED",
+        "DetailedVariable": "RAIN-UPDATED"
+      }
+    },
+    {
+      "scheme": "platforms",
+      "action": "replace",
+      "newLongName": "Earth Observing System, Terra (AM-1)-Updated",
+      "oldKeywordObject": {
+        "Category": "Platforms",
+        "Class": "Space-based Platforms",
+        "Type": "Earth Observation Satellites",
+        "ShortName": "Terra"
+      },
+      "newKeywordObject": {
+        "Category": "Platforms",
+        "Class": "Space-based Platforms",
+        "Type": "Earth Observation Satellites",
+        "ShortName": "Terra-UPDATED"
+      }
+    },
+    {
+      "scheme": "instruments",
+      "action": "delete",
+      "oldKeywordObject": {
+        "Category": "Imaging Spectrometers/Radiometers",
+        "Class": "",
+        "Subclass": "",
+        "ShortName": "AMSR-E"
+      }
+    },
+    {
+      "scheme": "projects",
+      "action": "replace",
+      "newLongName": "Advanced Microwave Scanning Radiometer Sea Ice Product Validation-UPDATED",
+      "oldKeywordObject": {
+        "Category": "A - C",
+        "ShortName": "AMSRICE06"
+      },
+      "newKeywordObject": {
+        "Category": "A - C",
+        "ShortName": "AMSRICE06-UPDATED"
+      }
+    },
+    {
+      "scheme": "providers",
+      "action": "replace",
+      "newLongName": "National Snow and Ice Data Center",
+      "oldKeywordObject": {
+        "BucketLevel0": "PROCESSOR",
+        "BucketLevel1": "",
+        "BucketLevel2": "",
+        "BucketLevel3": "",
+        "ShortName": "NASA/MSFC/AMSR-E SIPS"
+      },
+      "newKeywordObject": {
+        "BucketLevel0": "PROCESSOR",
+        "BucketLevel1": "",
+        "BucketLevel2": "",
+        "BucketLevel3": "",
+        "ShortName": "NASA/MSFC/AMSR-E SIPS-UPDATED"
+      }
+    },
+    {
+      "scheme": "rucontenttype",
+      "action": "replace",
+      "oldKeywordObject": {
+        "URLContentType": "PublicationURL",
+        "Type": "VIEW RELATED INFORMATION"
+      },
+      "newKeywordObject": {
+        "URLContentType": "PublicationURL-UPDATED",
+        "Type": "VIEW RELATED INFORMATION-UPDATED",
+        "Subtype": "Subtype-UPDATED"
+      }
+    },
+    {
+      "scheme": "dataformat",
+      "action": "replace",
+      "oldKeywordObject": {
+        "Value": "netCDF-4"
+      },
+      "newKeywordObject": {
+        "Value": "HDF5"
+      }
+    },
+    {
+      "scheme": "productlevelid",
+      "action": "replace",
+      "oldKeywordObject": {
+        "Value": "3"
+      },
+      "newKeywordObject": {
+        "Value": "4"
+      }
+    }
+  ]
+}

--- a/scripts/local/fixtures/metadata_correction_service.echo10.example.xml
+++ b/scripts/local/fixtures/metadata_correction_service.echo10.example.xml
@@ -1,0 +1,509 @@
+<Collection>
+    <ShortName>Mapping Short Name 1.18.5-echo10</ShortName>
+    <VersionId>1.18.5</VersionId>
+    <OtherIdentifiers>
+        <OtherIdentifier>
+            <Identifier>OtherIdentifier1</Identifier>
+            <Type>Other</Type>
+            <DescriptionOfOtherType>DAAC ID</DescriptionOfOtherType>
+        </OtherIdentifier>
+        <OtherIdentifier>
+            <Identifier>1234</Identifier>
+            <Type>ArchiveSetsNumber</Type>
+        </OtherIdentifier>
+        <OtherIdentifier>
+            <Identifier>gov.noaa.nodc:CRW-TS50km</Identifier>
+            <Type>ArchiveSetsNumber</Type>
+        </OtherIdentifier>
+    </OtherIdentifiers>
+    <InsertTime>2020-01-02T00:00:00.000Z</InsertTime>
+    <LastUpdate>2020-03-02T00:00:00.000Z</LastUpdate>
+    <DeleteTime>2037-01-02T00:00:00.000Z</DeleteTime>
+    <LongName>Not provided</LongName>
+    <DataSetId>Mapping Example for UMM-C 1.18.5-echo10</DataSetId>
+    <DataMaturity>Validated</DataMaturity>
+    <Description>This record is a Mapping Example.</Description>
+    <DOI>
+        <DOI>10.1234/DOIID</DOI>
+        <Authority>https://doi.org/</Authority>
+        <PreviousVersion>
+            <Version>1</Version>
+            <Description>Description of the Previous Version Element</Description>
+            <DOI>10.1234/Ref-1</DOI>
+            <Published>2003-03-03T00:00:00.000Z</Published>
+        </PreviousVersion>
+    </DOI>
+    <AssociatedDOIs>
+        <AssociatedDOI>
+            <DOI>10.1234/ParentDOIID1</DOI>
+            <Title>DOI Title 1</Title>
+            <Authority>https://doi.org/</Authority>
+        </AssociatedDOI>
+        <AssociatedDOI>
+            <DOI>10.1234/ParentDOIID2</DOI>
+            <Title>DOI Title 2</Title>
+            <Authority>https://doi.org/</Authority>
+            <Type>IsNewVersionOf</Type>
+        </AssociatedDOI>
+        <AssociatedDOI>
+            <DOI>10.1234/ParentDOIID2</DOI>
+            <Title>DOI Title 3</Title>
+            <Authority>https://doi.org/</Authority>
+            <Type>Other</Type>
+            <DescriptionOfOtherType>Calibration Data</DescriptionOfOtherType>
+        </AssociatedDOI>
+        <AssociatedDOI>
+            <DOI>10.1234/DescribedByDOIID2</DOI>
+            <Title>DOI Title 2</Title>
+            <Authority>https://doi.org/</Authority>
+            <Type>IsDescribedBy</Type>
+        </AssociatedDOI>
+    </AssociatedDOIs>
+    <CollectionDataType>LOW_LATENCY</CollectionDataType>
+    <RevisionDate>2020-03-01T00:00:00.000Z</RevisionDate>
+    <SuggestedUsage>This record is to be used to demonstrate how the CMR maps from one specification to another</SuggestedUsage>
+    <ProcessingCenter>NASA/MSFC/AMSR-E SIPS</ProcessingCenter>
+    <ProcessingLevelId>3</ProcessingLevelId>
+    <ProcessingLevelDescription>GRID</ProcessingLevelDescription>
+    <ArchiveCenter>NSIDC</ArchiveCenter>
+    <VersionDescription>Mapping Version 1.18.5 Description</VersionDescription>
+    <CitationForExternalPublication>Other Citation Details</CitationForExternalPublication>
+    <CollectionState>SUPERSEDED</CollectionState>
+    <RestrictionFlag>1</RestrictionFlag>
+    <RestrictionComment>Testing</RestrictionComment>
+    <UseConstraints>
+        <Description>Test description. This collection has no use constraints.</Description>
+        <FreeAndOpenData>true</FreeAndOpenData>
+        <EULAIdentifier>12345</EULAIdentifier>
+        <LicenseURL>
+            <URL>https://www.apache.org/licenses/LICENSE-2.0</URL>
+            <Type>License URL</Type>
+        </LicenseURL>
+    </UseConstraints>
+    <DataFormat>netCDF-4</DataFormat>
+    <TemporalKeywords>
+        <Keyword>TemporalKeyword1</Keyword>
+        <Keyword>TemporalKeyword2</Keyword>
+    </TemporalKeywords>
+    <Temporal>
+        <PrecisionOfSeconds>1</PrecisionOfSeconds>
+        <EndsAtPresentFlag>false</EndsAtPresentFlag>
+        <RangeDateTime>
+            <BeginningDateTime>2001-01-01T00:00:00.000Z</BeginningDateTime>
+            <EndingDateTime>2001-06-01T00:00:00.000Z</EndingDateTime>
+        </RangeDateTime>
+        <TemporalResolution>
+            <Value>25</Value>
+            <Unit>Minute</Unit>
+        </TemporalResolution>
+    </Temporal>
+    <Contacts>
+        <Contact>
+            <Role>PROCESSOR</Role>
+            <OrganizationName>NASA/MSFC/AMSR-E SIPS</OrganizationName>
+        </Contact>
+        <Contact>
+            <Role>ARCHIVER</Role>
+            <OrganizationName>NSIDC</OrganizationName>
+        </Contact>
+        <Contact>
+            <Role>ORIGINATOR</Role>
+            <OrganizationName>NASA/MSFC/AMSR-E SIPS</OrganizationName>
+            <ContactPersons>
+                <ContactPerson>
+                    <FirstName>Data Center Personnel First Name</FirstName>
+                    <MiddleName>Data Center Personnel Middle Name</MiddleName>
+                    <LastName>Data Center Personnel Last Name</LastName>
+                    <JobPosition>Science Contact</JobPosition>
+                </ContactPerson>
+                <ContactPerson>
+                    <FirstName>Data Center Personnel First Name</FirstName>
+                    <MiddleName>Data Center Personnel Middle Name</MiddleName>
+                    <LastName>Data Center Personnel Last Name</LastName>
+                    <JobPosition>INVESTIGATOR</JobPosition>
+                </ContactPerson>
+                <ContactPerson>
+                    <FirstName>Data Center Personnel First Name</FirstName>
+                    <MiddleName>Data Center Personnel Middle Name</MiddleName>
+                    <LastName>Data Center Personnel Last Name</LastName>
+                    <JobPosition>DATA CENTER CONTACT</JobPosition>
+                </ContactPerson>
+                <ContactPerson>
+                    <FirstName>Data Center Personnel2 First Name</FirstName>
+                    <MiddleName>Data Center Personnel2 Middle Name</MiddleName>
+                    <LastName>Data Center Personnel2 Last Name</LastName>
+                    <JobPosition>TECHNICAL CONTACT</JobPosition>
+                </ContactPerson>
+                <ContactPerson>
+                    <FirstName>Data Center Personnel2 First Name</FirstName>
+                    <MiddleName>Data Center Personnel2 Middle Name</MiddleName>
+                    <LastName>Data Center Personnel2 Last Name</LastName>
+                    <JobPosition>DATA CENTER CONTACT</JobPosition>
+                </ContactPerson>
+            </ContactPersons>
+        </Contact>
+        <Contact>
+            <Role>DISTRIBUTOR</Role>
+            <HoursOfService>8am-5pm (Mountain Time) Monday through Friday</HoursOfService>
+            <Instructions>contact by e-mail first</Instructions>
+            <OrganizationName>NSIDC</OrganizationName>
+            <OrganizationAddresses>
+                <Address>
+                    <StreetAddress>1540 30th St Campus Box 449</StreetAddress>
+                    <City>Boulder</City>
+                    <StateProvince>CO</StateProvince>
+                    <PostalCode>80303-0449</PostalCode>
+                    <Country>USA</Country>
+                </Address>
+            </OrganizationAddresses>
+            <OrganizationPhones>
+                <Phone>
+                    <Number>303-492-6199</Number>
+                    <Type>Telephone</Type>
+                </Phone>
+                <Phone>
+                    <Number>303-492-2468</Number>
+                    <Type>Fax</Type>
+                </Phone>
+            </OrganizationPhones>
+            <OrganizationEmails>
+                <Email>nsidc@kryos.colorado.edu</Email>
+            </OrganizationEmails>
+        </Contact>
+        <Contact>
+            <Role>TECHNICAL CONTACT</Role>
+            <ContactPersons>
+                <ContactPerson>
+                    <FirstName>Personnel First Name</FirstName>
+                    <MiddleName>Personnel Middle Name</MiddleName>
+                    <LastName>Personnel Last Name</LastName>
+                    <JobPosition>METADATA AUTHOR</JobPosition>
+                </ContactPerson>
+                <ContactPerson>
+                    <FirstName>Personnel First Name</FirstName>
+                    <MiddleName>Personnel Middle Name</MiddleName>
+                    <LastName>Personnel Last Name</LastName>
+                    <JobPosition>DATA CENTER CONTACT</JobPosition>
+                </ContactPerson>
+                <ContactPerson>
+                    <FirstName>Personnel2 First Name</FirstName>
+                    <MiddleName>Personnel2 Middle Name</MiddleName>
+                    <LastName>Personnel2 Last Name</LastName>
+                    <JobPosition>TECHNICAL CONTACT</JobPosition>
+                </ContactPerson>
+                <ContactPerson>
+                    <FirstName>Personnel2 First Name</FirstName>
+                    <MiddleName>Personnel2 Middle Name</MiddleName>
+                    <LastName>Personnel2 Last Name</LastName>
+                    <JobPosition>DATA CENTER CONTACT</JobPosition>
+                </ContactPerson>
+            </ContactPersons>
+        </Contact>
+    </Contacts>
+    <ScienceKeywords>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>TERRESTRIAL HYDROSPHERE</TopicKeyword>
+            <TermKeyword>SNOW/ICE</TermKeyword>
+            <VariableLevel1Keyword>
+                <Value>SNOW WATER EQUIVALENT</Value>
+                <VariableLevel2Keyword>
+                    <Value>SNOW ICE TEST</Value>
+                    <VariableLevel3Keyword>
+                        <Value>WATER ICE TEST</Value>
+                    </VariableLevel3Keyword>
+                </VariableLevel2Keyword>
+            </VariableLevel1Keyword>
+            <DetailedVariableKeyword>RAIN</DetailedVariableKeyword>
+        </ScienceKeyword>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>CRYOSPHERE</TopicKeyword>
+            <TermKeyword>SNOW/ICE</TermKeyword>
+            <VariableLevel1Keyword>
+                <Value>SNOW WATER EQUIVALENT</Value>
+            </VariableLevel1Keyword>
+            <DetailedVariableKeyword>SLEET</DetailedVariableKeyword>
+        </ScienceKeyword>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>TERRESTRIAL HYDROSPHERE</TopicKeyword>
+            <TermKeyword>SNOW/ICE</TermKeyword>
+            <VariableLevel1Keyword>
+                <Value>SNOW WATER EQUIVALENT</Value>
+            </VariableLevel1Keyword>
+        </ScienceKeyword>
+    </ScienceKeywords>
+    <Platforms>
+        <Platform>
+            <ShortName>Terra</ShortName>
+            <LongName>Earth Observing System, Terra (AM-1)</LongName>
+            <Type>Earth Observation Satellites</Type>
+            <Characteristics>
+                <Characteristic>
+                    <Name>PlatformCaracteristicName</Name>
+                    <Description>Platform Characteristics Description</Description>
+                    <DataType>INT</DataType>
+                    <Unit>Degrees</Unit>
+                    <Value>50</Value>
+                </Characteristic>
+            </Characteristics>
+            <Instruments>
+                <Instrument>
+                    <ShortName>AMSR-E</ShortName>
+                    <LongName>Advanced Microwave Scanning Radiometer-EOS</LongName>
+                    <Technique>Broadband scanning radiometry</Technique>
+                    <NumberOfSensors>1</NumberOfSensors>
+                    <Characteristics>
+                        <Characteristic>
+                            <Name>InstrumentCaracteristicName</Name>
+                            <Description>Instrument Characteristics Description</Description>
+                            <DataType>INT</DataType>
+                            <Unit>Calvin</Unit>
+                            <Value>150</Value>
+                        </Characteristic>
+                    </Characteristics>
+                    <Sensors>
+                        <Sensor>
+                            <ShortName>AMSR-E</ShortName>
+                            <LongName>Advanced Microwave Scanning Radiometer-EOS</LongName>
+                            <Technique>Radiometry</Technique>
+                            <Characteristics>
+                                <Characteristic>
+                                    <Name>ChildInstrumentCaracteristicName</Name>
+                                    <Description>Child Instrument Characteristics Description</Description>
+                                    <DataType>INT</DataType>
+                                    <Unit>Pascals</Unit>
+                                    <Value>250</Value>
+                                </Characteristic>
+                            </Characteristics>
+                        </Sensor>
+                    </Sensors>
+                    <OperationModes>
+                        <OperationMode>Mode1</OperationMode>
+                        <OperationMode>Mode2</OperationMode>
+                    </OperationModes>
+                </Instrument>
+            </Instruments>
+        </Platform>
+        <Platform>
+            <ShortName>LANDSAT-9</ShortName>
+            <LongName>LANDSAT-9</LongName>
+            <Type>Earth Observation Satellites</Type>
+        </Platform>
+        <Platform>
+            <ShortName>LANDSAT-8</ShortName>
+            <LongName>LANDSAT-8</LongName>
+            <Type>Earth Observation Satellites</Type>
+        </Platform>
+        <Platform>
+            <ShortName>ISS</ShortName>
+            <LongName>International Space Station</LongName>
+            <Type>Space Stations/Crewed Spacecraft</Type>
+        </Platform>
+    </Platforms>
+    <AdditionalAttributes>
+        <AdditionalAttribute>
+            <Name>SomeOtherFullElement</Name>
+            <DataType>INT</DataType>
+            <Description>Metadata Description</Description>
+            <Value>2</Value>
+        </AdditionalAttribute>
+        <AdditionalAttribute>
+            <Name>An Additional Attribute Name</Name>
+            <DataType>INT</DataType>
+            <Description>An Additional Attribute Description</Description>
+            <ParameterRangeBegin>1</ParameterRangeBegin>
+            <ParameterRangeEnd>10</ParameterRangeEnd>
+            <Value>5</Value>
+        </AdditionalAttribute>
+        <AdditionalAttribute>
+            <Name>An Additional Attribute Name 2</Name>
+            <DataType>INT</DataType>
+            <Description>An Additional Attribute Description 2</Description>
+            <ParameterRangeBegin>2</ParameterRangeBegin>
+            <ParameterRangeEnd>11</ParameterRangeEnd>
+            <Value>6</Value>
+        </AdditionalAttribute>
+    </AdditionalAttributes>
+    <CollectionAssociations>
+        <CollectionAssociation>
+            <ShortName>C1234453343-ECHO_REST</ShortName>
+            <VersionId>1</VersionId>
+            <CollectionType>SCIENCE ASSOCIATED</CollectionType>
+            <CollectionUse>This is a description of the metadata association</CollectionUse>
+        </CollectionAssociation>
+        <CollectionAssociation>
+            <ShortName>C1234453342-ECHO_REST</ShortName>
+            <VersionId>2</VersionId>
+            <CollectionType>LARGER CITATION WORKS</CollectionType>
+            <CollectionUse>This is a description of the metadata association 2</CollectionUse>
+        </CollectionAssociation>
+    </CollectionAssociations>
+    <Campaigns>
+        <Campaign>
+            <ShortName>AMSRICE06</ShortName>
+            <LongName>Advanced Microwave Scanning Radiometer Sea Ice Product Validation</LongName>
+            <StartDate>2000-01-01T00:00:00.000Z</StartDate>
+            <EndDate>2018-01-01T00:00:00.000Z</EndDate>
+        </Campaign>
+    </Campaigns>
+    <TwoDCoordinateSystems>
+        <TwoDCoordinateSystem>
+            <TwoDCoordinateSystemName>Military Grid Reference System</TwoDCoordinateSystemName>
+            <Coordinate1>
+                <MinimumValue>-100</MinimumValue>
+                <MaximumValue>-50</MaximumValue>
+            </Coordinate1>
+            <Coordinate2>
+                <MinimumValue>50</MinimumValue>
+                <MaximumValue>100</MaximumValue>
+            </Coordinate2>
+        </TwoDCoordinateSystem>
+        <TwoDCoordinateSystem>
+            <TwoDCoordinateSystemName>VIIRS Rotated Sinusoidal Tiling System</TwoDCoordinateSystemName>
+            <Coordinate1>
+                <MinimumValue>-100</MinimumValue>
+                <MaximumValue>-50</MaximumValue>
+            </Coordinate1>
+            <Coordinate2>
+                <MinimumValue>50</MinimumValue>
+                <MaximumValue>100</MaximumValue>
+            </Coordinate2>
+        </TwoDCoordinateSystem>
+    </TwoDCoordinateSystems>
+    <SpatialInfo>
+        <SpatialCoverageType>HORIZONTAL</SpatialCoverageType>
+        <HorizontalCoordinateSystem>
+            <GeodeticModel>
+                <HorizontalDatumName>World Geodetic System of 1984 (WGS84)</HorizontalDatumName>
+                <EllipsoidName>WGS 84</EllipsoidName>
+                <SemiMajorAxis>6378140.0</SemiMajorAxis>
+                <DenominatorOfFlatteningRatio>298.257</DenominatorOfFlatteningRatio>
+            </GeodeticModel>
+            <GeographicCoordinateSystem>
+                <GeographicCoordinateUnits>Meters</GeographicCoordinateUnits>
+                <LatitudeResolution>10</LatitudeResolution>
+                <LongitudeResolution>10</LongitudeResolution>
+            </GeographicCoordinateSystem>
+        </HorizontalCoordinateSystem>
+    </SpatialInfo>
+    <OnlineAccessURLs>
+        <OnlineAccessURL>
+            <URL>http://www.foo.com</URL>
+            <URLDescription>Testing Related url GET DATA translations</URLDescription>
+            <MimeType>text/html</MimeType>
+        </OnlineAccessURL>
+    </OnlineAccessURLs>
+    <OnlineResources>
+        <OnlineResource>
+            <URL>http://wwwghcc.msfc.nasa.gov/AMSR/qa.html</URL>
+            <Description>quality documentation</Description>
+            <Type>PublicationURL : VIEW RELATED INFORMATION</Type>
+        </OnlineResource>
+        <OnlineResource>
+            <URL>http://osdd.org/data/amsre/someopensearchdescription.xml</URL>
+            <Description>An IDN related URL where the OSDD link has been changed.</Description>
+            <Type>GET CAPABILITIES : OpenSearch</Type>
+            <MimeType>application/opensearchdescription+xml</MimeType>
+        </OnlineResource>
+        <OnlineResource>
+            <URL>http://osdd.org/data/somewcs.service.org</URL>
+            <Description>An IDN related URL where the OSDD link has a service URL.</Description>
+            <Type>USE SERVICE API : WEB COVERAGE SERVICE (WCS)</Type>
+            <MimeType>application/x-vnd.iso.19139-2+xml</MimeType>
+        </OnlineResource>
+        <OnlineResource>
+            <URL>http://osdd.org/data/somewcs.service.org</URL>
+            <Description>An IDN related URL where the OSDD link has a service URL.</Description>
+            <Type>USE SERVICE API : WEB COVERAGE SERVICE (WCS)</Type>
+            <MimeType>application/geo+json</MimeType>
+        </OnlineResource>
+    </OnlineResources>
+    <FileNamingConvention>
+        <Convention>YYYY-DD-MMT00:00:00.000Z-shortname</Convention>
+        <Description>The file naming convention that we use.</Description>
+    </FileNamingConvention>
+    <Spatial>
+        <SpatialCoverageType>HORIZONTAL</SpatialCoverageType>
+        <HorizontalSpatialDomain>
+            <ZoneIdentifier>1</ZoneIdentifier>
+            <Geometry>
+                <CoordinateSystem>CARTESIAN</CoordinateSystem>
+                <GPolygon>
+                    <Boundary>
+                        <Point>
+                            <PointLongitude>-10</PointLongitude>
+                            <PointLatitude>10</PointLatitude>
+                        </Point>
+                        <Point>
+                            <PointLongitude>10</PointLongitude>
+                            <PointLatitude>10</PointLatitude>
+                        </Point>
+                        <Point>
+                            <PointLongitude>10</PointLongitude>
+                            <PointLatitude>-10</PointLatitude>
+                        </Point>
+                        <Point>
+                            <PointLongitude>-10</PointLongitude>
+                            <PointLatitude>-10</PointLatitude>
+                        </Point>
+                    </Boundary>
+                    <ExclusiveZone>
+                        <Boundary>
+                            <Point>
+                                <PointLongitude>-5</PointLongitude>
+                                <PointLatitude>-1</PointLatitude>
+                            </Point>
+                            <Point>
+                                <PointLongitude>-1</PointLongitude>
+                                <PointLatitude>-1</PointLatitude>
+                            </Point>
+                            <Point>
+                                <PointLongitude>-1</PointLongitude>
+                                <PointLatitude>-5</PointLatitude>
+                            </Point>
+                            <Point>
+                                <PointLongitude>-5</PointLongitude>
+                                <PointLatitude>-5</PointLatitude>
+                            </Point>
+                        </Boundary>
+                        <Boundary>
+                            <Point>
+                                <PointLongitude>0</PointLongitude>
+                                <PointLatitude>5</PointLatitude>
+                            </Point>
+                            <Point>
+                                <PointLongitude>5</PointLongitude>
+                                <PointLatitude>5</PointLatitude>
+                            </Point>
+                            <Point>
+                                <PointLongitude>5</PointLongitude>
+                                <PointLatitude>0</PointLatitude>
+                            </Point>
+                            <Point>
+                                <PointLongitude>0</PointLongitude>
+                                <PointLatitude>0</PointLatitude>
+                            </Point>
+                        </Boundary>
+                    </ExclusiveZone>
+                </GPolygon>
+            </Geometry>
+        </HorizontalSpatialDomain>
+        <VerticalSpatialDomain>
+            <Type>Maximum Altitude</Type>
+            <Value>100</Value>
+        </VerticalSpatialDomain>
+        <VerticalSpatialDomain>
+            <Type>Minimum Altitude</Type>
+            <Value>1</Value>
+        </VerticalSpatialDomain>
+        <GranuleSpatialRepresentation>NO_SPATIAL</GranuleSpatialRepresentation>
+    </Spatial>
+    <DirectDistributionInformation>
+        <Region>us-east-2</Region>
+        <S3BucketAndObjectPrefixName>TestBucketOrObjectPrefix</S3BucketAndObjectPrefixName>
+        <S3CredentialsAPIEndpoint>https://DAACCredentialEndpoint.org</S3CredentialsAPIEndpoint>
+        <S3CredentialsAPIDocumentationURL>https://DAACCredentialDocumentation.org</S3CredentialsAPIDocumentationURL>
+    </DirectDistributionInformation>
+</Collection>

--- a/scripts/local/run_metadata_correction_echo10_smoke.mjs
+++ b/scripts/local/run_metadata_correction_echo10_smoke.mjs
@@ -6,21 +6,21 @@ import path from 'node:path'
 const rootDir = path.resolve(import.meta.dirname, '../..')
 const fixturePath = path.resolve(
   rootDir,
-  'scripts/local/fixtures/metadata_correction_service.dif10.example.json'
+  'scripts/local/fixtures/metadata_correction_service.echo10.example.json'
 )
 const metadataPayloadPath = path.resolve(
   rootDir,
-  'scripts/local/fixtures/metadata_correction_service.dif10.example.xml'
+  'scripts/local/fixtures/metadata_correction_service.echo10.example.xml'
 )
 const outputPath = path.resolve(
   rootDir,
-  'tmp/metadata_correction_dif10_smoke_output.xml'
+  'tmp/metadata_correction_echo10_smoke_output.xml'
 )
 
 const fixture = JSON.parse(await fs.readFile(fixturePath, 'utf8'))
 const metadataPayload = await fs.readFile(metadataPayloadPath, 'utf8')
 
-const { applyDif10MetadataCorrections } = await import('../../serverless/src/shared/applyDif10MetadataCorrections')
+const { applyEcho10MetadataCorrections } = await import('../../serverless/src/shared/applyEcho10MetadataCorrections')
 const { writeCorrectedMetadataToCmr } = await import('../../serverless/src/shared/writeCorrectedMetadataToCmr')
 
 const request = {
@@ -28,7 +28,7 @@ const request = {
   metadataPayload
 }
 
-const correctionResult = await applyDif10MetadataCorrections(request)
+const correctionResult = await applyEcho10MetadataCorrections(request)
 
 await fs.mkdir(path.dirname(outputPath), { recursive: true })
 await fs.writeFile(outputPath, correctionResult.correctedMetadata || '', 'utf8')

--- a/serverless/src/metadataCorrectionService/handler.js
+++ b/serverless/src/metadataCorrectionService/handler.js
@@ -10,7 +10,7 @@ import { validateCmrCollectionUmm } from '@/shared/validateCmrCollectionUmm'
 import { writeCorrectedMetadataToCmr } from '@/shared/writeCorrectedMetadataToCmr'
 
 // Keep the service allowlist aligned with the delegates that are safe for the current flow.
-const SUPPORTED_NATIVE_FORMATS = ['DIF10', 'UMM']
+const SUPPORTED_NATIVE_FORMATS = ['DIF10', 'ECHO10', 'UMM']
 
 // Normalize request formats so the service can compare them consistently.
 const normalizeNativeFormat = (nativeFormat) => String(nativeFormat).trim().toUpperCase()

--- a/serverless/src/shared/XmlMetadataPathEditor.js
+++ b/serverless/src/shared/XmlMetadataPathEditor.js
@@ -873,8 +873,11 @@ export class XmlMetadataPathEditor {
       if (targetNode) {
         this.setElementText(targetNode, value)
       } else {
-        const difNode = this.selectNodes('/DIF')[0]
-        if (!difNode) {
+        const root = this.document?.documentElement
+        const targetNodeRootName = config.nodeXPath.match(/\/\/(.*?)\//)[1]
+
+        // Check if the root node name and the target node's root name are different
+        if (!root || (root.nodeName !== targetNodeRootName)) {
           return false
         }
 
@@ -882,7 +885,7 @@ export class XmlMetadataPathEditor {
         // the literal element name so we can create `<Product_Level_Id>` (or similar) explicitly.
         const newNode = this.document.createElement(config.tagName)
         this.setElementText(newNode, value)
-        difNode.appendChild(newNode)
+        root.appendChild(newNode)
       }
 
       return true

--- a/serverless/src/shared/XmlMetadataPathEditor.js
+++ b/serverless/src/shared/XmlMetadataPathEditor.js
@@ -726,7 +726,12 @@ export class XmlMetadataPathEditor {
     }
 
     if (action === 'delete') {
+      const { parentNode } = targetNode
       this.removeNode(targetNode)
+
+      if (config.removeEmptyParent) {
+        this.removeNodeIfNoElementChildren(parentNode)
+      }
 
       if (typeof config.afterDelete === 'function') {
         config.afterDelete(this, targetNode)

--- a/serverless/src/shared/XmlMetadataPathEditor.js
+++ b/serverless/src/shared/XmlMetadataPathEditor.js
@@ -3,6 +3,7 @@ import xpath from 'xpath'
 
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8"?>'
 const ELEMENT_NODE = 1
+const SIMPLE_ABSOLUTE_FIELD_PATH = /^\/\/[A-Za-z_][\w.-]*(\/[A-Za-z_][\w.-]*)*$/
 
 /**
  * Normalize optional text inputs so object comparisons and XML writes behave consistently.
@@ -12,6 +13,26 @@ const ELEMENT_NODE = 1
  * // 'SPOT-4'
  */
 const trimString = (value) => ((typeof value === 'string') ? value.trim() : '')
+
+/**
+ * Trims a keyword-style object down to the specific keys being compared so find/replace matching
+ * stays consistent even when callers provide extra fields or untrimmed values.
+ *
+ * @param {Record<string, any>|null|undefined} valueObject Candidate keyword-style object.
+ * @param {string[]} valueKeys Ordered keys that matter for the current comparison.
+ * @returns {Record<string, string>} Trimmed object containing only the requested keys.
+ *
+ * @example
+ * normalizeValueObject({ Type: ' GET DATA ', Subtype: ' GIOVANNI ' }, ['Type', 'Subtype'])
+ * // { Type: 'GET DATA', Subtype: 'GIOVANNI' }
+ */
+const normalizeValueObject = (valueObject, valueKeys) => valueKeys.reduce(
+  (normalizedObject, valueKey) => ({
+    ...normalizedObject,
+    [valueKey]: trimString(valueObject?.[valueKey])
+  }),
+  {}
+)
 
 /**
  * True when any field in a keyword-style object contains meaningful text.
@@ -233,6 +254,52 @@ export class XmlMetadataPathEditor {
   }
 
   /**
+   * True when a field path should be resolved from the document root instead of the matched node.
+   *
+   * @param {string} fieldPath Candidate field path.
+   * @returns {boolean} Whether the path is an absolute document path.
+   */
+  isAbsoluteFieldPath(fieldPath) {
+    return typeof fieldPath === 'string' && fieldPath.startsWith('//')
+  }
+
+  /**
+   * Resolves an absolute `//Root/Child/...` field path and optionally creates missing descendants.
+   *
+   * Creation support is intentionally limited to simple tag-only paths so we do not overreach into
+   * full XPath semantics. That keeps absolute writes useful for root/sibling fields like
+   * `//DIF/ProcessingCenter` without changing the editor into a generic XPath mutation engine.
+   *
+   * @param {string} fieldPath Absolute `//...` field path.
+   * @param {Object} [options={}] Absolute-path resolution options.
+   * @param {boolean} [options.createIfMissing=false] Create missing descendants for simple paths.
+   * @returns {Element|null} Matching or newly created absolute target element.
+   */
+  resolveAbsoluteFieldElement(fieldPath, { createIfMissing = false } = {}) {
+    const matchedNode = this.selectNodes(fieldPath)[0] || null
+    if (matchedNode || !createIfMissing || !SIMPLE_ABSOLUTE_FIELD_PATH.test(fieldPath)) {
+      return matchedNode
+    }
+
+    const root = this.document?.documentElement
+    if (!root) {
+      return null
+    }
+
+    const [rootTagName, ...childPathParts] = fieldPath.replace(/^\/\//, '').split('/')
+    const rootNodeNames = [root.nodeName, root.localName].filter(Boolean)
+
+    if (!rootNodeNames.includes(rootTagName)) {
+      return null
+    }
+
+    return childPathParts.reduce(
+      (currentNode, tagName) => this.ensureDirectChildElement(currentNode, tagName),
+      root
+    )
+  }
+
+  /**
    * Reads trimmed text content from an element.
    *
    * @param {Node|null|undefined} node Candidate text node owner.
@@ -383,6 +450,16 @@ export class XmlMetadataPathEditor {
    * // undefined
    */
   setNestedText(node, fieldPath, value) {
+    if (this.isAbsoluteFieldPath(fieldPath)) {
+      const target = this.resolveAbsoluteFieldElement(fieldPath, { createIfMissing: true })
+
+      if (target) {
+        this.setElementText(target, value)
+      }
+
+      return
+    }
+
     const target = this.ensureNestedElement(node, fieldPath)
     this.setElementText(target, value)
   }
@@ -398,6 +475,12 @@ export class XmlMetadataPathEditor {
    * // undefined
    */
   removeNestedElement(node, fieldPath) {
+    if (this.isAbsoluteFieldPath(fieldPath)) {
+      this.removeNode(this.resolveAbsoluteFieldElement(fieldPath))
+
+      return
+    }
+
     const pathParts = fieldPath.split('/')
     const childTagName = pathParts.pop()
     const parentNode = pathParts.length > 0 ? this.getNestedElement(node, pathParts.join('/')) : node
@@ -441,8 +524,12 @@ export class XmlMetadataPathEditor {
   /**
    * Resolves the replacement value for a configured XML field from correction input.
    *
+   * Source configs can read directly from the correction payload (`param`), from the normalized
+   * replacement keyword object (`value`), or compute a composed value dynamically (`computed`).
+   *
    * @param {Object} correction Correction descriptor being applied.
    * @param {Object} [sourceConfig={}] Source selection rules for the replacement value.
+   * @param {Element|null} [targetNode=null] Matched XML node being updated.
    * @returns {string} Replacement value to write into the XML field.
    *
    * @example
@@ -458,7 +545,7 @@ export class XmlMetadataPathEditor {
    * )
    * // 'Systeme Observation de la Terre-4 Updated'
    */
-  getReplacementValue(correction, sourceConfig = {}) {
+  getReplacementValue(correction, sourceConfig = {}, targetNode = null) {
     if (sourceConfig.type === 'param') {
       return trimString(correction?.[sourceConfig.key])
     }
@@ -467,11 +554,24 @@ export class XmlMetadataPathEditor {
       return trimString(correction?.newKeywordObject?.[sourceConfig.key])
     }
 
+    if (sourceConfig.type === 'computed' && typeof sourceConfig.getValue === 'function') {
+      return trimString(sourceConfig.getValue({
+        correction,
+        editor: this,
+        targetNode,
+        sourceConfig
+      }))
+    }
+
     return ''
   }
 
   /**
    * Locates the XML node that corresponds to the current keyword value being corrected.
+   *
+   * Standard scheme configs compare ordered XML field paths against `oldKeywordObject`, while
+   * custom find callbacks can synthesize comparison objects for combined-format fields like
+   * `URLContentType : Type : Subtype`.
    *
    * @param {Object} correction Correction descriptor being applied.
    * @param {Object} config Scheme-specific node find configuration.
@@ -502,16 +602,38 @@ export class XmlMetadataPathEditor {
       const valueKeys = Array.isArray(config.find.valueKeys) && config.find.valueKeys.length > 0
         ? config.find.valueKeys
         : config.find.fieldPaths
-      const findValueObject = valueKeys.reduce((keywordObject, valueKey) => ({
-        ...keywordObject,
-        [valueKey]: trimString(correction?.oldKeywordObject?.[valueKey])
-      }), {})
+      const findValueObject = normalizeValueObject(
+        typeof config.find.getExpectedValueObject === 'function'
+          ? config.find.getExpectedValueObject({
+            correction,
+            editor: this,
+            valueKeys,
+            fieldPaths: config.find.fieldPaths,
+            findConfig: config.find
+          })
+          : valueKeys.reduce((keywordObject, valueKey) => ({
+            ...keywordObject,
+            [valueKey]: correction?.oldKeywordObject?.[valueKey]
+          }), {}),
+        valueKeys
+      )
 
       if (hasAnyObjectValue(findValueObject)) {
         const matchedNode = nodes.find((node) => {
-          const nodeValueObject = this.getNodeValueObject(
-            node,
-            config.find.fieldPaths,
+          const nodeValueObject = normalizeValueObject(
+            typeof config.find.getNodeValueObject === 'function'
+              ? config.find.getNodeValueObject({
+                node,
+                editor: this,
+                valueKeys,
+                fieldPaths: config.find.fieldPaths,
+                findConfig: config.find
+              })
+              : this.getNodeValueObject(
+                node,
+                config.find.fieldPaths,
+                valueKeys
+              ),
             valueKeys
           )
 
@@ -587,7 +709,7 @@ export class XmlMetadataPathEditor {
 
     if (action === 'replace') {
       config.replace.forEach(({ fieldPath, source }) => {
-        const value = this.getReplacementValue(correction, source)
+        const value = this.getReplacementValue(correction, source, targetNode)
 
         if (value.length > 0) {
           this.setNestedText(targetNode, fieldPath, value)

--- a/serverless/src/shared/XmlMetadataPathEditor.js
+++ b/serverless/src/shared/XmlMetadataPathEditor.js
@@ -325,7 +325,35 @@ export class XmlMetadataPathEditor {
    * // 'SPOT-4'
    */
   getNestedText(node, fieldPath) {
+    if (this.isAbsoluteFieldPath(fieldPath)) {
+      return this.getElementText(this.resolveAbsoluteFieldElement(fieldPath))
+    }
+
     return this.getElementText(this.getNestedElement(node, fieldPath))
+  }
+
+  /**
+   * Evaluates an optional replace-field condition against the current correction and target node.
+   *
+   * Conditions are only used to decide whether one configured field write should run; they do not
+   * affect node matching. This is useful for ECHO10-style sibling updates where a matched contact
+   * may own `ProcessingCenter` but not `ArchiveCenter`.
+   *
+   * @param {Object} correction Correction descriptor being applied.
+   * @param {Function|undefined} condition Optional condition callback.
+   * @param {Element|null} [targetNode=null] Matched XML node being updated.
+   * @returns {boolean} Whether the field write should be applied.
+   */
+  shouldApplyFieldCondition(correction, condition, targetNode) {
+    if (typeof condition !== 'function') {
+      return true
+    }
+
+    return Boolean(condition({
+      correction,
+      editor: this,
+      targetNode: targetNode ?? null
+    }))
   }
 
   /**
@@ -708,7 +736,11 @@ export class XmlMetadataPathEditor {
     }
 
     if (action === 'replace') {
-      config.replace.forEach(({ fieldPath, source }) => {
+      config.replace.forEach(({ fieldPath, source, condition }) => {
+        if (!this.shouldApplyFieldCondition(correction, condition, targetNode)) {
+          return
+        }
+
         const value = this.getReplacementValue(correction, source, targetNode)
 
         if (value.length > 0) {

--- a/serverless/src/shared/__mocks__/echo10.xml
+++ b/serverless/src/shared/__mocks__/echo10.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Collection>
+    <ShortName>PRESERVATION_TEST</ShortName>
+    <VersionId>001</VersionId>
+    <ScienceKeywords>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>SOLID EARTH</TopicKeyword>
+            <TermKeyword>TECTONICS</TermKeyword>
+            <VariableLevel1Keyword>
+                <Value>EARTHQUAKES</Value>
+                <VariableLevel2Keyword>
+                    <Value>SEISMIC PROFILE</Value>
+                </VariableLevel2Keyword>
+            </VariableLevel1Keyword>
+            <DetailedVariableKeyword>RAIN</DetailedVariableKeyword>
+        </ScienceKeyword>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>OCEANS</TopicKeyword>
+            <TermKeyword>MARINE SEDIMENTS</TermKeyword>
+            <VariableLevel1Keyword>
+                <Value>SEDIMENTARY STRUCTURES</Value>
+            </VariableLevel1Keyword>
+        </ScienceKeyword>
+    </ScienceKeywords>
+    <Platforms>
+        <Platform>
+            <ShortName>SPOT-4</ShortName>
+            <LongName>Systeme Observation de la Terre-4</LongName>
+            <Type>Earth Observation Satellites</Type>
+            <Instruments>
+                <Instrument>
+                    <ShortName>SEISMIC REFLECTION PROFILERS</ShortName>
+                </Instrument>
+                <Instrument>
+                    <ShortName>GEOPHONES</ShortName>
+                    <LongName>Geophone Array</LongName>
+                </Instrument>
+            </Instruments>
+        </Platform>
+        <Platform>
+            <ShortName>NASA S-3B VIKING</ShortName>
+            <Type>Aircraft</Type>
+            <Instruments>
+                <Instrument>
+                    <ShortName>TSX-1</ShortName>
+                    <LongName>Synthetic Aperture Radar</LongName>
+                </Instrument>
+            </Instruments>
+        </Platform>
+    </Platforms>
+    <Campaigns>
+        <Campaign>
+            <ShortName>ALIENS</ShortName>
+            <LongName>Aliens in Antarctica</LongName>
+        </Campaign>
+        <Campaign>
+            <ShortName>ICEBRIDGE</ShortName>
+            <LongName>IceBridge Mission</LongName>
+        </Campaign>
+    </Campaigns>
+    <Contacts>
+        <Contact>
+            <ContactPersons>
+                <Role>INVESTIGATOR</Role>
+                <ContactPerson>
+                    <FirstName>RAY</FirstName>
+                    <LastName>DIBBLE</LastName>
+                    <JobPosition>INVESTIGATOR</JobPosition>
+                </ContactPerson>
+            </ContactPersons>
+        </Contact>
+        <Contact>
+            <Role>ARCHIVER</Role>
+            <OrganizationName>NZ/NZAI/ANZ</OrganizationName>
+            <ContactPersons>
+                <ContactPerson>
+                    <FirstName>SHULAMIT</FirstName>
+                    <LastName>GORDON</LastName>
+                    <JobPosition>DATA CENTER CONTACT</JobPosition>
+                </ContactPerson>
+            </ContactPersons>
+        </Contact>
+    </Contacts>
+    <DataFormat>netCDF-4</DataFormat>
+    <OnlineResources>
+        <OnlineResource>
+            <URL>https://example.org/opensearch</URL>
+            <Description>OpenSearch endpoint</Description>
+            <Type>DistributionURL : VIEW RELATED INFORMATION : OpenSearch</Type>
+        </OnlineResource>
+    </OnlineResources>
+    <InsertTime>2009-03-03T00:00:00.000Z</InsertTime>
+    <LastUpdate>2017-04-20T00:00:00.000Z</LastUpdate>
+    <AdditionalAttributes>
+        <AdditionalAttribute>
+            <Name>metadata.keyword_version</Name>
+            <DataType>FLOAT</DataType>
+            <Description>Not provided</Description>
+            <Value>8.1</Value>
+        </AdditionalAttribute>
+    </AdditionalAttributes>
+    <ProcessingLevelId>NA</ProcessingLevelId>
+</Collection>

--- a/serverless/src/shared/__tests__/XmlMetadataPathEditor.test.js
+++ b/serverless/src/shared/__tests__/XmlMetadataPathEditor.test.js
@@ -1016,10 +1016,11 @@ describe('when updating XML nodes through XmlMetadataPathEditor', () => {
       expect(deleteWithoutParentPruneEditor.selectNodes('//DIF/Data_Resolution')).toHaveLength(1)
     })
 
-    test('should support scalar delete paths and return false when scalar updates are unsupported or cannot create a root field', () => {
+    test.only('should support scalar delete paths and return false when scalar updates are unsupported or cannot create a root field', () => {
       const deleteEditor = new XmlMetadataPathEditor('<DIF><Product_Level_Id>1A</Product_Level_Id></DIF>')
       const defaultReplaceEditor = new XmlMetadataPathEditor('<DIF><Product_Level_Id>1A</Product_Level_Id></DIF>')
       const missingDeleteEditor = new XmlMetadataPathEditor('<DIF><Entry_ID/></DIF>')
+      const missingReplaceEditor = new XmlMetadataPathEditor('<DIF></DIF>')
       const missingRootEditor = new XmlMetadataPathEditor('<Collection/>')
 
       expect(missingDeleteEditor.updateScalarNode({
@@ -1066,6 +1067,26 @@ describe('when updating XML nodes through XmlMetadataPathEditor', () => {
         nodeXPath: '//DIF/Product_Level_Id',
         tagName: 'Product_Level_Id'
       })).toBe(false)
+
+      expect(missingRootEditor.updateScalarNode({
+        action: 'replace',
+        newKeywordObject: {
+          Value: '1A'
+        }
+      }, {
+        nodeXPath: '//Collection/ProductLevelId',
+        tagName: 'ProductLevelId'
+      })).toBe(true)
+
+      expect(missingReplaceEditor.updateScalarNode({
+        action: 'replace',
+        newKeywordObject: {
+          Value: '1A'
+        }
+      }, {
+        nodeXPath: '//DIF/Product_Level_Id',
+        tagName: 'Product_Level_Id'
+      })).toBe(true)
 
       expect(deleteEditor.updateScalarNode({
         action: 'noop',

--- a/serverless/src/shared/__tests__/XmlMetadataPathEditor.test.js
+++ b/serverless/src/shared/__tests__/XmlMetadataPathEditor.test.js
@@ -141,47 +141,6 @@ describe('when using XmlMetadataPathEditor DOM helpers', () => {
     )).toBe('SNOW/ICE')
   })
 
-  describe('for the ECHO10 use cases called out in review', () => {
-    test('use case #1 should support absolute document paths for sibling updates', () => {
-      const editor = new XmlMetadataPathEditor('<DIF><Node/></DIF>')
-      const node = editor.selectNodes('//DIF/Node')[0]
-
-      editor.setNestedText(node, '//DIF/ProcessingCenter', 'NSIDC')
-      expect(editor.serialize()).toContain('<ProcessingCenter>NSIDC</ProcessingCenter>')
-
-      editor.removeNestedElement(node, '//DIF/ProcessingCenter')
-      expect(editor.selectNodes('//DIF/ProcessingCenter')).toEqual([])
-
-      editor.setNestedText(node, '//Collection/ProcessingCenter', 'NSIDC')
-      expect(editor.serialize()).not.toContain('<Collection>')
-    })
-
-    test('use case #3 should derive replacement values for composed field writes', () => {
-      const editor = new XmlMetadataPathEditor('<DIF><Node/></DIF>')
-      const targetNode = editor.selectNodes('//DIF/Node')[0]
-
-      expect(editor.getReplacementValue(
-        {
-          newKeywordObject: {
-            URLContentType: 'DistributionURL',
-            Type: 'GET DATA',
-            Subtype: 'EARTHDATA SEARCH'
-          }
-        },
-        {
-          type: 'computed',
-          getValue: ({ correction, editor: currentEditor, targetNode: currentTargetNode }) => [
-            correction.newKeywordObject.URLContentType,
-            correction.newKeywordObject.Type,
-            correction.newKeywordObject.Subtype,
-            currentEditor.getElementText(currentTargetNode)
-          ].filter(Boolean).join(' : ')
-        },
-        targetNode
-      )).toBe('DistributionURL : GET DATA : EARTHDATA SEARCH')
-    })
-  })
-
   describe('outside cases', () => {
     test('should return no child elements for an undefined node', () => {
       const editor = new XmlMetadataPathEditor('<DIF><Node><A>one</A></Node></DIF>')
@@ -482,7 +441,21 @@ describe('when updating XML nodes through XmlMetadataPathEditor', () => {
   })
 
   describe('for the ECHO10 use cases called out in review', () => {
-    test('use case #1 should support absolute replace field paths outside the matched block node', () => {
+    test('use case #1 should support absolute document paths for sibling updates', () => {
+      const editor = new XmlMetadataPathEditor('<DIF><Node/></DIF>')
+      const node = editor.selectNodes('//DIF/Node')[0]
+
+      editor.setNestedText(node, '//DIF/ProcessingCenter', 'NSIDC')
+      expect(editor.serialize()).toContain('<ProcessingCenter>NSIDC</ProcessingCenter>')
+
+      editor.removeNestedElement(node, '//DIF/ProcessingCenter')
+      expect(editor.selectNodes('//DIF/ProcessingCenter')).toEqual([])
+
+      editor.setNestedText(node, '//Collection/ProcessingCenter', 'NSIDC')
+      expect(editor.serialize()).not.toContain('<Collection>')
+    })
+
+    test('use case #2 should update only the owned top-level center field when role and current value match', () => {
       const editor = new XmlMetadataPathEditor(`
         <DIF>
           <Organization>
@@ -492,16 +465,18 @@ describe('when updating XML nodes through XmlMetadataPathEditor', () => {
             </Organization_Name>
           </Organization>
           <ProcessingCenter>KPDC</ProcessingCenter>
-          <ArchiveCenter>KPDC</ArchiveCenter>
+          <ArchiveCenter>ARCHIVE-OWNER</ArchiveCenter>
         </DIF>
       `)
 
       const isUpdated = editor.updateBlockNode({
         action: 'replace',
         oldKeywordObject: {
+          BucketLevel0: 'PROCESSOR',
           ShortName: 'KPDC'
         },
         newKeywordObject: {
+          BucketLevel0: 'PROCESSOR',
           ShortName: 'NSIDC'
         },
         newLongName: 'National Snow and Ice Data Center'
@@ -528,6 +503,11 @@ describe('when updating XML nodes through XmlMetadataPathEditor', () => {
           },
           {
             fieldPath: '//DIF/ProcessingCenter',
+            condition: ({ correction, editor: currentEditor }) => (
+              correction.oldKeywordObject?.BucketLevel0 === 'PROCESSOR'
+              && currentEditor.getNestedText(null, '//DIF/ProcessingCenter')
+              === correction.oldKeywordObject?.ShortName
+            ),
             source: {
               type: 'value',
               key: 'ShortName'
@@ -535,6 +515,11 @@ describe('when updating XML nodes through XmlMetadataPathEditor', () => {
           },
           {
             fieldPath: '//DIF/ArchiveCenter',
+            condition: ({ correction, editor: currentEditor }) => (
+              correction.oldKeywordObject?.BucketLevel0 === 'ARCHIVER'
+              && currentEditor.getNestedText(null, '//DIF/ArchiveCenter')
+              === correction.oldKeywordObject?.ShortName
+            ),
             source: {
               type: 'value',
               key: 'ShortName'
@@ -547,7 +532,92 @@ describe('when updating XML nodes through XmlMetadataPathEditor', () => {
       expect(editor.serialize()).toContain('<Short_Name>NSIDC</Short_Name>')
       expect(editor.serialize()).toContain('<Long_Name>National Snow and Ice Data Center</Long_Name>')
       expect(editor.serialize()).toContain('<ProcessingCenter>NSIDC</ProcessingCenter>')
-      expect(editor.serialize()).toContain('<ArchiveCenter>NSIDC</ArchiveCenter>')
+      expect(editor.serialize()).toContain('<ArchiveCenter>ARCHIVE-OWNER</ArchiveCenter>')
+    })
+
+    test('use case #2 should leave top-level center fields alone when the current value no longer matches the old short name', () => {
+      const editor = new XmlMetadataPathEditor(`
+        <DIF>
+          <Organization>
+            <Organization_Name>
+              <Short_Name>KPDC</Short_Name>
+              <Long_Name>Korea Polar Data Center, KOPRI</Long_Name>
+            </Organization_Name>
+          </Organization>
+          <ProcessingCenter>SOMEONE-ELSE</ProcessingCenter>
+          <ArchiveCenter>KPDC</ArchiveCenter>
+        </DIF>
+      `)
+
+      const isUpdated = editor.updateBlockNode({
+        action: 'replace',
+        oldKeywordObject: {
+          BucketLevel0: 'PROCESSOR',
+          ShortName: 'KPDC'
+        },
+        newKeywordObject: {
+          BucketLevel0: 'PROCESSOR',
+          ShortName: 'NSIDC'
+        },
+        newLongName: 'National Snow and Ice Data Center'
+      }, {
+        nodeXPath: '//DIF/Organization',
+        find: {
+          fieldPaths: ['Organization_Name/Short_Name'],
+          valueKeys: ['ShortName']
+        },
+        replace: [
+          {
+            fieldPath: 'Organization_Name/Short_Name',
+            source: {
+              type: 'value',
+              key: 'ShortName'
+            }
+          },
+          {
+            fieldPath: '//DIF/ProcessingCenter',
+            condition: ({ correction, editor: currentEditor }) => (
+              correction.oldKeywordObject?.BucketLevel0 === 'PROCESSOR'
+              && currentEditor.getNestedText(null, '//DIF/ProcessingCenter')
+              === correction.oldKeywordObject?.ShortName
+            ),
+            source: {
+              type: 'value',
+              key: 'ShortName'
+            }
+          }
+        ]
+      })
+
+      expect(isUpdated).toBe(true)
+      expect(editor.serialize()).toContain('<Short_Name>NSIDC</Short_Name>')
+      expect(editor.serialize()).toContain('<ProcessingCenter>SOMEONE-ELSE</ProcessingCenter>')
+      expect(editor.serialize()).toContain('<ArchiveCenter>KPDC</ArchiveCenter>')
+    })
+
+    test('use case #3 should derive replacement values for composed field writes', () => {
+      const editor = new XmlMetadataPathEditor('<DIF><Node/></DIF>')
+      const targetNode = editor.selectNodes('//DIF/Node')[0]
+
+      expect(editor.getReplacementValue(
+        {
+          newKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: 'EARTHDATA SEARCH'
+          }
+        },
+        {
+          type: 'computed',
+          getValue: ({ correction, editor: currentEditor, targetNode: currentTargetNode }) => [
+            correction.newKeywordObject.URLContentType,
+            correction.newKeywordObject.Type,
+            correction.newKeywordObject.Subtype,
+            currentEditor.getElementText(currentTargetNode)
+          ].filter(Boolean).join(' : ')
+        },
+        targetNode
+      )).toBe('DistributionURL : GET DATA : EARTHDATA SEARCH')
     })
 
     test('use case #3 should support computed find and replacement values for composed block fields', () => {
@@ -623,6 +693,36 @@ describe('when updating XML nodes through XmlMetadataPathEditor', () => {
   })
 
   describe('outside cases', () => {
+    test('should default field conditions to true and honor condition callbacks when provided', () => {
+      const editor = new XmlMetadataPathEditor('<DIF><Node/></DIF>')
+      const targetNode = editor.selectNodes('//DIF/Node')[0]
+      let seenTargetNodeName = null
+      let sawNullTargetNode = false
+
+      expect(editor.shouldApplyFieldCondition({}, undefined, targetNode)).toBe(true)
+
+      expect(editor.shouldApplyFieldCondition({
+        oldKeywordObject: {
+          ShortName: 'KPDC'
+        }
+      }, ({ correction, editor: currentEditor, targetNode: currentTargetNode }) => {
+        seenTargetNodeName = currentTargetNode.nodeName
+
+        return correction.oldKeywordObject?.ShortName === 'KPDC'
+          && currentEditor === editor
+      }, targetNode)).toBe(true)
+
+      expect(seenTargetNodeName).toBe('Node')
+      expect(editor.shouldApplyFieldCondition({}, ({ targetNode: currentTargetNode }) => {
+        sawNullTargetNode = currentTargetNode === null
+
+        return true
+      })).toBe(true)
+
+      expect(sawNullTargetNode).toBe(true)
+      expect(editor.shouldApplyFieldCondition({}, () => false, targetNode)).toBe(false)
+    })
+
     test('should invoke afterDelete callbacks for block nodes', () => {
       let callbackNodeName = null
       const editor = new XmlMetadataPathEditor('<DIF><Block><Short_Name>ONE</Short_Name></Block></DIF>')

--- a/serverless/src/shared/__tests__/XmlMetadataPathEditor.test.js
+++ b/serverless/src/shared/__tests__/XmlMetadataPathEditor.test.js
@@ -80,37 +80,11 @@ describe('when using XmlMetadataPathEditor object helpers', () => {
 })
 
 describe('when using XmlMetadataPathEditor DOM helpers', () => {
-  test('should return no child elements for an undefined node', () => {
-    const editor = new XmlMetadataPathEditor('<DIF><Node><A>one</A></Node></DIF>')
-
-    expect(editor.getElementChildren(undefined)).toEqual([])
-  })
-
   test('should build ordered node field values with default options', () => {
     const editor = new XmlMetadataPathEditor('<DIF><Node><A>one</A><B></B></Node></DIF>')
     const node = editor.selectNodes('//DIF/Node')[0]
 
     expect(editor.getNodeFieldValues(node, ['A', 'B'])).toEqual(['one', ''])
-  })
-
-  test('should remove direct nested elements and ignore detached nodes', () => {
-    const editor = new XmlMetadataPathEditor('<DIF><Node><Child>1</Child></Node></DIF>')
-    const node = editor.selectNodes('//DIF/Node')[0]
-    const detached = editor.document.createElement('Detached')
-
-    editor.removeNestedElement(node, 'Child')
-    editor.removeNode(detached)
-
-    expect(editor.selectNodes('//DIF/Child')).toEqual([])
-  })
-
-  test('should ignore nested removals when the intermediate parent path does not exist', () => {
-    const editor = new XmlMetadataPathEditor('<DIF><Node><Child>1</Child></Node></DIF>')
-    const node = editor.selectNodes('//DIF/Node')[0]
-
-    editor.removeNestedElement(node, 'Missing/Child')
-
-    expect(editor.getElementText(editor.selectNodes('//DIF/Node/Child')[0])).toBe('1')
   })
 
   test('should derive replacement values from params and keyword objects', () => {
@@ -167,51 +141,199 @@ describe('when using XmlMetadataPathEditor DOM helpers', () => {
     )).toBe('SNOW/ICE')
   })
 
-  test('should fall back to fieldPaths and empty scalar keyword text when optional values are absent', () => {
-    const editor = new XmlMetadataPathEditor(`
-      <DIF>
-        <Node>
-          <A>one</A>
-          <B>two</B>
-        </Node>
-      </DIF>
-    `)
+  describe('for the ECHO10 use cases called out in review', () => {
+    test('use case #1 should support absolute document paths for sibling updates', () => {
+      const editor = new XmlMetadataPathEditor('<DIF><Node/></DIF>')
+      const node = editor.selectNodes('//DIF/Node')[0]
 
-    expect(editor.resolveNodeByFind({
-      oldKeywordObject: {}
-    }, {
-      nodeXPath: '//DIF/Node',
-      find: {
-        fieldPaths: ['A', 'B']
-      }
-    })).toBeNull()
+      editor.setNestedText(node, '//DIF/ProcessingCenter', 'NSIDC')
+      expect(editor.serialize()).toContain('<ProcessingCenter>NSIDC</ProcessingCenter>')
 
-    expect(editor.updateScalarNode({
-      action: 'replace'
-    }, {
-      nodeXPath: '//DIF/Missing',
-      tagName: 'Missing'
-    })).toBe(false)
+      editor.removeNestedElement(node, '//DIF/ProcessingCenter')
+      expect(editor.selectNodes('//DIF/ProcessingCenter')).toEqual([])
+
+      editor.setNestedText(node, '//Collection/ProcessingCenter', 'NSIDC')
+      expect(editor.serialize()).not.toContain('<Collection>')
+    })
+
+    test('use case #3 should derive replacement values for composed field writes', () => {
+      const editor = new XmlMetadataPathEditor('<DIF><Node/></DIF>')
+      const targetNode = editor.selectNodes('//DIF/Node')[0]
+
+      expect(editor.getReplacementValue(
+        {
+          newKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: 'EARTHDATA SEARCH'
+          }
+        },
+        {
+          type: 'computed',
+          getValue: ({ correction, editor: currentEditor, targetNode: currentTargetNode }) => [
+            correction.newKeywordObject.URLContentType,
+            correction.newKeywordObject.Type,
+            correction.newKeywordObject.Subtype,
+            currentEditor.getElementText(currentTargetNode)
+          ].filter(Boolean).join(' : ')
+        },
+        targetNode
+      )).toBe('DistributionURL : GET DATA : EARTHDATA SEARCH')
+    })
   })
 
-  test('should fall back to the first non-empty object value for scalar replacements', () => {
-    const editor = new XmlMetadataPathEditor(`
-      <DIF>
-        <Product_Level_Id>Legacy</Product_Level_Id>
-      </DIF>
-    `)
+  describe('outside cases', () => {
+    test('should return no child elements for an undefined node', () => {
+      const editor = new XmlMetadataPathEditor('<DIF><Node><A>one</A></Node></DIF>')
 
-    expect(editor.updateScalarNode({
-      action: 'replace',
-      newKeywordObject: {
-        Alias: 'Level 1A'
-      }
-    }, {
-      nodeXPath: '//DIF/Product_Level_Id',
-      tagName: 'Product_Level_Id'
-    })).toBe(true)
+      expect(editor.getElementChildren(undefined)).toEqual([])
+    })
 
-    expect(editor.getElementText(editor.selectNodes('//DIF/Product_Level_Id')[0])).toBe('Level 1A')
+    test('should remove direct nested elements and ignore detached nodes', () => {
+      const editor = new XmlMetadataPathEditor('<DIF><Node><Child>1</Child></Node></DIF>')
+      const node = editor.selectNodes('//DIF/Node')[0]
+      const detached = editor.document.createElement('Detached')
+
+      editor.removeNestedElement(node, 'Child')
+      editor.removeNode(detached)
+
+      expect(editor.selectNodes('//DIF/Child')).toEqual([])
+    })
+
+    test('should ignore nested removals when the intermediate parent path does not exist', () => {
+      const editor = new XmlMetadataPathEditor('<DIF><Node><Child>1</Child></Node></DIF>')
+      const node = editor.selectNodes('//DIF/Node')[0]
+
+      expect(editor.getNestedElement(node, 'Missing/Child')).toBe(null)
+
+      editor.removeNestedElement(node, 'Missing/Child')
+
+      expect(editor.getElementText(editor.selectNodes('//DIF/Node/Child')[0])).toBe('1')
+    })
+
+    test('should return null for absolute-path creation when the document root is missing or mismatched', () => {
+      const editor = new XmlMetadataPathEditor('<DIF/>')
+      const originalSelectNodes = editor.selectNodes
+
+      editor.selectNodes = () => []
+      editor.document = { documentElement: null }
+      expect(editor.resolveAbsoluteFieldElement('//DIF/ProcessingCenter', { createIfMissing: true })).toBe(null)
+
+      editor.document = new XmlMetadataPathEditor('<DIF/>').document
+      expect(editor.resolveAbsoluteFieldElement('//Collection/ProcessingCenter', { createIfMissing: true })).toBe(null)
+
+      editor.selectNodes = originalSelectNodes
+    })
+
+    test('should remove empty nodes and return null when block matching has no candidates or no meaningful node values', () => {
+      const editor = new XmlMetadataPathEditor(`
+        <DIF>
+          <EmptyBlock/>
+          <NonEmptyBlock>
+            <Child>1</Child>
+          </NonEmptyBlock>
+          <Node>
+            <Type></Type>
+          </Node>
+        </DIF>
+      `)
+
+      const emptyBlockNode = editor.selectNodes('//DIF/EmptyBlock')[0]
+      const nonEmptyBlockNode = editor.selectNodes('//DIF/NonEmptyBlock')[0]
+      editor.removeNodeIfNoElementChildren(emptyBlockNode)
+      editor.removeNodeIfNoElementChildren(nonEmptyBlockNode)
+      expect(editor.selectNodes('//DIF/EmptyBlock')).toEqual([])
+      expect(editor.selectNodes('//DIF/NonEmptyBlock')).toHaveLength(1)
+
+      expect(editor.resolveNodeByFind({
+        oldKeywordObject: {
+          Type: 'GET DATA'
+        }
+      }, {
+        nodeXPath: '//DIF/Missing',
+        find: {
+          fieldPaths: ['Type'],
+          valueKeys: ['Type']
+        }
+      })).toBe(null)
+
+      expect(editor.resolveNodeByFind({
+        oldKeywordObject: {
+          Type: 'GET DATA'
+        }
+      }, {
+        nodeXPath: '//DIF/Node',
+        find: {
+          fieldPaths: ['Type'],
+          valueKeys: ['Type']
+        }
+      })).toBe(null)
+    })
+
+    test('should return null for scalar-style matching when no text node matches the old keyword value', () => {
+      const editor = new XmlMetadataPathEditor('<DIF><Leaf>OLD</Leaf></DIF>')
+
+      expect(editor.resolveNodeByFind({
+        oldKeywordObject: {
+          Value: 'MISSING'
+        }
+      }, {
+        nodeXPath: '//DIF/Leaf'
+      })).toBe(null)
+
+      expect(editor.resolveNodeByFind({
+        oldKeywordObject: {}
+      }, {
+        nodeXPath: '//DIF/Leaf'
+      })).toBe(null)
+    })
+
+    test('should fall back to fieldPaths and empty scalar keyword text when optional values are absent', () => {
+      const editor = new XmlMetadataPathEditor(`
+        <DIF>
+          <Node>
+            <A>one</A>
+            <B>two</B>
+          </Node>
+        </DIF>
+      `)
+
+      expect(editor.resolveNodeByFind({
+        oldKeywordObject: {}
+      }, {
+        nodeXPath: '//DIF/Node',
+        find: {
+          fieldPaths: ['A', 'B']
+        }
+      })).toBeNull()
+
+      expect(editor.updateScalarNode({
+        action: 'replace'
+      }, {
+        nodeXPath: '//DIF/Missing',
+        tagName: 'Missing'
+      })).toBe(false)
+    })
+
+    test('should fall back to the first non-empty object value for scalar replacements', () => {
+      const editor = new XmlMetadataPathEditor(`
+        <DIF>
+          <Product_Level_Id>Legacy</Product_Level_Id>
+        </DIF>
+      `)
+
+      expect(editor.updateScalarNode({
+        action: 'replace',
+        newKeywordObject: {
+          Alias: 'Level 1A'
+        }
+      }, {
+        nodeXPath: '//DIF/Product_Level_Id',
+        tagName: 'Product_Level_Id'
+      })).toBe(true)
+
+      expect(editor.getElementText(editor.selectNodes('//DIF/Product_Level_Id')[0])).toBe('Level 1A')
+    })
   })
 })
 
@@ -359,99 +481,501 @@ describe('when updating XML nodes through XmlMetadataPathEditor', () => {
     expect(editor.serialize()).toContain('<Term>SNOW/ICE - chris v5</Term>')
   })
 
-  test('should invoke afterDelete callbacks for block nodes', () => {
-    let callbackNodeName = null
-    const editor = new XmlMetadataPathEditor('<DIF><Block><Short_Name>ONE</Short_Name></Block></DIF>')
+  describe('for the ECHO10 use cases called out in review', () => {
+    test('use case #1 should support absolute replace field paths outside the matched block node', () => {
+      const editor = new XmlMetadataPathEditor(`
+        <DIF>
+          <Organization>
+            <Organization_Name>
+              <Short_Name>KPDC</Short_Name>
+              <Long_Name>Korea Polar Data Center, KOPRI</Long_Name>
+            </Organization_Name>
+          </Organization>
+          <ProcessingCenter>KPDC</ProcessingCenter>
+          <ArchiveCenter>KPDC</ArchiveCenter>
+        </DIF>
+      `)
 
-    const isUpdated = editor.updateBlockNode({
-      action: 'delete',
-      oldKeywordObject: {
-        ShortName: 'ONE'
-      }
-    }, {
-      nodeXPath: '//DIF/Block',
-      find: {
-        fieldPaths: ['Short_Name'],
-        valueKeys: ['ShortName']
-      },
-      afterDelete: (_, targetNode) => {
-        callbackNodeName = targetNode.nodeName
-      }
-    })
-
-    expect(isUpdated).toBe(true)
-    expect(callbackNodeName).toBe('Block')
-    expect(editor.selectNodes('//DIF/Block')).toEqual([])
-  })
-
-  test('should invoke afterReplace callbacks for block nodes', () => {
-    let callbackNodeName = null
-    const editor = new XmlMetadataPathEditor('<DIF><Block><Short_Name>ONE</Short_Name></Block></DIF>')
-
-    const isUpdated = editor.updateBlockNode({
-      action: 'replace',
-      oldKeywordObject: {
-        ShortName: 'ONE'
-      },
-      newKeywordObject: {
-        ShortName: 'TWO'
-      }
-    }, {
-      nodeXPath: '//DIF/Block',
-      find: {
-        fieldPaths: ['Short_Name'],
-        valueKeys: ['ShortName']
-      },
-      replace: [
-        {
-          fieldPath: 'Short_Name',
-          source: {
-            type: 'value',
-            key: 'ShortName'
+      const isUpdated = editor.updateBlockNode({
+        action: 'replace',
+        oldKeywordObject: {
+          ShortName: 'KPDC'
+        },
+        newKeywordObject: {
+          ShortName: 'NSIDC'
+        },
+        newLongName: 'National Snow and Ice Data Center'
+      }, {
+        nodeXPath: '//DIF/Organization',
+        find: {
+          fieldPaths: ['Organization_Name/Short_Name'],
+          valueKeys: ['ShortName']
+        },
+        replace: [
+          {
+            fieldPath: 'Organization_Name/Short_Name',
+            source: {
+              type: 'value',
+              key: 'ShortName'
+            }
+          },
+          {
+            fieldPath: 'Organization_Name/Long_Name',
+            source: {
+              type: 'param',
+              key: 'newLongName'
+            }
+          },
+          {
+            fieldPath: '//DIF/ProcessingCenter',
+            source: {
+              type: 'value',
+              key: 'ShortName'
+            }
+          },
+          {
+            fieldPath: '//DIF/ArchiveCenter',
+            source: {
+              type: 'value',
+              key: 'ShortName'
+            }
           }
+        ]
+      })
+
+      expect(isUpdated).toBe(true)
+      expect(editor.serialize()).toContain('<Short_Name>NSIDC</Short_Name>')
+      expect(editor.serialize()).toContain('<Long_Name>National Snow and Ice Data Center</Long_Name>')
+      expect(editor.serialize()).toContain('<ProcessingCenter>NSIDC</ProcessingCenter>')
+      expect(editor.serialize()).toContain('<ArchiveCenter>NSIDC</ArchiveCenter>')
+    })
+
+    test('use case #3 should support computed find and replacement values for composed block fields', () => {
+      let seenCurrentCombinedValue = null
+      const editor = new XmlMetadataPathEditor(`
+        <Collection>
+          <OnlineResource>
+            <Type>DistributionURL : GET DATA : GIOVANNI</Type>
+          </OnlineResource>
+          <OnlineResource>
+            <Type>CollectionURL : VIEW PROJECT HOME PAGE</Type>
+          </OnlineResource>
+        </Collection>
+      `)
+
+      const isUpdated = editor.updateBlockNode({
+        action: 'replace',
+        oldKeywordObject: {
+          URLContentType: 'DistributionURL',
+          Type: 'GET DATA',
+          Subtype: 'GIOVANNI'
+        },
+        newKeywordObject: {
+          URLContentType: 'DistributionURL',
+          Type: 'GET DATA',
+          Subtype: 'EARTHDATA SEARCH'
         }
-      ],
-      afterReplace: (_, targetNode) => {
-        callbackNodeName = targetNode.nodeName
-      }
-    })
+      }, {
+        nodeXPath: '//Collection/OnlineResource',
+        find: {
+          fieldPaths: ['Type'],
+          valueKeys: ['CombinedType'],
+          getExpectedValueObject: ({ correction }) => ({
+            CombinedType: [
+              correction.oldKeywordObject?.URLContentType,
+              correction.oldKeywordObject?.Type,
+              correction.oldKeywordObject?.Subtype
+            ].filter(Boolean).join(' : ')
+          }),
+          getNodeValueObject: ({ node, editor: currentEditor }) => ({
+            CombinedType: currentEditor.getNestedText(node, 'Type')
+          })
+        },
+        replace: [
+          {
+            fieldPath: 'Type',
+            source: {
+              type: 'computed',
+              getValue: ({ correction, editor: currentEditor, targetNode }) => {
+                seenCurrentCombinedValue = currentEditor.getNestedText(targetNode, 'Type')
 
-    expect(isUpdated).toBe(true)
-    expect(callbackNodeName).toBe('Block')
-    expect(editor.serialize()).toContain('<Short_Name>TWO</Short_Name>')
+                return [
+                  correction.newKeywordObject?.URLContentType,
+                  correction.newKeywordObject?.Type,
+                  correction.newKeywordObject?.Subtype
+                ].filter(Boolean).join(' : ')
+              }
+            }
+          }
+        ]
+      })
+
+      expect(isUpdated).toBe(true)
+      expect(seenCurrentCombinedValue).toBe('DistributionURL : GET DATA : GIOVANNI')
+      expect(editor.serialize()).toContain(
+        '<Type>DistributionURL : GET DATA : EARTHDATA SEARCH</Type>'
+      )
+
+      expect(editor.serialize()).toContain(
+        '<Type>CollectionURL : VIEW PROJECT HOME PAGE</Type>'
+      )
+    })
   })
 
-  test('should replace leaf node text with an empty string when the new keyword object has no scalar value', () => {
-    const editor = new XmlMetadataPathEditor('<DIF><Leaf>OLD</Leaf></DIF>')
+  describe('outside cases', () => {
+    test('should invoke afterDelete callbacks for block nodes', () => {
+      let callbackNodeName = null
+      const editor = new XmlMetadataPathEditor('<DIF><Block><Short_Name>ONE</Short_Name></Block></DIF>')
 
-    const isUpdated = editor.updateLeafNode({
-      action: 'replace',
-      oldKeywordObject: {
-        Value: 'OLD'
-      },
-      newKeywordObject: {}
-    }, {
-      nodeXPath: '//DIF/Leaf'
+      const isUpdated = editor.updateBlockNode({
+        action: 'delete',
+        oldKeywordObject: {
+          ShortName: 'ONE'
+        }
+      }, {
+        nodeXPath: '//DIF/Block',
+        find: {
+          fieldPaths: ['Short_Name'],
+          valueKeys: ['ShortName']
+        },
+        afterDelete: (_, targetNode) => {
+          callbackNodeName = targetNode.nodeName
+        }
+      })
+
+      expect(isUpdated).toBe(true)
+      expect(callbackNodeName).toBe('Block')
+      expect(editor.selectNodes('//DIF/Block')).toEqual([])
     })
 
-    expect(isUpdated).toBe(true)
-    expect(editor.getElementText(editor.selectNodes('//DIF/Leaf')[0])).toBe('')
-  })
+    test('should invoke afterReplace callbacks for block nodes', () => {
+      let callbackNodeName = null
+      const editor = new XmlMetadataPathEditor('<DIF><Block><Short_Name>ONE</Short_Name></Block></DIF>')
 
-  test('should use tagName to create a missing scalar node when the DIF root exists', () => {
-    const editor = new XmlMetadataPathEditor('<DIF><Entry_ID/></DIF>')
+      const isUpdated = editor.updateBlockNode({
+        action: 'replace',
+        oldKeywordObject: {
+          ShortName: 'ONE'
+        },
+        newKeywordObject: {
+          ShortName: 'TWO'
+        }
+      }, {
+        nodeXPath: '//DIF/Block',
+        find: {
+          fieldPaths: ['Short_Name'],
+          valueKeys: ['ShortName']
+        },
+        replace: [
+          {
+            fieldPath: 'Short_Name',
+            source: {
+              type: 'value',
+              key: 'ShortName'
+            }
+          }
+        ],
+        afterReplace: (_, targetNode) => {
+          callbackNodeName = targetNode.nodeName
+        }
+      })
 
-    const isUpdated = editor.updateScalarNode({
-      action: 'replace',
-      newKeywordObject: {
-        Value: '1A'
-      }
-    }, {
-      nodeXPath: '//DIF/Product_Level_Id',
-      tagName: 'Product_Level_Id'
+      expect(isUpdated).toBe(true)
+      expect(callbackNodeName).toBe('Block')
+      expect(editor.serialize()).toContain('<Short_Name>TWO</Short_Name>')
     })
 
-    expect(isUpdated).toBe(true)
-    expect(editor.serialize()).toContain('<Product_Level_Id>1A</Product_Level_Id>')
+    test('should use tagName to create a missing scalar node when the DIF root exists', () => {
+      const editor = new XmlMetadataPathEditor('<DIF><Entry_ID/></DIF>')
+
+      const isUpdated = editor.updateScalarNode({
+        action: 'replace',
+        newKeywordObject: {
+          Value: '1A'
+        }
+      }, {
+        nodeXPath: '//DIF/Product_Level_Id',
+        tagName: 'Product_Level_Id'
+      })
+
+      expect(isUpdated).toBe(true)
+      expect(editor.serialize()).toContain('<Product_Level_Id>1A</Product_Level_Id>')
+    })
+
+    test('should default block updates to replace and allow deletes without callbacks', () => {
+      const replaceEditor = new XmlMetadataPathEditor('<DIF><Block><Short_Name>ONE</Short_Name></Block></DIF>')
+      const deleteEditor = new XmlMetadataPathEditor('<DIF><Block><Short_Name>ONE</Short_Name></Block></DIF>')
+
+      expect(replaceEditor.updateBlockNode({
+        oldKeywordObject: {
+          ShortName: 'ONE'
+        },
+        newKeywordObject: {
+          ShortName: 'TWO'
+        }
+      }, {
+        nodeXPath: '//DIF/Block',
+        find: {
+          fieldPaths: ['Short_Name'],
+          valueKeys: ['ShortName']
+        },
+        replace: [
+          {
+            fieldPath: 'Short_Name',
+            source: {
+              type: 'value',
+              key: 'ShortName'
+            }
+          }
+        ]
+      })).toBe(true)
+
+      expect(replaceEditor.serialize()).toContain('<Short_Name>TWO</Short_Name>')
+
+      expect(deleteEditor.updateBlockNode({
+        action: 'delete',
+        oldKeywordObject: {
+          ShortName: 'ONE'
+        }
+      }, {
+        nodeXPath: '//DIF/Block',
+        find: {
+          fieldPaths: ['Short_Name'],
+          valueKeys: ['ShortName']
+        }
+      })).toBe(true)
+
+      expect(deleteEditor.selectNodes('//DIF/Block')).toEqual([])
+    })
+
+    test('should return false when block updates do not match a node or use an unsupported action', () => {
+      const editor = new XmlMetadataPathEditor('<DIF><Block><Short_Name>ONE</Short_Name></Block></DIF>')
+
+      expect(editor.updateBlockNode({
+        action: 'replace',
+        oldKeywordObject: {
+          ShortName: 'MISSING'
+        },
+        newKeywordObject: {
+          ShortName: 'TWO'
+        }
+      }, {
+        nodeXPath: '//DIF/Block',
+        find: {
+          fieldPaths: ['Short_Name'],
+          valueKeys: ['ShortName']
+        },
+        replace: [
+          {
+            fieldPath: 'Short_Name',
+            source: {
+              type: 'value',
+              key: 'ShortName'
+            }
+          }
+        ]
+      })).toBe(false)
+
+      expect(editor.updateBlockNode({
+        action: 'noop',
+        oldKeywordObject: {
+          ShortName: 'ONE'
+        },
+        newKeywordObject: {
+          ShortName: 'TWO'
+        }
+      }, {
+        nodeXPath: '//DIF/Block',
+        find: {
+          fieldPaths: ['Short_Name'],
+          valueKeys: ['ShortName']
+        },
+        replace: [
+          {
+            fieldPath: 'Short_Name',
+            source: {
+              type: 'value',
+              key: 'ShortName'
+            }
+          }
+        ]
+      })).toBe(false)
+    })
+
+    test('should remove block nodes when replace leaves them empty and pruning is enabled', () => {
+      const editor = new XmlMetadataPathEditor('<DIF><Block><Short_Name>ONE</Short_Name></Block></DIF>')
+
+      const isUpdated = editor.updateBlockNode({
+        action: 'replace',
+        oldKeywordObject: {
+          ShortName: 'ONE'
+        },
+        newKeywordObject: {}
+      }, {
+        nodeXPath: '//DIF/Block',
+        find: {
+          fieldPaths: ['Short_Name'],
+          valueKeys: ['ShortName']
+        },
+        replace: [
+          {
+            fieldPath: 'Short_Name',
+            source: {
+              type: 'value',
+              key: 'ShortName'
+            }
+          }
+        ],
+        removeNodeIfEmptyAfterReplace: true
+      })
+
+      expect(isUpdated).toBe(true)
+      expect(editor.selectNodes('//DIF/Block')).toEqual([])
+    })
+
+    test('should replace leaf node text with an empty string when the new keyword object has no scalar value', () => {
+      const editor = new XmlMetadataPathEditor('<DIF><Leaf>OLD</Leaf></DIF>')
+
+      const isUpdated = editor.updateLeafNode({
+        oldKeywordObject: {
+          Value: 'OLD'
+        },
+        newKeywordObject: {}
+      }, {
+        nodeXPath: '//DIF/Leaf'
+      })
+
+      expect(isUpdated).toBe(true)
+      expect(editor.getElementText(editor.selectNodes('//DIF/Leaf')[0])).toBe('')
+    })
+
+    test('should delete leaf nodes and prune empty parents when configured, and return false for unmatched or unsupported actions', () => {
+      const editor = new XmlMetadataPathEditor(`
+        <DIF>
+          <Data_Resolution>
+            <Horizontal_Resolution_Range>1</Horizontal_Resolution_Range>
+          </Data_Resolution>
+        </DIF>
+      `)
+
+      expect(editor.updateLeafNode({
+        action: 'replace',
+        oldKeywordObject: {
+          Value: 'MISSING'
+        },
+        newKeywordObject: {
+          Value: 'NEXT'
+        }
+      }, {
+        nodeXPath: '//DIF/MissingLeaf'
+      })).toBe(false)
+
+      const isDeleted = editor.updateLeafNode({
+        action: 'delete',
+        oldKeywordObject: {
+          Value: '1'
+        }
+      }, {
+        nodeXPath: '//DIF/Data_Resolution/Horizontal_Resolution_Range',
+        removeEmptyParent: true
+      })
+
+      expect(isDeleted).toBe(true)
+      expect(editor.selectNodes('//DIF/Data_Resolution')).toEqual([])
+
+      const unsupportedActionEditor = new XmlMetadataPathEditor('<DIF><Leaf>OLD</Leaf></DIF>')
+      expect(unsupportedActionEditor.updateLeafNode({
+        action: 'noop',
+        oldKeywordObject: {
+          Value: 'OLD'
+        },
+        newKeywordObject: {
+          Value: 'OTHER'
+        }
+      }, {
+        nodeXPath: '//DIF/Leaf'
+      })).toBe(false)
+
+      const deleteWithoutParentPruneEditor = new XmlMetadataPathEditor(`
+        <DIF>
+          <Data_Resolution>
+            <Horizontal_Resolution_Range>1</Horizontal_Resolution_Range>
+          </Data_Resolution>
+        </DIF>
+      `)
+
+      expect(deleteWithoutParentPruneEditor.updateLeafNode({
+        action: 'delete',
+        oldKeywordObject: {
+          Value: '1'
+        }
+      }, {
+        nodeXPath: '//DIF/Data_Resolution/Horizontal_Resolution_Range'
+      })).toBe(true)
+
+      expect(deleteWithoutParentPruneEditor.selectNodes('//DIF/Data_Resolution')).toHaveLength(1)
+    })
+
+    test('should support scalar delete paths and return false when scalar updates are unsupported or cannot create a root field', () => {
+      const deleteEditor = new XmlMetadataPathEditor('<DIF><Product_Level_Id>1A</Product_Level_Id></DIF>')
+      const defaultReplaceEditor = new XmlMetadataPathEditor('<DIF><Product_Level_Id>1A</Product_Level_Id></DIF>')
+      const missingDeleteEditor = new XmlMetadataPathEditor('<DIF><Entry_ID/></DIF>')
+      const missingRootEditor = new XmlMetadataPathEditor('<Collection/>')
+
+      expect(missingDeleteEditor.updateScalarNode({
+        action: 'delete',
+        oldKeywordObject: {
+          Value: '1A'
+        }
+      }, {
+        nodeXPath: '//DIF/Product_Level_Id',
+        tagName: 'Product_Level_Id'
+      })).toBe(false)
+
+      expect(deleteEditor.updateScalarNode({
+        action: 'delete',
+        oldKeywordObject: {
+          Value: '1A'
+        }
+      }, {
+        nodeXPath: '//DIF/Product_Level_Id',
+        tagName: 'Product_Level_Id'
+      })).toBe(true)
+
+      expect(deleteEditor.selectNodes('//DIF/Product_Level_Id')).toEqual([])
+
+      expect(defaultReplaceEditor.updateScalarNode({
+        newKeywordObject: {
+          Value: '1B'
+        }
+      }, {
+        nodeXPath: '//DIF/Product_Level_Id',
+        tagName: 'Product_Level_Id'
+      })).toBe(true)
+
+      expect(defaultReplaceEditor.getElementText(
+        defaultReplaceEditor.selectNodes('//DIF/Product_Level_Id')[0]
+      )).toBe('1B')
+
+      expect(missingRootEditor.updateScalarNode({
+        action: 'replace',
+        newKeywordObject: {
+          Value: '1A'
+        }
+      }, {
+        nodeXPath: '//DIF/Product_Level_Id',
+        tagName: 'Product_Level_Id'
+      })).toBe(false)
+
+      expect(deleteEditor.updateScalarNode({
+        action: 'noop',
+        newKeywordObject: {
+          Value: '1B'
+        }
+      }, {
+        nodeXPath: '//DIF/Product_Level_Id',
+        tagName: 'Product_Level_Id'
+      })).toBe(false)
+    })
   })
 })

--- a/serverless/src/shared/__tests__/XmlMetadataPathEditor.test.js
+++ b/serverless/src/shared/__tests__/XmlMetadataPathEditor.test.js
@@ -1016,7 +1016,7 @@ describe('when updating XML nodes through XmlMetadataPathEditor', () => {
       expect(deleteWithoutParentPruneEditor.selectNodes('//DIF/Data_Resolution')).toHaveLength(1)
     })
 
-    test.only('should support scalar delete paths and return false when scalar updates are unsupported or cannot create a root field', () => {
+    test('should support scalar delete paths and return false when scalar updates are unsupported or cannot create a root field', () => {
       const deleteEditor = new XmlMetadataPathEditor('<DIF><Product_Level_Id>1A</Product_Level_Id></DIF>')
       const defaultReplaceEditor = new XmlMetadataPathEditor('<DIF><Product_Level_Id>1A</Product_Level_Id></DIF>')
       const missingDeleteEditor = new XmlMetadataPathEditor('<DIF><Entry_ID/></DIF>')

--- a/serverless/src/shared/__tests__/applyDif10MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyDif10MetadataCorrections.test.js
@@ -4305,39 +4305,6 @@ describe('when applying related URL content type DIF10 corrections', () => {
     expect(result.correctionCount).toBe(0)
   })
 
-  test('should remove the URL_Content_Type container entirely if all its fields are deleted', async () => {
-    const result = await applyDif10MetadataCorrections({
-      metadataPayload: mockDif10WithRelatedURLs,
-      corrections: [{
-        scheme: 'rucontenttype',
-        action: 'replace',
-        oldKeywordObject: {
-          URLContentType: 'DistributionURL',
-          Type: 'GET DATA',
-          Subtype: ''
-        },
-        newKeywordObject: {
-          URLContentType: '',
-          Type: '',
-          Subtype: ''
-        } // Last 2 segments: '' and ''
-      }]
-    })
-
-    expect(result.correctionCount).toBe(1)
-
-    // 1. Verify the specific value is gone
-    expect(result.correctedMetadata).not.toContain('GET DATA')
-
-    // 2. Verify the structure has dropped URL_Content_Type for index 0 completely
-    expect(result.correctedMetadata).toMatch(
-      /<Related_URL>\s*<URL>https:\/\/example\.com\/data<\/URL>\s*<\/Related_URL>/
-    )
-
-    // 3. Verify we didn't accidentally delete URL_Content_Type from other blocks
-    expect(result.correctedMetadata).toContain('<Type>USE SERVICE API</Type>')
-  })
-
   test('should return false when oldKeywordObject does not match any current elements', async () => {
     const result = await applyDif10MetadataCorrections({
       collectionConceptId: 'C1',

--- a/serverless/src/shared/__tests__/applyEcho10MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyEcho10MetadataCorrections.test.js
@@ -1,0 +1,3681 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+import { DOMParser } from '@xmldom/xmldom'
+import {
+  describe,
+  expect,
+  test
+} from 'vitest'
+import xpath from 'xpath'
+
+import {
+  applyEcho10MetadataCorrections as applyEcho10MetadataCorrectionsRaw
+} from '../applyEcho10MetadataCorrections'
+
+const applyEcho10MetadataCorrections = (params = {}) => applyEcho10MetadataCorrectionsRaw(params)
+
+const mockEcho10 = `
+<Collection>
+    <ShortName>Test_Collection</ShortName>
+    <VersionId>001</VersionId>
+    <ScienceKeywords>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>ATMOSPHERE</TopicKeyword>
+            <TermKeyword>AEROSOLS</TermKeyword>
+        </ScienceKeyword>
+    </ScienceKeywords>
+    <Platforms>
+        <Platform>
+            <Type>In Situ Land-based Platforms</Type>
+            <ShortName>GROUND STATIONS</ShortName>
+        </Platform>        
+    </Platforms>
+</Collection>`
+
+const mockEcho10ForMetadataPreservation = `<Collection>
+    <ShortName>PRESERVATION_TEST</ShortName>
+    <VersionId>001</VersionId>
+    <ScienceKeywords>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>ATMOSPHERE</TopicKeyword>
+            <TermKeyword>AEROSOLS</TermKeyword>
+        </ScienceKeyword>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>SOLID EARTH</TopicKeyword>
+            <TermKeyword>TECTONICS</TermKeyword>
+            <VariableLevel1Keyword>
+                <Value>EARTHQUAKES</Value>
+                <VariableLevel2Keyword>
+                    <Value>SEISMIC PROFILE</Value>
+                </VariableLevel2Keyword>
+            </VariableLevel1Keyword>
+            <DetailedVariableKeyword>RAIN</DetailedVariableKeyword>
+        </ScienceKeyword>
+    </ScienceKeywords>
+    <Platforms>
+        <Platform>
+            <ShortName>SPOT-4</ShortName>
+            <LongName>Systeme Observation de la Terre-4</LongName>
+            <Type>Earth Observation Satellites</Type>
+            <Instruments>
+                <Instrument>
+                    <ShortName>SEISMIC REFLECTION PROFILERS</ShortName>
+                </Instrument>
+                <Instrument>
+                    <ShortName>GEOPHONES</ShortName>
+                    <LongName>Geophone Array</LongName>
+                </Instrument>
+            </Instruments>
+        </Platform>
+        <Platform>
+            <ShortName>NASA S-3B VIKING</ShortName>
+            <Type>Aircraft</Type>
+            <Instruments>
+                <Instrument>
+                    <ShortName>TSX-1</ShortName>
+                    <LongName>Synthetic Aperture Radar</LongName>
+                </Instrument>
+            </Instruments>
+        </Platform>
+    </Platforms>
+    <Campaigns>
+        <Campaign>
+            <ShortName>ALIENS</ShortName>
+            <LongName>Aliens in Antarctica</LongName>
+        </Campaign>
+        <Campaign>
+            <ShortName>ICEBRIDGE</ShortName>
+            <LongName>IceBridge Mission</LongName>
+        </Campaign>
+    </Campaigns>
+    <Contacts>
+        <Contact>
+            <ContactPersons>
+                <Role>INVESTIGATOR</Role>
+                <ContactPerson>
+                    <FirstName>RAY</FirstName>
+                    <LastName>DIBBLE</LastName>
+                    <JobPosition>INVESTIGATOR</JobPosition>
+                </ContactPerson>
+            </ContactPersons>
+        </Contact>
+        <Contact>
+            <Role>ARCHIVER</Role>
+            <OrganizationName>NZ/NZAI/ANZ</OrganizationName>
+            <ContactPersons>
+                <ContactPerson>
+                    <FirstName>SHULAMIT</FirstName>
+                    <LastName>GORDON</LastName>
+                    <JobPosition>DATA CENTER CONTACT</JobPosition>
+                </ContactPerson>
+            </ContactPersons>
+        </Contact>
+    </Contacts>
+    <OnlineResources>
+        <OnlineResource>
+            <URL>https://example.org/opensearch</URL>
+            <Description>OpenSearch endpoint</Description>
+            <Type>DistributionURL : VIEW RELATED INFORMATION : OpenSearch</Type>
+        </OnlineResource>
+    </OnlineResources>
+    <InsertTime>2009-03-03T00:00:00.000Z</InsertTime>
+    <LastUpdate>2017-04-20T00:00:00.000Z</LastUpdate>
+    <AdditionalAttributes>
+        <AdditionalAttribute>
+            <Name>metadata.keyword_version</Name>
+            <DataType>FLOAT</DataType>
+            <Description>Not provided</Description>
+            <Value>8.1</Value>
+        </AdditionalAttribute>
+    </AdditionalAttributes>
+    <DataFormat>netCDF-4</DataFormat>
+    <ProcessingLevelId>NA</ProcessingLevelId>
+</Collection>`
+
+const parseXml = (xml) => new DOMParser().parseFromString(xml, 'text/xml')
+const normalizeXmlText = (value) => String(value || '').replace(/\s+/g, ' ').trim()
+const selectText = (document, expression) => {
+  const node = xpath.select1(expression, document)
+
+  return normalizeXmlText(node?.textContent)
+}
+
+const selectTexts = (document, expression) => xpath.select(expression, document)
+  .map((node) => normalizeXmlText(node.textContent))
+
+describe('when applying ECHO10 metadata corrections', () => {
+  test('should return early if metadataPayload is missing', async () => {
+    const result = await applyEcho10MetadataCorrections({ metadataPayload: null })
+    expect(result.correctionCount).toBe(0)
+    expect(result.stubbed).toBe(true)
+  })
+
+  test('should apply multiple corrections from different schemes sequentially', async () => {
+    const corrections = [
+      {
+        scheme: 'sciencekeywords',
+        action: 'replace',
+        oldKeywordObject: {
+          Category: 'EARTH SCIENCE',
+          Topic: 'ATMOSPHERE',
+          Term: 'AEROSOLS',
+          VariableLevel1: '',
+          VariableLevel2: '',
+          VariableLevel3: '',
+          DetailedVariable: ''
+        },
+        newKeywordObject: {
+          Category: 'EARTH SCIENCE',
+          Topic: 'OCEANS',
+          Term: 'MARINE SEDIMENTS',
+          VariableLevel1: '',
+          VariableLevel2: '',
+          VariableLevel3: '',
+          DetailedVariable: ''
+        }
+      },
+      {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: {
+          Category: '',
+          Class: '',
+          Type: 'In Situ Land-based Platforms',
+          ShortName: 'GROUND STATIONS'
+        },
+        newKeywordObject: {
+          Category: '',
+          Class: 'Space-based Platforms',
+          Type: 'Earth Observation Satellites',
+          ShortName: 'C-130'
+        }
+      }
+    ]
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: mockEcho10,
+      corrections
+    })
+
+    expect(result.correctionCount).toBe(2)
+    expect(result.correctionsApplied).toHaveLength(2)
+
+    // Check XML Content
+    expect(result.correctedMetadata).toContain('<TopicKeyword>OCEANS</TopicKeyword>')
+    expect(result.correctedMetadata).toContain('<ShortName>C-130</ShortName>')
+    expect(result.correctedMetadata).not.toContain('<TopicKeyword>ATMOSPHERE</TopicKeyword>')
+  })
+
+  test('should handle unknown schemes gracefully by ignoring them', async () => {
+    const corrections = [
+      {
+        scheme: 'invalid_scheme',
+        action: 'replace',
+        newKeywordObject: {
+          Value: 'Should Not Apply'
+        }
+      }
+    ]
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: mockEcho10,
+      corrections
+    })
+
+    expect(result.correctionCount).toBe(0)
+    expect(result.correctionsApplied).toHaveLength(0)
+    // Metadata should remain unchanged (save for standard formatting)
+    expect(result.correctedMetadata).toContain('<TermKeyword>AEROSOLS</TermKeyword>')
+  })
+
+  test('should ignore corrections when the scheme is missing', async () => {
+    const corrections = [
+      {
+        action: 'replace',
+        newKeywordObject: {
+          Value: 'Should Not Apply'
+        }
+      }
+    ]
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: mockEcho10,
+      corrections
+    })
+
+    expect(result.correctionCount).toBe(0)
+    expect(result.correctionsApplied).toHaveLength(0)
+    expect(result.correctedMetadata).toContain('<TermKeyword>AEROSOLS</TermKeyword>')
+  })
+
+  test('should verify XML declaration and formatting', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: mockEcho10,
+      corrections: []
+    })
+
+    expect(result.correctedMetadata).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+    expect(result.correctedMetadata).toContain('<Collection>')
+  })
+})
+
+describe('when correcting a ECHO10 record', () => {
+  test('should return a corrected ECHO10', async () => {
+    const mockECHO10Xml = readFileSync(
+      join(__dirname, '../__mocks__/echo10.xml'),
+      'utf-8'
+    )
+
+    const corrections = [
+      {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: {
+          Category: '',
+          Class: 'Space-based Platforms',
+          Type: 'Earth Observation Satellites',
+          ShortName: 'SPOT-4'
+        },
+        newKeywordObject: {
+          Category: '',
+          Class: 'Space-based Platforms',
+          Type: 'Earth Observation Satellites',
+          ShortName: 'SPOT-4-UPDATED'
+        },
+        newLongName: 'Systeme Observation de la Terre-4 Updated'
+      },
+      {
+        scheme: 'instruments',
+        action: 'replace',
+        oldKeywordObject: {
+          Category: 'Imaging Spectrometers/Radiometers',
+          Class: '',
+          Subclass: '',
+          ShortName: 'GEOPHONES'
+        },
+        newKeywordObject: {
+          Category: 'Imaging Spectrometers/Radiometers',
+          Class: '',
+          Subclass: '',
+          ShortName: 'GEOPHONES-UPDATED'
+        },
+        newLongName: 'Updated Geophone Array'
+      },
+      {
+        scheme: 'projects',
+        oldKeywordObject: {
+          Category: 'A - C',
+          ShortName: 'ALIENS'
+        },
+        newKeywordObject: {
+          Category: 'A - C',
+          ShortName: 'ALIENS-UPDATED'
+        },
+        newLongName: 'Aliens in Antarctica Updated'
+      },
+      {
+        scheme: 'providers',
+        action: 'replace',
+        oldKeywordObject: {
+          BucketLevel0: 'ARCHIVER',
+          BucketLevel1: '',
+          BucketLevel2: '',
+          BucketLevel3: '',
+          ShortName: 'NZ/NZAI/ANZ'
+        },
+        newKeywordObject: {
+          BucketLevel0: 'ARCHIVER',
+          BucketLevel1: '',
+          BucketLevel2: '',
+          BucketLevel3: '',
+          ShortName: 'NZ/NZAI/ANZ-UPDATED'
+        },
+        newLongName: 'Antarctica New Zealand Updated'
+      },
+      {
+        scheme: 'rucontenttype',
+        action: 'replace',
+        oldKeywordObject: {
+          URLContentType: 'DistributionURL',
+          Type: 'VIEW RELATED INFORMATION',
+          Subtype: 'OpenSearch'
+        },
+        newKeywordObject: {
+          URLContentType: 'DistributionURL',
+          Type: 'VIEW RELATED INFORMATION',
+          Subtype: 'OGC WMS'
+        }
+      },
+      {
+        scheme: 'sciencekeywords',
+        action: 'replace',
+        oldKeywordObject: {
+          Category: 'EARTH SCIENCE',
+          Topic: 'OCEANS',
+          Term: 'MARINE SEDIMENTS',
+          VariableLevel1: 'SEDIMENTARY STRUCTURES',
+          VariableLevel2: '',
+          VariableLevel3: '',
+          DetailedVariable: ''
+        },
+        newKeywordObject: {
+          Category: 'EARTH SCIENCE',
+          Topic: 'OCEANS',
+          Term: 'MARINE SEDIMENTS',
+          VariableLevel1: 'SEDIMENT TRANSPORT',
+          VariableLevel2: '',
+          VariableLevel3: '',
+          DetailedVariable: ''
+        }
+      },
+      {
+        scheme: 'dataformat',
+        action: 'replace',
+        oldKeywordObject: {
+          Value: 'netCDF-4'
+        },
+        newKeywordObject: {
+          Value: 'HDF5'
+        }
+      },
+      {
+        scheme: 'ProductLevelId',
+        action: 'replace',
+        oldKeywordObject: {
+          Value: 'NA'
+        },
+        newKeywordObject: {
+          Value: '1A'
+        }
+      }
+    ]
+
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockECHO10Xml,
+      corrections
+    })
+
+    // 1. Assert expected overall modification telemetry
+    expect(result.correctionCount).toBe(8)
+    expect(result.stubbed).toBe(false)
+
+    // 2. Assert exact extraction sequence of applied schemes
+    const appliedSchemes = result.correctionsApplied.map((c) => c.scheme)
+    expect(appliedSchemes).toEqual([
+      'platforms',
+      'instruments',
+      'projects',
+      'providers',
+      'rucontenttype',
+      'sciencekeywords',
+      'dataformat',
+      'ProductLevelId'
+    ])
+
+    // 3. Concrete XML assertions for each structural modification family
+    const xml = result.correctedMetadata
+
+    // Platforms verification
+    expect(xml).toContain('<ShortName>SPOT-4-UPDATED</ShortName>')
+    expect(xml).toContain('<LongName>Systeme Observation de la Terre-4 Updated</LongName>')
+
+    // Instruments verification
+    expect(xml).toContain('<ShortName>GEOPHONES-UPDATED</ShortName>')
+    expect(xml).toContain('<LongName>Updated Geophone Array</LongName>')
+
+    // Projects verification
+    expect(xml).toContain('<ShortName>ALIENS-UPDATED</ShortName>')
+    expect(xml).toContain('<LongName>Aliens in Antarctica Updated</LongName>')
+
+    // Providers verification
+    expect(xml).toContain('<OrganizationName>NZ/NZAI/ANZ-UPDATED</OrganizationName>')
+
+    // RUContentType verification
+    expect(xml).toContain('<Type>DistributionURL : VIEW RELATED INFORMATION : OGC WMS</Type>')
+    expect(xml).not.toContain('<Type>DistributionURL : VIEW RELATED INFORMATION : OpenSearch</Type>')
+
+    // ScienceKeywords verification
+    expect(xml).toContain('<Value>SEDIMENT TRANSPORT</Value>')
+    expect(xml).not.toContain('SEDIMENTARY STRUCTURES')
+
+    // DataFormat verification
+    expect(xml).toContain('<DataFormat>HDF5</DataFormat>')
+    expect(xml).not.toContain('<DataFormat>netCDF-4</DataFormat>')
+
+    // ProductLevelId verification
+    expect(xml).toContain('<ProcessingLevelId>1A</ProcessingLevelId>')
+    expect(xml).not.toContain('<ProcessingLevelId>NA</ProcessingLevelId>')
+  })
+})
+
+describe('when verifying ECHO10 corrections do not remove unrelated metadata', () => {
+  test('should preserve unrelated metadata while applying broad updates and deletes across supported fields', async () => {
+    const originalDocument = parseXml(mockEcho10ForMetadataPreservation)
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10ForMetadataPreservation,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'ATMOSPHERE',
+            Term: 'AEROSOLS',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'OCEANS',
+            Term: 'MARINE SEDIMENTS',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        },
+        {
+          scheme: 'platforms',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: '',
+            Class: 'Space-based Platforms',
+            Type: 'Earth Observation Satellites',
+            ShortName: 'SPOT-4'
+          },
+          newKeywordObject: {
+            Category: '',
+            Class: 'Space-based Platforms',
+            Type: 'Earth Observation Satellites',
+            ShortName: 'SPOT-4-UPDATED'
+          },
+          newLongName: 'Systeme Observation de la Terre-4 Updated'
+        },
+        {
+          scheme: 'instruments',
+          action: 'delete',
+          oldKeywordObject: {
+            Category: 'Imaging Spectrometers/Radiometers',
+            Class: '',
+            Subclass: '',
+            ShortName: 'GEOPHONES'
+          }
+        },
+        {
+          scheme: 'projects',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: 'A - C',
+            ShortName: 'ALIENS'
+          },
+          newKeywordObject: {
+            Category: 'A - C',
+            ShortName: 'ALIENS-UPDATED'
+          },
+          newLongName: 'Aliens in Antarctica Updated'
+        },
+        {
+          scheme: 'providers',
+          action: 'replace',
+          oldKeywordObject: {
+            BucketLevel0: 'ARCHIVER',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'NZ/NZAI/ANZ'
+          },
+          newKeywordObject: {
+            BucketLevel0: 'ARCHIVER',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'NZ/NZAI/ANZ-UPDATED'
+          },
+          newLongName: 'Antarctica New Zealand Updated'
+        },
+        {
+          scheme: 'rucontenttype',
+          action: 'replace',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'VIEW RELATED INFORMATION',
+            Subtype: 'OpenSearch'
+          },
+          newKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'VIEW RELATED INFORMATION',
+            Subtype: 'OGC WMS'
+          }
+        },
+        {
+          scheme: 'dataformat',
+          action: 'replace',
+          oldKeywordObject: {
+            Value: 'netCDF-4'
+          },
+          newKeywordObject: {
+            Value: 'HDF5'
+          }
+        },
+        {
+          scheme: 'productlevelid',
+          action: 'replace',
+          oldKeywordObject: {
+            Value: 'NA'
+          },
+          newKeywordObject: {
+            Value: '1A'
+          }
+        }
+      ]
+    })
+
+    const updatedDocument = parseXml(result.correctedMetadata)
+
+    expect(result.correctionCount).toBe(8)
+
+    expect(selectTexts(updatedDocument, '//ScienceKeywords/ScienceKeyword/TopicKeyword')).toContain('OCEANS')
+    expect(selectTexts(updatedDocument, '//ScienceKeywords/ScienceKeyword/TermKeyword')).toContain('MARINE SEDIMENTS')
+    expect(selectTexts(updatedDocument, '//Platforms/Platform/ShortName')).toContain('SPOT-4-UPDATED')
+    expect(selectText(updatedDocument, '//Platforms/Platform[ShortName="SPOT-4-UPDATED"]/LongName')).toBe('Systeme Observation de la Terre-4 Updated')
+    expect(selectTexts(updatedDocument, '//Platforms/Platform[ShortName="SPOT-4-UPDATED"]/Instruments/Instrument/ShortName')).not.toContain('GEOPHONES')
+    expect(selectTexts(updatedDocument, '//Platforms/Platform[ShortName="SPOT-4-UPDATED"]/Instruments/Instrument/ShortName')).toContain('SEISMIC REFLECTION PROFILERS')
+    expect(selectTexts(updatedDocument, '//Campaigns/Campaign/ShortName')).toContain('ALIENS-UPDATED')
+    expect(selectTexts(updatedDocument, '//Campaigns/Campaign/ShortName')).toContain('ICEBRIDGE')
+    expect(selectText(updatedDocument, '//Contacts/Contact/OrganizationName')).toBe('NZ/NZAI/ANZ-UPDATED')
+    expect(selectText(updatedDocument, '//OnlineResources/OnlineResource/Type')).toBe('DistributionURL : VIEW RELATED INFORMATION : OGC WMS')
+    expect(selectText(updatedDocument, '//DataFormat')).toBe('HDF5')
+    expect(selectText(updatedDocument, '//ProcessingLevelId')).toBe('1A')
+
+    const preservedTextExpressions = [
+      '//Entry_Title',
+      '//Personnel[Role="INVESTIGATOR"]/Contact_Person/Email',
+      '//Temporal_Coverage/Temporal_Info',
+      '//Summary/Abstract',
+      '//Quality',
+      '//Dataset_Language',
+      '//Organization/Organization_URL',
+      '//Organization/Personnel/Contact_Person/Email',
+      '//Related_URL/URL',
+      '//Related_URL/Description',
+      '//Metadata_Dates/Metadata_Last_Revision',
+      '//Additional_Attributes[Name="metadata.keyword_version"]/Value'
+    ]
+
+    preservedTextExpressions.forEach((expression) => {
+      expect(selectText(updatedDocument, expression)).toBe(selectText(originalDocument, expression))
+    })
+
+    expect(selectTexts(updatedDocument, '//Platforms/Platform/ShortName')).toContain('NASA S-3B VIKING')
+    expect(selectText(updatedDocument, '//Platforms/Platform[ShortName="NASA S-3B VIKING"]/Instruments/Instrument/ShortName')).toBe('TSX-1')
+    expect(selectTexts(updatedDocument, '//ScienceKeywords/ScienceKeyword/TopicKeyword')).toContain('SOLID EARTH')
+    expect(selectTexts(updatedDocument, '//ScienceKeywords/ScienceKeyword/VariableLevel1Keyword/Value')).toContain('EARTHQUAKES')
+  })
+})
+
+const mockEcho10WithInstruments = `<Collection>
+    <ShortName>Instruments_Test</ShortName>
+    <VersionId>001</VersionId>
+    <Platforms>
+        <Platform>
+            <ShortName>UC-12B</ShortName>
+            <LongName>NASA Langley Beechcraft UC-12B Huron</LongName>
+            <Type>Air-based Platforms</Type>
+            <Instruments>
+                <Instrument>
+                    <ShortName>IRMSS</ShortName>
+                    <LongName>Infrared Multispectral Scanner</LongName>
+                </Instrument>
+            </Instruments>
+        </Platform>
+        <Platform>
+            <ShortName>MINTS</ShortName>
+            <LongName>Multi-Scale Integrated Intelligent Interactive Sensing Consortium</LongName>
+            <Type>Land-based Platforms</Type>
+            <Instruments>
+                <Instrument>
+                    <ShortName>LISS-II</ShortName>
+                    <LongName>Linear Imaging Self Scanning Sensor II</LongName>
+                </Instrument>
+            </Instruments>
+        </Platform>
+    </Platforms>
+</Collection>`
+
+describe('when applying instrument ECHO10 corrections', () => {
+  test('should apply long name correction to first Instrument', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithInstruments,
+      corrections: [
+        {
+          scheme: 'instruments',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: 'Imaging Spectrometers/Radiometers',
+            Class: '',
+            Subclass: '',
+            ShortName: 'IRMSS'
+          },
+          newKeywordObject: {
+            Category: 'Imaging Spectrometers/Radiometers',
+            Class: '',
+            Subclass: '',
+            ShortName: 'IRMSS'
+          },
+          newLongName: 'Updated Infrared Multispectral Scanner'
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctionsApplied).toHaveLength(1)
+
+    // Verify first long name was updated
+    expect(result.correctedMetadata).toContain('<LongName>Updated Infrared Multispectral Scanner</LongName>')
+    expect(result.correctedMetadata).not.toContain('<LongName>Infrared Multispectral Scanner</LongName>')
+
+    // Other long name should remain unchanged
+    expect(result.correctedMetadata).toContain('<LongName>Linear Imaging Self Scanning Sensor II</LongName>')
+
+    // Platform stays untouched
+    expect(result.correctedMetadata).toContain('<ShortName>UC-12B</ShortName>')
+  })
+
+  test('should update both short name and long name', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithInstruments,
+      corrections: [
+        {
+          scheme: 'instruments',
+          oldKeywordObject: {
+            Category: 'Imaging Spectrometers/Radiometers',
+            Class: '',
+            Subclass: '',
+            ShortName: 'LISS-II'
+          },
+          newKeywordObject: {
+            Category: 'Imaging Spectrometers/Radiometers',
+            Class: '',
+            Subclass: '',
+            ShortName: 'LISSUPDATE-II'
+          },
+          newLongName: 'Linear Imaging Self Scanning Sensor II Updated'
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Verify short name was updated
+    expect(result.correctedMetadata).toContain('<ShortName>LISSUPDATE-II</ShortName>')
+    expect(result.correctedMetadata).not.toContain('<ShortName>LISS-II</ShortName>')
+
+    // Verify long name was updated
+    expect(result.correctedMetadata).toContain('<LongName>Linear Imaging Self Scanning Sensor II Updated</LongName>')
+    expect(result.correctedMetadata).not.toContain('<LongName>Linear Imaging Self Scanning Sensor II</LongName>')
+  })
+
+  test('should delete Instrument', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithInstruments,
+      corrections: [
+        {
+          scheme: 'instruments',
+          action: 'delete',
+          oldKeywordObject: {
+            Category: 'Imaging Spectrometers/Radiometers',
+            Class: '',
+            Subclass: '',
+            ShortName: 'IRMSS'
+          },
+          newKeywordObject: {}
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Instrument should be removed
+    expect(result.correctedMetadata).not.toContain('<ShortName>IRMSS</ShortName>')
+
+    // Other Instrument should be unchanged
+    expect(result.correctedMetadata).toContain('<ShortName>LISS-II</ShortName>')
+  })
+
+  test('should delete parent Instrument property when the last instrument in an array is removed', async () => {
+    const multiInstrumentXml = `<Collection>
+      <Platforms>
+        <Platform>
+          <ShortName>P1</ShortName>
+            <Instruments>
+              <Instrument><ShortName>I1</ShortName></Instrument>
+              <Instrument><ShortName>I2</ShortName></Instrument>
+            </Instruments>
+        </Platform>
+      </Platforms>
+    </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: multiInstrumentXml,
+      corrections: [
+        {
+          scheme: 'instruments',
+          action: 'delete',
+          oldKeywordObject: {
+            Category: 'Instrument',
+            Class: '',
+            Subclass: '',
+            ShortName: 'I1'
+          }
+        },
+        {
+          scheme: 'instruments',
+          action: 'delete',
+          oldKeywordObject: {
+            Category: 'Instrument',
+            Class: '',
+            Subclass: '',
+            ShortName: 'I2'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(2)
+    // The Instrument tag should be entirely removed from the XML
+    expect(result.correctedMetadata).not.toContain('<Instrument>')
+  })
+
+  test('should cover the else branch by deleting a single instrument object', async () => {
+    const singleInstrumentXml = `<Collection>
+      <Platforms>
+        <Platform>
+          <ShortName>P1</ShortName>
+            <Instruments>
+              <Instrument>
+                <ShortName>I1</ShortName>
+              </Instrument>
+            </Instruments>
+        </Platform>
+      </Platforms>  
+    </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: singleInstrumentXml,
+      corrections: [
+        {
+          scheme: 'instruments',
+          action: 'delete',
+          oldKeywordObject: {
+            Category: 'Instrument',
+            Class: '',
+            Subclass: '',
+            ShortName: 'I1'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctedMetadata).not.toContain('<Instrument>')
+  })
+
+  test('should cover the field pruning else branch by providing an empty long name', async () => {
+    const instrumentXml = `<Collection>
+      <Platforms>
+        <Platform>
+          <ShortName>P1</ShortName>
+            <Instruments>
+              <Instrument>
+                <ShortName>OLD-SHORT</ShortName>
+                <LongName>Old Long Name to delete</LongName>
+              </Instrument>
+            </Instruments>
+        </Platform>
+      </Platforms>
+    </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: instrumentXml,
+      corrections: [
+        {
+          scheme: 'instruments',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: 'Instrument',
+            Class: '',
+            Subclass: '',
+            ShortName: 'OLD-SHORT'
+          },
+          newKeywordObject: {
+            Category: 'Category',
+            Class: 'Topic',
+            Subclass: 'Term',
+            ShortName: 'NEW-SHORT'
+          },
+          newLongName: '' // Triggers delete target['LongName']
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctedMetadata).toContain('<ShortName>NEW-SHORT</ShortName>')
+    expect(result.correctedMetadata).not.toContain('<LongName>')
+  })
+
+  test('should handle missing Instrument element', async () => {
+    const xmlWithoutPlatform = `<Collection>
+        <ShortName>No_instrument</ShortName>
+        <Platforms>
+          <Platform>
+            <Type>Air-based Platforms</Type>
+            <ShortName>UC-12B</ShortName>
+            <LongName>NASA Langley Beechcraft UC-12B Huron</LongName>
+          </Platform>
+        </Platforms>
+    </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: xmlWithoutPlatform,
+      corrections: [
+        {
+          scheme: 'instruments',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: 'Imaging Spectrometers/Radiometers',
+            Class: '',
+            Subclass: '',
+            ShortName: 'IRMSS'
+          },
+          newKeywordObject: {
+            Category: 'Imaging Spectrometers/Radiometers',
+            Class: '',
+            Subclass: '',
+            ShortName: 'IRMSS1'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(0)
+    expect(result.correctionsApplied).toHaveLength(0)
+  })
+
+  test('should match by old keyword path even when a stale ummPath is present', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithInstruments,
+      corrections: [
+        {
+          scheme: 'instruments',
+          action: 'replace',
+          ummPath: ['Platform', 10, 'Instrument', 0],
+          oldKeywordObject: {
+            Category: 'Imaging Spectrometers/Radiometers',
+            Class: '',
+            Subclass: '',
+            ShortName: 'IRMSS'
+          },
+          newKeywordObject: {
+            Category: 'Imaging Spectrometers/Radiometers',
+            Class: '',
+            Subclass: '',
+            ShortName: 'IRMSS1'
+          },
+          newLongName: 'Infrared Multispectral Scanner Updated'
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctedMetadata).toContain('<ShortName>IRMSS1</ShortName>')
+  })
+})
+
+describe('when instrument guard clauses prevent a correction', () => {
+  test('should return false when oldKeywordObject is missing', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: mockEcho10WithInstruments,
+      corrections: [{
+        scheme: 'instruments',
+        action: 'replace',
+        newKeywordObject: {
+          Category: 'Category',
+          Class: 'Topic',
+          Subclass: 'Term',
+          ShortName: 'NEW-SHORT'
+        }
+      }]
+    })
+
+    expect(result.correctionCount).toBe(0)
+  })
+
+  test('should return false when Platform or Instrument element is missing from metadata', async () => {
+    const xmlNoInstruments = '<Collection><ShortName>TEST</ShortName></Collection>'
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: xmlNoInstruments,
+      corrections: [{
+        scheme: 'instruments',
+        action: 'replace',
+        newKeywordObject: {
+          Category: 'Category',
+          Class: 'Topic',
+          Subclass: 'Term',
+          ShortName: 'NEW-SHORT'
+        }
+      }]
+    })
+
+    expect(result.correctionCount).toBe(0)
+  })
+
+  test('should return false when the current instrument path cannot be matched', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: mockEcho10WithInstruments,
+      corrections: [{
+        scheme: 'instruments',
+        action: 'replace',
+        oldKeywordObject: {
+          Category: 'Imaging Spectrometers/Radiometers',
+          Class: '',
+          Subclass: '',
+          ShortName: 'NOT-REAL'
+        },
+        newKeywordObject: {
+          Category: 'Category',
+          Class: 'Topic',
+          Subclass: 'Term',
+          ShortName: 'NEW-SHORT'
+        }
+      }]
+    })
+
+    expect(result.correctionCount).toBe(0)
+  })
+
+  test('should return false for unsupported action (final fall-through)', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: mockEcho10WithInstruments,
+      corrections: [{
+        scheme: 'instruments',
+        action: 'invalid_action_type'
+      }]
+    })
+
+    expect(result.correctionCount).toBe(0)
+  })
+})
+
+const mockEcho10WithPlatforms = `<Collection>
+    <ShortName>Platforms_Test</ShortName>
+    <VersionId>001</VersionId>
+      <Platforms>
+        <Platform>
+          <Type>Earth Observation Satellites</Type>
+          <ShortName>SPOT-4</ShortName>
+          <LongName>Systeme Observation de la Terre-4</LongName>
+          <Instruments>
+            <Instrument>
+              <ShortName>VEGETATION-1</ShortName>
+              <LongName>VEGETATION INSTRUMENT 1 (SPOT 4)</LongName>
+            </Instrument>
+          </Instruments>
+        </Platform>
+        <Platform>
+          <Type>Earth Observation planes</Type>
+          <ShortName>SPOT-5</ShortName>
+          <LongName>Systeme Observation de la Terre-5</LongName>
+          <Instruments>
+            <Instrument>
+              <ShortName>VEGETATION-2</ShortName>
+              <LongName>VEGETATION INSTRUMENT 2 (SPOT 5)</LongName>
+            </Instrument>
+          </Instruments>
+        </Platform>
+    </Platforms>
+</Collection>`
+
+describe('when applying platform ECHO10 corrections', () => {
+  test('should apply long name correction to first Platform', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithPlatforms,
+      corrections: [
+        {
+          scheme: 'platforms',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: '',
+            Class: 'Space-based Platforms',
+            Type: 'Earth Observation Satellites',
+            ShortName: 'SPOT-4'
+          },
+          newKeywordObject: {
+            Category: '',
+            Class: 'Space-based Platforms',
+            Type: 'Earth Observation Satellites',
+            ShortName: 'SPOT-4'
+          },
+          newLongName: 'Systeme Observation de la Terre-4 Updated'
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctionsApplied).toHaveLength(1)
+
+    // Verify first long name was updated
+    expect(result.correctedMetadata).toContain('<LongName>Systeme Observation de la Terre-4 Updated</LongName>')
+    expect(result.correctedMetadata).not.toContain('<LongName>Systeme Observation de la Terre-4</LongName>')
+
+    // Other Type should remain unchanged
+    expect(result.correctedMetadata).toContain('<LongName>Systeme Observation de la Terre-5</LongName>')
+
+    // Instrument stays untouched
+    expect(result.correctedMetadata).toContain('<ShortName>VEGETATION-1</ShortName>')
+
+    // Platform type untouched
+    expect(result.correctedMetadata).toContain('<Type>Earth Observation Satellites</Type>')
+  })
+
+  test('should update both short name and long name', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithPlatforms,
+      corrections: [
+        {
+          scheme: 'platforms',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: '',
+            Class: 'Space-based Platforms',
+            Type: 'Earth Observation Satellites',
+            ShortName: 'SPOT-5'
+          },
+          newKeywordObject: {
+            Category: '',
+            Class: 'Space-based Platforms',
+            Type: 'Earth Observation Satellites',
+            ShortName: 'SPOT-7-New'
+          },
+          newLongName: 'Systeme Observation de la Terre-5 Updated'
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Verify short name was updated
+    expect(result.correctedMetadata).toContain('<ShortName>SPOT-7-New</ShortName>')
+    expect(result.correctedMetadata).not.toContain('<ShortName>SPOT-7</ShortName>')
+
+    // Verify long name was updated
+    expect(result.correctedMetadata).toContain('<LongName>Systeme Observation de la Terre-5 Updated</LongName>')
+    expect(result.correctedMetadata).not.toContain('<LongName>Systeme Observation de la Terre-5</LongName>')
+
+    expect(result.correctedMetadata).toContain('<Type>Earth Observation Satellites</Type>')
+    expect(result.correctedMetadata).not.toContain('<Type>Earth Observation planes</Type>')
+  })
+
+  test('should apply platform correction when there is only a single platform (object branch)', async () => {
+    const singlePlatformXml = `<Collection>
+      <ShortName>SINGLE_PLAT_TEST</ShortName>
+      <VersionId>001</VersionId>
+      <Platforms>
+        <Platform>
+            <Type>In Situ Land-based Platforms</Type>
+            <ShortName>GROUND STATIONS</ShortName>
+            <LongName>Long Name to be replaced</LongName>
+        </Platform>
+      </Platforms>
+  </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: singlePlatformXml,
+      corrections: [
+        {
+          scheme: 'platforms',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: '',
+            Class: 'In Situ Land-based Platforms',
+            Type: '',
+            ShortName: 'GROUND STATIONS'
+          },
+          newKeywordObject: {
+            Category: '',
+            Class: 'In Situ Land-based Platforms',
+            Type: 'Aircraft',
+            ShortName: 'C-130'
+          },
+          newLongName: 'Lockheed C-130 Hercules'
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Verify the object branch was taken and updated the fields correctly
+    expect(result.correctedMetadata).toContain('<Type>Aircraft</Type>')
+    expect(result.correctedMetadata).toContain('<ShortName>C-130</ShortName>')
+    expect(result.correctedMetadata).toContain('<LongName>Lockheed C-130 Hercules</LongName>')
+    expect(result.correctedMetadata).not.toContain('GROUND STATIONS')
+  })
+
+  test('should delete parent Platform property when the last platform in an array is removed', async () => {
+    const multiPlatformXml = `<Collection>
+      <Platforms>
+        <Platform>
+            <Type>Aircraft</Type>
+            <ShortName>A1</ShortName>
+        </Platform>
+        <Platform>
+            <Type>Aircraft</Type>
+            <ShortName>A2</ShortName>
+        </Platform>
+      </Platforms>
+  </Collection>`
+
+    // Applying two deletions to empty the array and trigger the length === 0 check
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: multiPlatformXml,
+      corrections: [
+        {
+          scheme: 'platforms',
+          action: 'delete',
+          oldKeywordObject: {
+            Category: '',
+            Class: 'Aircraft',
+            Type: '',
+            ShortName: 'A1'
+          }
+        },
+        {
+          scheme: 'platforms',
+          action: 'delete',
+          oldKeywordObject: {
+            Category: '',
+            Class: 'Aircraft',
+            Type: '',
+            ShortName: 'A2'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(2)
+    // The Platform key should be entirely removed from the resulting XML
+    expect(result.correctedMetadata).not.toContain('<Platform>')
+    expect(result.correctedMetadata).not.toContain('</Platform>')
+  })
+
+  test('should delete Platform', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithPlatforms,
+      corrections: [
+        {
+          scheme: 'platforms',
+          action: 'delete',
+          oldKeywordObject: {
+            Category: '',
+            Class: 'Space-based Platforms',
+            Type: 'Earth Observation Satellites',
+            ShortName: 'SPOT-4'
+          },
+          newKeywordObject: {}
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Platform should be removed
+    expect(result.correctedMetadata).not.toContain('<Type>Earth Observation Satellites</Type>')
+
+    // Other Platform should be unchanged
+    expect(result.correctedMetadata).toContain('<Type>Earth Observation planes</Type>')
+  })
+
+  test('should return false when an unrecognized action is passed to platforms', async () => {
+    const platformOnlyXml = '<Collection><Platforms><Platform><ShortName>TEST</ShortName></Platform></Platforms></Collection>'
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: platformOnlyXml,
+      corrections: [
+        {
+          scheme: 'platforms',
+          action: 'not_an_action', // Triggers the final return false
+          newKeywordObject: {
+            Category: '',
+            Class: 'A',
+            Type: 'B',
+            ShortName: 'C'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(0)
+  })
+
+  test('should cover the else branch by deleting a single platform object', async () => {
+    const singlePlatformXml = `<Collection>
+      <ShortName>SINGLE_DELETE_TEST</ShortName>
+      <Platforms>
+        <Platform>
+            <Type>Aircraft</Type>
+            <ShortName>A1</ShortName>
+        </Platform>
+      </Platforms>
+  </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: singlePlatformXml,
+      corrections: [
+        {
+          scheme: 'platforms',
+          action: 'delete',
+          oldKeywordObject: {
+            Category: '',
+            Class: 'Aircraft',
+            Type: '',
+            ShortName: 'A1'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    // Verify the Platform tag is completely removed from the XML
+    expect(result.correctedMetadata).not.toContain('<Platform>')
+    expect(result.correctedMetadata).not.toContain('</Platform>')
+  })
+
+  test('should cover the field pruning else branch by providing a shorter keyword path', async () => {
+    const platformXml = `<Collection>
+      <Platforms>
+        <Platform>
+            <Type>Aircraft</Type>
+            <ShortName>OLD-SHORT</ShortName>
+            <LongName>Old Long Name that should be deleted</LongName>
+        </Platform>
+      </Platforms>
+  </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: platformXml,
+      corrections: [
+        {
+          scheme: 'platforms',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: '',
+            Class: 'Aircraft',
+            Type: '',
+            ShortName: 'OLD-SHORT'
+          },
+          // Providing only one segment forces the LongName field to hit the 'else { delete }' branch
+          newKeywordObject: {
+            Category: '',
+            Class: 'Space-based Platforms',
+            Type: 'Earth Observation Satellites',
+            ShortName: 'NEW-SHORT'
+          },
+          newLongName: ''
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Verify ShortName was updated
+    expect(result.correctedMetadata).toContain('<ShortName>NEW-SHORT</ShortName>')
+
+    // Verify LongName was deleted (this is the branch we are covering)
+    expect(result.correctedMetadata).not.toContain('<LongName>')
+    expect(result.correctedMetadata).not.toContain('Old Long Name that should be deleted')
+  })
+
+  test('should handle missing Platform element', async () => {
+    const xmlWithoutPlatform = `<Collection>
+        <ShortName>NO_URL</ShortName>
+    </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: xmlWithoutPlatform,
+      corrections: [
+        {
+          scheme: 'platforms',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: '',
+            Class: 'Earth Observation planes',
+            Type: '',
+            ShortName: 'SPOT-5'
+          },
+          newKeywordObject: {
+            Category: '',
+            Class: 'Earth Observation rockets',
+            Type: '',
+            ShortName: 'SPOT-7'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(0)
+    expect(result.correctionsApplied).toHaveLength(0)
+  })
+
+  test('should match by old keyword path even when a stale ummPath is present', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithPlatforms,
+      corrections: [
+        {
+          scheme: 'platforms',
+          action: 'replace',
+          ummPath: ['Platform', 10],
+          oldKeywordObject: {
+            Category: '',
+            Class: 'Space-based Platforms',
+            Type: 'Earth Observation Satellites',
+            ShortName: 'SPOT-5'
+          },
+          newKeywordObject: {
+            Category: '',
+            Class: 'Space-based Platforms',
+            Type: 'Earth Observation Satellites',
+            ShortName: 'SPOT-7'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctedMetadata).toContain('<ShortName>SPOT-7</ShortName>')
+  })
+})
+
+describe('when applying Dataformat ECHO10 corrections', () => {
+  const mockEcho10WithDataFormat = `<Collection>
+    <DataFormat>netCDF-4</DataFormat>
+</Collection>`
+
+  describe('when replacing DataFormat', () => {
+    test('should successfully update the DataFormat with a new string', async () => {
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: mockEcho10WithDataFormat,
+        corrections: [{
+          scheme: 'dataformat',
+          action: 'replace',
+          newKeywordObject: {
+            Value: 'HDF4'
+          }
+        }]
+      })
+
+      expect(result.correctionCount).toBe(1)
+      expect(result.correctedMetadata).toContain('<DataFormat>HDF4</DataFormat>')
+      expect(result.correctedMetadata).not.toContain('netCDF-4')
+    })
+
+    test('should default to replace action if no action is provided', async () => {
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: mockEcho10WithDataFormat,
+        corrections: [{
+          scheme: 'dataformat',
+          newKeywordObject: {
+            Value: 'HDF5'
+          }
+        }]
+      })
+
+      expect(result.correctionCount).toBe(1)
+      expect(result.correctedMetadata).toContain('<DataFormat>HDF5</DataFormat>')
+    })
+
+    test('should return false and not modify the field if newKeywordObject is empty or invalid', async () => {
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: mockEcho10WithDataFormat,
+        corrections: [{
+          scheme: 'dataformat',
+          action: 'replace',
+          newKeywordObject: {} // Empty spaces
+        }]
+      })
+
+      expect(result.correctionCount).toBe(0)
+      expect(result.correctedMetadata).toContain('<DataFormat>netCDF-4</DataFormat>')
+    })
+  })
+
+  describe('when deleting DataFormat', () => {
+    test('should successfully delete the DataFormat key from the object', async () => {
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: mockEcho10WithDataFormat,
+        corrections: [{
+          scheme: 'dataFormat',
+          action: 'delete'
+        }]
+      })
+
+      expect(result.correctionCount).toBe(1)
+      expect(result.correctedMetadata).not.toContain('<DataFormat>')
+    })
+
+    test('should return false if trying to delete a DataFormat that does not exist', async () => {
+      const missingFieldXml = '<Collection><ShortName>TEST</ShortName></Collection>'
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: missingFieldXml,
+        corrections: [{
+          scheme: 'dataformat',
+          action: 'delete'
+        }]
+      })
+
+      expect(result.correctionCount).toBe(0)
+    })
+  })
+
+  describe('when handling DataFormat edge cases', () => {
+    test('should return empty count if metadataPayload is null or undefined', async () => {
+      const resultNull = await applyEcho10MetadataCorrections({
+        metadataPayload: null,
+        corrections: [{
+          scheme: 'dataformat',
+          action: 'replace',
+          newKeywordObject: {
+            Value: 'hdf6'
+          }
+        }]
+      })
+
+      expect(resultNull.correctionCount).toBe(0)
+      expect(resultNull.stubbed).toBe(true)
+    })
+
+    test('should return false if parsedMetadata does not contain a ECHO object', async () => {
+      const malformedXml = '<NOT_Collection><DataFormat>NetCDF-4</DataFormat></NOT_Collection>'
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: malformedXml,
+        corrections: [{
+          scheme: 'dataformat',
+          action: 'replace',
+          newKeywordObject: {
+            Value: 'HDF4'
+          }
+        }]
+      })
+
+      expect(result.correctionCount).toBe(0)
+    })
+
+    test('should return false if an unknown action type is provided', async () => {
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: mockEcho10WithDataFormat,
+        corrections: [{
+          scheme: 'dataformat',
+          action: 'invalid_action_type',
+          newKeywordObject: {
+            Value: 'HDF2'
+          }
+        }]
+      })
+
+      expect(result.correctionCount).toBe(0)
+      expect(result.correctedMetadata).toContain('<DataFormat>netCDF-4</DataFormat>')
+    })
+  })
+})
+
+describe('when applying ProcessingLevelId ECHO10 corrections', () => {
+  const mockEcho10WithProductLevel = `<Collection>
+    <ProcessingLevelId>Level 1B</ProcessingLevelId>
+</Collection>`
+
+  describe('when replacing ProcessingLevelId', () => {
+    test('should successfully update the ProcessingLevelId with a new string', async () => {
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: mockEcho10WithProductLevel,
+        corrections: [{
+          scheme: 'productlevelid',
+          action: 'replace',
+          newKeywordObject: {
+            Value: 'Level 2'
+          }
+        }]
+      })
+
+      expect(result.correctionCount).toBe(1)
+      expect(result.correctedMetadata).toContain('<ProcessingLevelId>Level 2</ProcessingLevelId>')
+      expect(result.correctedMetadata).not.toContain('Level 1B')
+    })
+
+    test('should default to replace action if no action is provided', async () => {
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: mockEcho10WithProductLevel,
+        corrections: [{
+          scheme: 'productlevelid',
+          newKeywordObject: {
+            Value: 'Level 3'
+          }
+        }]
+      })
+
+      expect(result.correctionCount).toBe(1)
+      expect(result.correctedMetadata).toContain('<ProcessingLevelId>Level 3</ProcessingLevelId>')
+    })
+
+    test('should return false and not modify the field if newKeywordObject is empty or invalid', async () => {
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: mockEcho10WithProductLevel,
+        corrections: [{
+          scheme: 'productlevelid',
+          action: 'replace',
+          newKeywordObject: {} // Empty spaces
+        }]
+      })
+
+      expect(result.correctionCount).toBe(0)
+      expect(result.correctedMetadata).toContain('<ProcessingLevelId>Level 1B</ProcessingLevelId>')
+    })
+  })
+
+  describe('when deleting ProcessingLevelId', () => {
+    test('should successfully delete the ProcessingLevelId key from the object', async () => {
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: mockEcho10WithProductLevel,
+        corrections: [{
+          scheme: 'productlevelid',
+          action: 'delete'
+        }]
+      })
+
+      expect(result.correctionCount).toBe(1)
+      expect(result.correctedMetadata).not.toContain('<ProcessingLevelId>')
+    })
+
+    test('should return false if trying to delete a ProcessingLevelId that does not exist', async () => {
+      const missingFieldXml = '<Collection><Entry_ID><ShortName>TEST</ShortName></Entry_ID></Collection>'
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: missingFieldXml,
+        corrections: [{
+          scheme: 'productlevelid',
+          action: 'delete'
+        }]
+      })
+
+      expect(result.correctionCount).toBe(0)
+    })
+  })
+
+  describe('when handling ProcessingLevelId edge cases', () => {
+    test('should return empty count if metadataPayload is null or undefined', async () => {
+      const resultNull = await applyEcho10MetadataCorrections({
+        metadataPayload: null,
+        corrections: [{
+          scheme: 'productlevelid',
+          action: 'replace',
+          newKeywordObject: {
+            Value: 'Level 4'
+          }
+        }]
+      })
+
+      expect(resultNull.correctionCount).toBe(0)
+      expect(resultNull.stubbed).toBe(true)
+    })
+
+    test('should return false if parsedMetadata does not contain a ECHO object', async () => {
+      const malformedXml = '<NOT_Collection><ProcessingLevelId>Level 1B</ProcessingLevelId></NOT_Collection>'
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: malformedXml,
+        corrections: [{
+          scheme: 'productlevelid',
+          action: 'replace',
+          newKeywordObject: {
+            Value: 'Level 4'
+          }
+        }]
+      })
+
+      expect(result.correctionCount).toBe(0)
+    })
+
+    test('should return false if an unknown action type is provided', async () => {
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: mockEcho10WithProductLevel,
+        corrections: [{
+          scheme: 'productlevelid',
+          action: 'invalid_action_type',
+          newKeywordObject: {
+            Value: 'Level 2'
+          }
+        }]
+      })
+
+      expect(result.correctionCount).toBe(0)
+      expect(result.correctedMetadata).toContain('<ProcessingLevelId>Level 1B</ProcessingLevelId>')
+    })
+  })
+})
+
+const mockEcho10WithProjects = `<Collection>
+    <ShortName>Projects_Test</ShortName>
+    <VersionId>001</VersionId>
+    <Campaigns>
+        <Campaign>
+            <ShortName>ESIP</ShortName>
+            <LongName>Earth Science Information Partners Program</LongName>
+        </Campaign>
+        <Campaign>
+            <ShortName>ALIENS</ShortName>
+            <LongName>Aliens in Antarctica</LongName>
+        </Campaign>
+    </Campaigns>
+</Collection>`
+
+describe('when applying project ECHO10 corrections', () => {
+  test('should apply long name correction to first Project', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithProjects,
+      corrections: [
+        {
+          scheme: 'projects',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: 'D - F',
+            ShortName: 'ESIP'
+          },
+          newKeywordObject: {
+            Category: 'D - F',
+            ShortName: 'ESIP'
+          },
+          newLongName: 'Updated Earth Science Information Partners Program'
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctionsApplied).toHaveLength(1)
+
+    // Verify first long name was updated
+    expect(result.correctedMetadata).toContain('<LongName>Updated Earth Science Information Partners Program</LongName>')
+    expect(result.correctedMetadata).not.toContain('<LongName>Earth Science Information Partners Program</LongName>')
+
+    // Second long name stays untouched
+    expect(result.correctedMetadata).toContain('<LongName>Aliens in Antarctica</LongName>')
+  })
+
+  test('should update both short name and long name', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithProjects,
+      corrections: [
+        {
+          scheme: 'projects',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: 'A - C',
+            ShortName: 'ALIENS'
+          },
+          newKeywordObject: {
+            Category: 'A - C',
+            ShortName: 'ALIENS UP'
+          },
+          newLongName: 'Aliens research in Antarctica'
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Verify short name was updated
+    expect(result.correctedMetadata).toContain('<ShortName>ALIENS UP</ShortName>')
+    expect(result.correctedMetadata).not.toContain('<ShortName>ALIENS</ShortName>')
+
+    // Verify long name was updated
+    expect(result.correctedMetadata).toContain('<LongName>Aliens research in Antarctica</LongName>')
+    expect(result.correctedMetadata).not.toContain('<LongName>Aliens in Antarctica</LongName>')
+  })
+
+  test('should delete Project', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithProjects,
+      corrections: [
+        {
+          scheme: 'projects',
+          action: 'delete',
+          oldKeywordObject: {
+            Category: 'D - F',
+            ShortName: 'ESIP'
+          },
+          newKeywordObject: {}
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Project should be removed
+    expect(result.correctedMetadata).not.toContain('<ShortName>ESIP</ShortName>')
+
+    // Other Project should be unchanged
+    expect(result.correctedMetadata).toContain('<ShortName>ALIENS</ShortName>')
+  })
+
+  test('should delete the Project key when the last element of an array is removed', async () => {
+    // Starting with an array of two projects (from mockEcho10WithProjects)
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: mockEcho10WithProjects,
+      corrections: [
+        {
+          scheme: 'projects',
+          action: 'delete',
+          oldKeywordObject: {
+            Category: 'D - F',
+            ShortName: 'ESIP'
+          }
+        },
+        {
+          scheme: 'projects',
+          action: 'delete',
+          oldKeywordObject: {
+            Category: 'A - C',
+            ShortName: 'ALIENS'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(2)
+    // This specifically triggers:
+    // if (parent.Project.length === 0) { delete parent.Project }
+    expect(result.correctedMetadata).not.toContain('<Project>')
+  })
+
+  test('should delete the Project key when it is a single object (non-array)', async () => {
+    // XML with only one Project tag, which is parsed as a single object
+    const singleProjectXml = `<Collection>
+        <Campaigns>
+            <Campaign>
+                <ShortName>SINGLE-PROJ</ShortName>
+                <LongName>Single Project Test</LongName>
+            </Campaign>
+        </Campaigns>
+    </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: singleProjectXml,
+      corrections: [
+        {
+          scheme: 'projects',
+          action: 'delete',
+          oldKeywordObject: {
+            Category: 'S - U',
+            ShortName: 'SINGLE-PROJ'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    // This specifically triggers:
+    // } else { delete parent.Project }
+    expect(result.correctedMetadata).not.toContain('<Project>')
+    expect(result.correctedMetadata).not.toContain('SINGLE-PROJ')
+  })
+
+  test('should delete the Project key when it is a single object (non-array branch)', async () => {
+    // XML with only one Project tag, which is parsed as a single object
+    const singleProjectXml = `<Collection>
+        <Campaigns>
+          <Campaign>
+              <ShortName>SINGLE-PROJ</ShortName>
+              <LongName>Single Project Test</LongName>
+          </Campaign>
+        </Campaigns>
+    </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: singleProjectXml,
+      corrections: [
+        {
+          scheme: 'projects',
+          action: 'delete',
+          oldKeywordObject: {
+            Category: 'S - U',
+            ShortName: 'SINGLE-PROJ'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    // This specifically triggers:
+    // } else { delete parent.Project }
+    expect(result.correctedMetadata).not.toContain('<Campaign>')
+    expect(result.correctedMetadata).not.toContain('SINGLE-PROJ')
+  })
+
+  test('should handle missing Project element', async () => {
+    const xmlWithoutProject = `<Collection>
+        <ShortName>No_project</ShortName>
+    </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: xmlWithoutProject,
+      corrections: [
+        {
+          scheme: 'projects',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: 'D - F',
+            ShortName: 'ESIP'
+          },
+          newKeywordObject: {
+            Category: 'D - F',
+            ShortName: 'ESIP-7'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(0)
+    expect(result.correctionsApplied).toHaveLength(0)
+  })
+
+  test('should delete a specific field (LongName) within a Project when the new value is undefined', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: mockEcho10WithProjects,
+      corrections: [
+        {
+          scheme: 'projects',
+          action: 'replace',
+          oldKeywordObject: {
+            Category: 'D - F',
+            ShortName: 'ESIP'
+          },
+          // Providing a single segment and NO newLongName
+          // results in normalizedSegments[1] (LongName) being undefined
+          newKeywordObject: {
+            Category: 'M - O',
+            ShortName: 'ONLY_SHORT'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // 1. Verify ShortName was updated
+    expect(result.correctedMetadata).toContain('<ShortName>ONLY_SHORT</ShortName>')
+
+    // 2. Verify the OLD LongName for Project 0 is gone
+    expect(result.correctedMetadata).not.toContain('Earth Science Information Partners Program')
+
+    // 3. Verify that Project 1 still HAS its LongName (proving we didn't delete everything)
+    expect(result.correctedMetadata).toContain('<LongName>Aliens in Antarctica</LongName>')
+  })
+
+  test('should match by old keyword path even when a stale ummPath is present', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithProjects,
+      corrections: [
+        {
+          scheme: 'projects',
+          action: 'replace',
+          ummPath: ['Project', 10],
+          oldKeywordObject: {
+            Category: 'D - F',
+            ShortName: 'ESIP'
+          },
+          newKeywordObject: {
+            Category: 'D - F',
+            ShortName: 'ESIP-7'
+          },
+          newLongName: 'Updated Earth Science Information Partners Program'
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctedMetadata).toContain('<ShortName>ESIP-7</ShortName>')
+  })
+
+  describe('when guard clauses prevent a correction', () => {
+    test('should return false if oldKeywordObject is missing', async () => {
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: mockEcho10WithProjects,
+        corrections: [{
+          scheme: 'projects'
+        }]
+      })
+
+      expect(result.correctionCount).toBe(0)
+    })
+
+    test('should return false if Project tag is missing from metadata', async () => {
+      const xmlWithoutProject = '<Collection><ShortName>TEST</ShortName></Collection>'
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: xmlWithoutProject,
+        corrections: [{
+          scheme: 'projects'
+        }]
+      })
+
+      expect(result.correctionCount).toBe(0)
+    })
+
+    test('should return false if the current project path cannot be matched', async () => {
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: mockEcho10WithProjects,
+        corrections: [{
+          scheme: 'projects',
+          oldKeywordObject: {
+            Category: 'S - U',
+            ShortName: 'NOT-REAL'
+          }
+        }]
+      })
+
+      expect(result.correctionCount).toBe(0)
+    })
+
+    test('should return false for unsupported action', async () => {
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: mockEcho10WithProjects,
+        corrections: [{
+          scheme: 'projects',
+          action: 'invalid_action'
+        }]
+      })
+
+      expect(result.correctionCount).toBe(0)
+    })
+  })
+})
+
+const mockEcho10WithProviders = `<Collection>
+    <ShortName>Providers_Test</ShortName>
+    <VersionId>001</VersionId>
+    <Contacts>
+        <Contact>
+            <Role>PROCESSOR</Role>
+            <OrganizationName>NASA/MSFC/AMSR-E SIPS</OrganizationName>
+        </Contact>
+        <Contact>
+            <Role>ARCHIVER</Role>
+            <OrganizationName>NSIDC</OrganizationName>
+        </Contact>
+        <Contact>
+            <Role>ACADEMIC</Role>
+            <OrganizationName>BROWN/GEO</OrganizationName>
+            <HoursOfService>0800-1600</HoursOfService>
+            <Instructions>In addition to the address below there are other ESIC offices throught the country. Afull list of these offices is at:&lt;URL: http://www-nmd.usgs.gov/esic/esic_index.html&gt;</Instructions>
+            <ContactPersons>
+                <ContactPerson>
+                    <FirstName>Customer</FirstName>
+                    <MiddleName>Services</MiddleName>
+                    <LastName>Representative</LastName>
+                    <JobPosition>DATA CENTER CONTACT</JobPosition>
+                </ContactPerson>
+            </ContactPersons>
+        </Contact>
+        <Contact>
+            <Role>COMMERCIAL</Role>
+            <OrganizationName>ESRI-CANADA</OrganizationName>
+            <HoursOfService>0800-1630</HoursOfService>
+            <Instructions>In addition to the address below there are other ESIC offices throught the country. Afull list of these offices is at:&lt;URL: http://www-nmd.usgs.gov/esic/esic_index.html&gt;</Instructions>
+            <ContactPersons>
+                <ContactPerson>
+                    <LastName>Not provided</LastName>
+                    <JobPosition>DATA CENTER CONTACT</JobPosition>
+                </ContactPerson>
+            </ContactPersons>
+        </Contact>
+    </Contacts>
+    <ProcessingCenter>NASA/MSFC/AMSR-E SIPS</ProcessingCenter>
+    <ArchiveCenter>NSIDC</ArchiveCenter>
+</Collection>`
+
+describe('when applying provider ECHO10 corrections', () => {
+  test('should update the short name for COMMERCIAL only', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithProviders,
+      corrections: [
+        {
+          scheme: 'providers',
+          action: 'replace',
+          oldKeywordObject: {
+            BucketLevel0: 'COMMERCIAL',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'ESRI-CANADA'
+          },
+          newKeywordObject: {
+            BucketLevel0: 'COMMERCIAL',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'ESRI2-CANADA'
+          },
+          newLongName: 'Environmental Systems Research Institute 2, Inc. - Canada'
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Verify short name was updated
+    expect(result.correctedMetadata).toContain('<OrganizationName>ESRI2-CANADA</OrganizationName>')
+    expect(result.correctedMetadata).not.toContain('<OrganizationName>ESRI-CANADA</OrganizationName>')
+
+    // Verify ProcesssingCenter and ArchiveCenter were not updated
+    expect(result.correctedMetadata).toContain('<ProcessingCenter>NASA/MSFC/AMSR-E SIPS</ProcessingCenter>')
+    expect(result.correctedMetadata).toContain('<ArchiveCenter>NSIDC</ArchiveCenter>')
+  })
+
+  test('should update the short name for PROCESSOR and ProcessingCenter', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithProviders,
+      corrections: [
+        {
+          scheme: 'providers',
+          action: 'replace',
+          oldKeywordObject: {
+            BucketLevel0: 'PROCESSOR',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'NASA/MSFC/AMSR-E SIPS'
+          },
+          newKeywordObject: {
+            BucketLevel0: 'PROCESSOR',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'NASA/MSFC/AMSR-E SIPS-UPDATED'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Verify short name was updated
+    expect(result.correctedMetadata).toContain('<OrganizationName>NASA/MSFC/AMSR-E SIPS-UPDATED</OrganizationName>')
+    expect(result.correctedMetadata).not.toContain('<OrganizationName>NASA/MSFC/AMSR-E SIPS</OrganizationName>')
+
+    // Verify ProcesssingCenter and ArchiveCenter were not updated
+    expect(result.correctedMetadata).toContain('<ProcessingCenter>NASA/MSFC/AMSR-E SIPS-UPDATED</ProcessingCenter>')
+    expect(result.correctedMetadata).toContain('<ArchiveCenter>NSIDC</ArchiveCenter>')
+  })
+
+  test('should update the short name for ARCHIVER and ArchiveCenter', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithProviders,
+      corrections: [
+        {
+          scheme: 'providers',
+          action: 'replace',
+          oldKeywordObject: {
+            BucketLevel0: 'ARCHIVER',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'NSIDC'
+          },
+          newKeywordObject: {
+            BucketLevel0: 'ARCHIVER',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'NSIDC-UPDATED'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Verify short name was updated
+    expect(result.correctedMetadata).toContain('<OrganizationName>NSIDC-UPDATED</OrganizationName>')
+    expect(result.correctedMetadata).not.toContain('<OrganizationName>NSIDC</OrganizationName>')
+
+    // Verify ProcesssingCenter and ArchiveCenter were not updated
+    expect(result.correctedMetadata).toContain('<ProcessingCenter>NASA/MSFC/AMSR-E SIPS</ProcessingCenter>')
+    expect(result.correctedMetadata).toContain('<ArchiveCenter>NSIDC-UPDATED</ArchiveCenter>')
+  })
+
+  test('should delete Provider', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithProviders,
+      corrections: [
+        {
+          scheme: 'providers',
+          action: 'delete',
+          oldKeywordObject: {
+            BucketLevel0: 'COMMERCIAL',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'ESRI-CANADA'
+          },
+          newKeywordObject: {}
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Provider should be removed
+    expect(result.correctedMetadata).not.toContain('ESRI-CANADA')
+
+    // Other Provider should be unchanged
+    expect(result.correctedMetadata).toContain('<OrganizationName>BROWN/GEO</OrganizationName>')
+  })
+
+  test('should handle missing Provider element', async () => {
+    const xmlWithoutProvider = `<Collection>
+        <Entry_ID>
+            <ShortName>No_instrument</ShortName>
+        </Entry_ID>
+        <Platform>
+          <Type>Air-based Platforms</Type>
+          <ShortName>UC-12B</ShortName>
+          <LongName>NASA Langley Beechcraft UC-12B Huron</LongName>
+        </Platform>
+    </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: xmlWithoutProvider,
+      corrections: [
+        {
+          scheme: 'providers',
+          action: 'replace',
+          oldKeywordObject: {
+            BucketLevel0: 'COMMERCIAL',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'ESRI-CANADA'
+          },
+          newKeywordObject: {
+            BucketLevel0: 'COMMERCIAL',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'ESRI2-CANADA'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(0)
+    expect(result.correctionsApplied).toHaveLength(0)
+  })
+
+  test('should match by old keyword path even when a stale ummPath is present', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithProviders,
+      corrections: [
+        {
+          scheme: 'providers',
+          action: 'replace',
+          ummPath: ['Organization_Name', 10],
+          oldKeywordObject: {
+            BucketLevel0: 'COMMERCIAL',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'ESRI-CANADA'
+          },
+          newKeywordObject: {
+            BucketLevel0: 'COMMERCIAL',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'ESRI2-CANADA'
+          },
+          newLongName: 'Environmental Systems Research Institute 2, Inc. - Canada'
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctedMetadata).toContain('<OrganizationName>ESRI2-CANADA</OrganizationName>')
+  })
+
+  test('should return false when the current provider path cannot be matched', async () => {
+    // Organization block without the Organization_Name child
+    const missingNameXml = `<Collection>
+        <Organization>
+            <Organization_Type>ARCHIVER</Organization_Type>
+        </Organization>
+      </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: missingNameXml,
+      corrections: [{
+        scheme: 'providers',
+        action: 'replace',
+        oldKeywordObject: {
+          BucketLevel0: 'ARCHIVER',
+          BucketLevel1: '',
+          BucketLevel2: '',
+          BucketLevel3: '',
+          ShortName: 'MISSING'
+        },
+        newKeywordObject: {
+          BucketLevel0: '',
+          BucketLevel1: '',
+          BucketLevel2: '',
+          BucketLevel3: '',
+          ShortName: 'SHORT'
+        },
+        newLongName: 'LONG'
+      }]
+    })
+
+    expect(result.correctionCount).toBe(0)
+    expect(result.correctedMetadata).not.toContain('<OrganizationName>SHORT</OrganizationName>')
+  })
+
+  test('should remove the Contacts key entirely when the last provider in an array is deleted', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: mockEcho10WithProviders,
+      corrections: [
+        {
+          scheme: 'providers',
+          action: 'delete',
+          oldKeywordObject: {
+            BucketLevel0: 'ACADEMIC',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'BROWN/GEO'
+          }
+        },
+        {
+          scheme: 'providers',
+          action: 'delete',
+          oldKeywordObject: {
+            BucketLevel0: 'COMMERCIAL',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'ESRI-CANADA'
+          }
+        },
+        {
+          scheme: 'providers',
+          action: 'delete',
+          oldKeywordObject: {
+            BucketLevel0: 'ARCHIVER',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'NSIDC'
+          }
+        },
+        {
+          scheme: 'providers',
+          action: 'delete',
+          oldKeywordObject: {
+            BucketLevel0: 'PROCESSOR',
+            BucketLevel1: '',
+            BucketLevel2: '',
+            BucketLevel3: '',
+            ShortName: 'NASA/MSFC/AMSR-E SIPS'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(4)
+    // This triggers: if (parent.Organization.length === 0) { delete parent.Organization }
+    expect(result.correctedMetadata).not.toContain('<Contacts>')
+  })
+
+  test('should delete the Contacts key when it contains a single object instead of an array', async () => {
+    const singleOrgXml = '<Collection><Contacts><Contact><Role>ORG</Role><OrganizationName>O</OrganizationName></Contact></Contacts></Collection>'
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: singleOrgXml,
+      corrections: [{
+        scheme: 'providers',
+        action: 'delete',
+        oldKeywordObject: {
+          BucketLevel0: 'ORG',
+          BucketLevel1: '',
+          BucketLevel2: '',
+          BucketLevel3: '',
+          ShortName: 'O'
+        }
+      }]
+    })
+
+    // This triggers the 'else' branch: delete parent.Organization
+    expect(result.correctedMetadata).not.toContain('<Contacts>')
+  })
+
+  test('should remove a specific provider field when the replacement value is empty or undefined', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: mockEcho10WithProviders,
+      corrections: [{
+        scheme: 'providers',
+        action: 'replace',
+        oldKeywordObject: {
+          BucketLevel0: 'ACADEMIC',
+          BucketLevel1: '',
+          BucketLevel2: '',
+          BucketLevel3: '',
+          ShortName: 'BROWN/GEO'
+        },
+        // Providing only one segment and no newLongName should prune the existing LongName field.
+        newKeywordObject: {
+          BucketLevel0: '',
+          BucketLevel1: '',
+          BucketLevel2: '',
+          BucketLevel3: '',
+          ShortName: 'ONLY_SHORT'
+        }
+      }]
+    })
+
+    // This triggers: } else { delete target[field] }
+    expect(result.correctedMetadata).toContain('<OrganizationName>ONLY_SHORT</OrganizationName>')
+  })
+
+  test('should return false and make no changes when an unsupported action is provided', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: mockEcho10WithProviders,
+      corrections: [{
+        scheme: 'providers',
+        action: 'invalid_action'
+      }]
+    })
+
+    // This triggers the final: return false
+    expect(result.correctionCount).toBe(0)
+  })
+})
+
+const mockEcho10WithRelatedURLs = `<Collection>
+    <ShortName>RELATED_URL_TEST</ShortName>
+    <VersionId>001</VersionId>
+    <OnlineResources>
+        <OnlineResource>
+            <URL>https://example.com/data</URL>
+            <Type>DistributionURL : GET DATA</Type>
+        </OnlineResource>
+        <OnlineResource>
+            <URL>https://example.org/opensearch</URL>
+            <Description>OpenSearch endpoint</Description>
+            <Type>DistributionURL : GET CAPABILITIES : OpenSearch</Type>
+        </OnlineResource>
+        <OnlineResource>
+            <URL>https://example.org/api</URL>
+            <Type>DistributionURL : USE SERVICE API : REST</Type>
+        </OnlineResource>
+    </OnlineResources>
+</Collection>`
+
+describe('when applying related URL content type ECHO10 corrections', () => {
+  test('should apply URL content type correction to first Related_URL', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithRelatedURLs,
+      corrections: [
+        {
+          scheme: 'rucontenttype',
+          action: 'replace',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: ''
+          }, // Last 2 segments: 'GET DATA' and ''
+          newKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET SERVICE',
+            Subtype: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctionsApplied).toHaveLength(1)
+
+    // Verify first URL's type was updated
+    expect(result.correctedMetadata).toContain('<Type>DistributionURL : GET SERVICE</Type>')
+    expect(result.correctedMetadata).not.toContain('<Type>DistributionURL : GET DATA</Type>')
+
+    // Other URLs should remain unchanged
+    expect(result.correctedMetadata).toContain('<Type>DistributionURL : GET CAPABILITIES : OpenSearch</Type>')
+    expect(result.correctedMetadata).toContain('<Type>DistributionURL : USE SERVICE API : REST</Type>')
+  })
+
+  test('should update both type and subtype and append to URLContentType', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithRelatedURLs,
+      corrections: [
+        {
+          scheme: 'rucontenttype',
+          action: 'replace',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET CAPABILITIES',
+            Subtype: 'OpenSearch'
+          }, // Last 2 segments: 'GET CAPABILITIES' and 'OpenSearch'
+          newKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET CAPABILITIES',
+            Subtype: 'OGC WMS'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Verify type was updated
+    expect(result.correctedMetadata).toContain('<Type>DistributionURL : GET CAPABILITIES : OGC WMS</Type>')
+    expect(result.correctedMetadata).not.toContain('<Type>DistributionURL : GET CAPABILITIES : OpenSearch</Type>')
+  })
+
+  test('should append subtype to URL that only had type', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithRelatedURLs,
+      corrections: [
+        {
+          scheme: 'rucontenttype',
+          action: 'replace',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: ''
+          },
+          newKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: 'DIRECT DOWNLOAD'
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    expect(result.correctedMetadata).toContain('<Type>DistributionURL : GET DATA : DIRECT DOWNLOAD</Type>')
+    expect(result.correctedMetadata).not.toContain('<Type>DistributionURL : GET DATA</Type>')
+  })
+
+  test('should remove subtype when moving to type-only', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithRelatedURLs,
+      corrections: [
+        {
+          scheme: 'rucontenttype',
+          action: 'replace',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'USE SERVICE API',
+            Subtype: 'REST'
+          },
+          newKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Type should be updated
+    const getDataMatches = result.correctedMetadata.match(/<Type>DistributionURL : GET DATA<\/Type>/g)
+    expect(getDataMatches.length).toBeGreaterThan(0)
+
+    // REST subtype should be removed from third URL
+    expect(result.correctedMetadata).not.toContain('<Type>DistributionURL : USE SERVICE API : REST</Type>')
+  })
+
+  test('should delete URL_Content_Type from Related_URL', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithRelatedURLs,
+      corrections: [
+        {
+          scheme: 'rucontenttype',
+          action: 'delete',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET CAPABILITIES',
+            Subtype: 'OpenSearch'
+          },
+          newKeywordObject: {}
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // URL_Content_Type should be removed from second Related_URL
+    expect(result.correctedMetadata).not.toContain('OpenSearch')
+
+    // The Related_URL itself should be removed too
+    expect(result.correctedMetadata).not.toContain('https://example.com/opensearch')
+
+    // Other Related_URLs should be unchanged
+    expect(result.correctedMetadata).toContain('<Type>DistributionURL : GET DATA</Type>')
+    expect(result.correctedMetadata).toContain('<Type>DistributionURL : USE SERVICE API : REST</Type>')
+  })
+
+  test('should handle single Related_URL (not array)', async () => {
+    const singleUrlXml = `<Collection>
+    <ShortName>SINGLE_URL</ShortName>
+    <OnlineResources>
+        <OnlineResource>
+            <URL>https://example.com</URL>
+            <Type>DistributionURL : VIEW PROJECT HOME PAGE</Type>
+        </OnlineResource>
+    </OnlineResources>
+</Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: singleUrlXml,
+      corrections: [
+        {
+          scheme: 'rucontenttype',
+          action: 'replace',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'VIEW PROJECT HOME PAGE',
+            Subtype: ''
+          },
+          newKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'VIEW RELATED INFORMATION',
+            Subtype: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctedMetadata).toContain('<Type>DistributionURL : VIEW RELATED INFORMATION</Type>')
+    expect(result.correctedMetadata).not.toContain('VIEW PROJECT HOME PAGE')
+  })
+
+  test('should handle missing Related_URL element', async () => {
+    const xmlWithoutRelatedURL = `<Collection>
+    <ShortName>NO_URL</ShortName>
+</Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: xmlWithoutRelatedURL,
+      corrections: [
+        {
+          scheme: 'rucontenttype',
+          action: 'replace',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: ''
+          },
+          newKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET SERVICE',
+            Subtype: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(0)
+    expect(result.correctionsApplied).toHaveLength(0)
+  })
+
+  test('should remove a specific content type field when the replacement value is empty or undefined', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: mockEcho10WithRelatedURLs,
+      corrections: [{
+        scheme: 'rucontenttype',
+        action: 'replace',
+        oldKeywordObject: {
+          URLContentType: 'DistributionURL',
+          Type: 'GET CAPABILITIES',
+          Subtype: 'OpenSearch'
+        },
+        newKeywordObject: {
+          URLContentType: '',
+          Type: 'JUST_A_TYPE',
+          Subtype: ''
+        } // Last 2 segments: 'JUST_A_TYPE' and ''
+      }]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // 1. Verify the specific target was updated
+    expect(result.correctedMetadata).toContain('<Type>JUST_A_TYPE</Type>')
+
+    // 2. Verify the specific OLD Type is gone
+    expect(result.correctedMetadata).not.toContain('<Type>DistributionURL : GET CAPABILITIES : OpenSearch</Type>')
+
+    // 3. Verify that other Subtypes in different blocks are UNTOUCHED
+    expect(result.correctedMetadata).toContain('<Type>DistributionURL : GET DATA</Type>')
+    expect(result.correctedMetadata).toContain('<Type>DistributionURL : USE SERVICE API : REST</Type>')
+  })
+
+  test('should return false and make no changes when an unsupported action is provided', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: mockEcho10WithRelatedURLs,
+      corrections: [{
+        scheme: 'rucontenttype',
+        action: 'unsupported_action',
+        oldKeywordObject: {
+          URLContentType: 'DistributionURL',
+          Type: 'GET DATA',
+          Subtype: ''
+        }
+      }]
+    })
+
+    expect(result.correctionCount).toBe(0)
+  })
+
+  test('should return false when oldKeywordObject does not match any current elements', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10WithRelatedURLs,
+      corrections: [
+        {
+          scheme: 'rucontenttype',
+          action: 'replace',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'NOT_REAL_TYPE',
+            Subtype: ''
+          }, // Will not find a value match
+          newKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET SERVICE',
+            Subtype: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(0)
+    expect(result.correctionsApplied).toHaveLength(0)
+  })
+
+  test('should preserve existing element attributes when replacing the text content', async () => {
+    const xmlWithAttributes = `<Collection>
+        <OnlineResources>
+            <OnlineResource>
+                <URL>https://example.com/data</URL>
+                <Type>GET DATA</Type>
+            </OnlineResource>
+        </OnlineResources>
+    </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: xmlWithAttributes,
+      corrections: [
+        {
+          scheme: 'rucontenttype',
+          action: 'replace',
+          oldKeywordObject: {
+            Type: 'GET DATA',
+            Subtype: ''
+          },
+          newKeywordObject: {
+            Type: 'GET SERVICE',
+            Subtype: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctedMetadata).toContain('<Type>GET SERVICE</Type>')
+    expect(result.correctedMetadata).not.toContain('<Type>GET DATA</Type>')
+  })
+})
+
+const mockEcho10Xml = `<Collection>
+    <ShortName>DEM_100M</ShortName>
+    <VersionId>001</VersionId>
+    <ScienceKeywords>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>LAND SURFACE</TopicKeyword>
+            <TermKeyword>TOPOGRAPHY</TermKeyword>
+            <VariableLevel1Keyword>
+                <Value>LANDFORMS</Value>
+                <VariableLevel2Keyword>
+                    <Value>DEM</Value>
+                </VariableLevel2Keyword>
+            </VariableLevel1Keyword>
+        </ScienceKeyword>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>LAND SURFACE</TopicKeyword>
+            <TermKeyword>TOPOGRAPHY</TermKeyword>
+            <VariableLevel1Keyword>
+                <Value>TERRAIN ELEVATION</Value>
+                <VariableLevel2Keyword>
+                    <Value>DIGITAL TERRAIN MODEL</Value>
+                </VariableLevel2Keyword>
+            </VariableLevel1Keyword>
+        </ScienceKeyword>
+    </ScienceKeywords>
+    <Platforms>
+        <Platform>
+            <ShortName>Not provided</ShortName>
+            <Type>Not provided</Type>
+        </Platform>
+    </Platforms>
+</Collection>`
+
+const mockSimpleEcho10Xml = `<Collection>
+    <ShortName>TEST_COLLECTION</ShortName>
+    <ScienceKeywords>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>ATMOSPHERE</TopicKeyword>
+            <TermKeyword>AEROSOLS</TermKeyword>
+            <VariableLevel1Keyword>
+                <Value>LEGACY AEROSOLS</Value>
+            </VariableLevel1Keyword>
+        </ScienceKeyword>
+    </ScienceKeywords>
+</Collection>`
+
+describe('when applying science keyword ECHO10 corrections', () => {
+  test('should apply science keyword renaming correction (same hierarchy, different name)', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockSimpleEcho10Xml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'replace',
+          ummPath: ['Science_Keywords', 0],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'ATMOSPHERE',
+            Term: 'AEROSOLS',
+            VariableLevel1: 'LEGACY AEROSOLS',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'ATMOSPHERE',
+            Term: 'AEROSOLS',
+            VariableLevel1: 'AEROSOLS RENAMED',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctionsApplied).toHaveLength(1)
+    expect(result.stubbed).toBe(false)
+
+    // Verify the corrected XML contains the renamed keyword
+    expect(result.correctedMetadata).toContain('<CategoryKeyword>EARTH SCIENCE</CategoryKeyword>')
+    expect(result.correctedMetadata).toContain('<TopicKeyword>ATMOSPHERE</TopicKeyword>')
+    expect(result.correctedMetadata).toContain('<TermKeyword>AEROSOLS</TermKeyword>')
+    expect(result.correctedMetadata).toContain('<Value>AEROSOLS RENAMED</Value>')
+    // Old name should be gone
+    expect(result.correctedMetadata).not.toContain('LEGACY AEROSOLS')
+  })
+
+  test('should apply science keyword hierarchy move (same name, different topic)', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockSimpleEcho10Xml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'replace',
+          ummPath: ['Science_Keywords', 0],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'ATMOSPHERE',
+            Term: 'AEROSOLS',
+            VariableLevel1: 'LEGACY AEROSOLS',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'AIR QUALITY',
+            Term: 'AEROSOLS',
+            VariableLevel1: 'LEGACY AEROSOLS',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctionsApplied).toHaveLength(1)
+
+    // Verify the keyword moved to the new topic
+    expect(result.correctedMetadata).toContain('<CategoryKeyword>EARTH SCIENCE</CategoryKeyword>')
+    expect(result.correctedMetadata).toContain('<TopicKeyword>AIR QUALITY</TopicKeyword>')
+    expect(result.correctedMetadata).toContain('<TermKeyword>AEROSOLS</TermKeyword>')
+    expect(result.correctedMetadata).toContain('<Value>LEGACY AEROSOLS</Value>')
+    // Old topic should be gone
+    expect(result.correctedMetadata).not.toContain('ATMOSPHERE')
+  })
+
+  test('should apply hierarchy move with renaming at same level', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10Xml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'replace',
+          ummPath: ['Science_Keywords', 0],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'LAND SURFACE',
+            Term: 'TOPOGRAPHY',
+            VariableLevel1: 'LANDFORMS',
+            VariableLevel2: 'DEM',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'LAND SURFACE',
+            Term: 'ELEVATION',
+            VariableLevel1: 'TERRAIN FEATURES',
+            VariableLevel2: 'DIGITAL ELEVATION MODEL',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctionsApplied).toHaveLength(1)
+
+    // Verify new hierarchy
+    expect(result.correctedMetadata).toContain('<CategoryKeyword>EARTH SCIENCE</CategoryKeyword>')
+    expect(result.correctedMetadata).toContain('<TopicKeyword>LAND SURFACE</TopicKeyword>')
+    expect(result.correctedMetadata).toContain('<TermKeyword>ELEVATION</TermKeyword>')
+    expect(result.correctedMetadata).toContain('<Value>TERRAIN FEATURES</Value>')
+    expect(result.correctedMetadata).toContain('<Value>DIGITAL ELEVATION MODEL</Value>')
+
+    // Old values should be gone from first keyword (second keyword still has TOPOGRAPHY)
+    const topographyMatches = result.correctedMetadata.match(/<TermKeyword>TOPOGRAPHY<\/TermKeyword>/g)
+    expect(topographyMatches).toHaveLength(1) // Only in second keyword
+    expect(result.correctedMetadata).not.toContain('LANDFORMS')
+  })
+
+  test('should apply correction to second keyword in array', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10Xml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'replace',
+          ummPath: ['Science_Keywords', 1],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'LAND SURFACE',
+            Term: 'TOPOGRAPHY',
+            VariableLevel1: 'TERRAIN ELEVATION',
+            VariableLevel2: 'DIGITAL TERRAIN MODEL',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'LAND SURFACE',
+            Term: 'TOPOGRAPHY',
+            VariableLevel1: 'ELEVATION DATA',
+            VariableLevel2: 'DIGITAL ELEVATION DATA',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctionsApplied).toHaveLength(1)
+
+    // First keyword should remain unchanged
+    expect(result.correctedMetadata).toContain('LANDFORMS')
+    expect(result.correctedMetadata).toContain('<Value>DEM</Value>')
+
+    // Second keyword should be updated with new names
+    expect(result.correctedMetadata).toContain('<Value>ELEVATION DATA</Value>')
+    expect(result.correctedMetadata).toContain('<Value>DIGITAL ELEVATION DATA</Value>')
+    // Old values should be gone
+    expect(result.correctedMetadata).not.toContain('TERRAIN ELEVATION')
+    expect(result.correctedMetadata).not.toContain('DIGITAL TERRAIN MODEL')
+  })
+
+  test('should remove science keyword when delete action is applied', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10Xml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'delete',
+          ummPath: ['Science_Keywords', 0],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'LAND SURFACE',
+            Term: 'TOPOGRAPHY',
+            VariableLevel1: 'LANDFORMS',
+            VariableLevel2: 'DEM',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {}
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctionsApplied).toHaveLength(1)
+
+    // First keyword should be removed
+    expect(result.correctedMetadata).not.toContain('LANDFORMS')
+    expect(result.correctedMetadata).not.toContain('<Value>DEM</Value>')
+
+    // Second keyword should remain
+    expect(result.correctedMetadata).toContain('TERRAIN ELEVATION')
+    expect(result.correctedMetadata).toContain('DIGITAL TERRAIN MODEL')
+  })
+
+  test('should remove second science keyword when delete action is applied', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10Xml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'delete',
+          ummPath: ['Science_Keywords', 1],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'LAND SURFACE',
+            Term: 'TOPOGRAPHY',
+            VariableLevel1: 'TERRAIN ELEVATION',
+            VariableLevel2: 'DIGITAL TERRAIN MODEL',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {}
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // First keyword should remain
+    expect(result.correctedMetadata).toContain('LANDFORMS')
+    expect(result.correctedMetadata).toContain('DEM')
+
+    // Second keyword should be removed
+    expect(result.correctedMetadata).not.toContain('TERRAIN ELEVATION')
+    expect(result.correctedMetadata).not.toContain('DIGITAL TERRAIN MODEL')
+  })
+
+  test('should delete parent Science_Keywords property when the last keyword in an array is removed', async () => {
+    const multiKeywordXml = `<Collection>
+    <ScienceKeywords>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>ATMOSPHERE</TopicKeyword>
+            <TermKeyword>AEROSOLS</TermKeyword>
+        </ScienceKeyword>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>OCEANS</TopicKeyword>
+            <TermKeyword>MARINE SEDIMENTS</TermKeyword>
+        </ScienceKeyword>
+    </ScienceKeywords>
+  </Collection>`
+
+    // Since lookups are by path format value string, we specify the exact old keyword path values
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: multiKeywordXml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'delete',
+          ummPath: ['ScienceKeywords', 0],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'ATMOSPHERE',
+            Term: 'AEROSOLS',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        },
+        {
+          scheme: 'sciencekeywords',
+          action: 'delete',
+          ummPath: ['ScienceKeywords', 1],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'OCEANS',
+            Term: 'MARINE SEDIMENTS',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(2)
+    // Verify the entire container is gone from the XML
+    expect(result.correctedMetadata).not.toContain('<ScienceKeywords>')
+    expect(result.correctedMetadata).not.toContain('</ScienceKeywords>')
+  })
+
+  test('should return false when an unsupported action is provided', async () => {
+    const singleScienceKeywordXml = `<Collection>
+      <ScienceKeywords>
+          <ScienceKeyword>
+              <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+              <TopicKeyword>ATMOSPHERE</TopicKeyword>
+              <TermKeyword>AEROSOLS</TermKeyword>
+          </ScienceKeyword>
+      </ScienceKeywords>
+  </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      metadataPayload: singleScienceKeywordXml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'invalid_action_type', // Neither 'replace' nor 'delete'
+          ummPath: ['ScienceKeywords', 0],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'ATMOSPHERE',
+            Term: 'AEROSOLS',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'OCEANS',
+            Term: 'MARINE SEDIMENTS',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        }
+      ]
+    })
+
+    // The delegate returns false, so the orchestrator does not increment the count
+    expect(result.correctionCount).toBe(0)
+    expect(result.correctionsApplied).toHaveLength(0)
+  })
+
+  test('should apply multiple science keyword corrections (mix of rename and move)', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10Xml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'replace',
+          ummPath: ['Science_Keywords', 0],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'LAND SURFACE',
+            Term: 'TOPOGRAPHY',
+            VariableLevel1: 'LANDFORMS',
+            VariableLevel2: 'DEM',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'LAND SURFACE',
+            Term: 'TOPOGRAPHY',
+            VariableLevel1: 'LANDFORMS',
+            VariableLevel2: 'DIGITAL ELEVATION MODEL',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        },
+        {
+          scheme: 'sciencekeywords',
+          action: 'replace',
+          ummPath: ['Science_Keywords', 1],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'LAND SURFACE',
+            Term: 'TOPOGRAPHY',
+            VariableLevel1: 'TERRAIN ELEVATION',
+            VariableLevel2: 'DIGITAL TERRAIN MODEL',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'TERRESTRIAL HYDROSPHERE',
+            Term: 'SURFACE WATER',
+            VariableLevel1: 'ELEVATION',
+            VariableLevel2: 'DTM',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(2)
+    expect(result.correctionsApplied).toHaveLength(2)
+
+    // First keyword: renamed DEM to DIGITAL ELEVATION MODEL
+    expect(result.correctedMetadata).toContain('LANDFORMS')
+    expect(result.correctedMetadata).toContain('<Value>DIGITAL ELEVATION MODEL</Value>')
+
+    // Second keyword: moved to completely different hierarchy
+    expect(result.correctedMetadata).toContain('TERRESTRIAL HYDROSPHERE')
+    expect(result.correctedMetadata).toContain('SURFACE WATER')
+    expect(result.correctedMetadata).toContain('<Value>DTM</Value')
+    expect(result.correctedMetadata).not.toContain('DIGITAL TERRAIN MODEL')
+  })
+
+  test('should apply term-level rename within same category and topic', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10Xml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'replace',
+          ummPath: ['Science_Keywords', 0],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'LAND SURFACE',
+            Term: 'TOPOGRAPHY',
+            VariableLevel1: 'LANDFORMS',
+            VariableLevel2: 'DEM',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'LAND SURFACE',
+            Term: 'SURFACE TOPOGRAPHY',
+            VariableLevel1: 'LANDFORMS',
+            VariableLevel2: 'DEM',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Verify term changed from TOPOGRAPHY to SURFACE TOPOGRAPHY
+    expect(result.correctedMetadata).toContain('<TermKeyword>SURFACE TOPOGRAPHY</TermKeyword>')
+    expect(result.correctedMetadata).toContain('LANDFORMS')
+    expect(result.correctedMetadata).toContain('DEM')
+
+    // Old term should still exist in second keyword
+    const topographyMatches = result.correctedMetadata.match(/<TermKeyword>TOPOGRAPHY<\/TermKeyword>/g)
+    expect(topographyMatches).toHaveLength(1) // Only in second keyword
+  })
+
+  test('should apply category-level change (moving keyword to different category)', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockSimpleEcho10Xml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'replace',
+          ummPath: ['Science_Keywords', 0],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'ATMOSPHERE',
+            Term: 'AEROSOLS',
+            VariableLevel1: 'LEGACY AEROSOLS',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {
+            Category: 'EARTH SCIENCE SERVICES',
+            Topic: 'DATA ANALYSIS AND VISUALIZATION',
+            Term: 'AEROSOL ANALYSIS',
+            VariableLevel1: 'LEGACY AEROSOLS',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // Verify category changed completely
+    expect(result.correctedMetadata).toContain('<CategoryKeyword>EARTH SCIENCE SERVICES</CategoryKeyword>')
+    expect(result.correctedMetadata).toContain('<TopicKeyword>DATA ANALYSIS AND VISUALIZATION</TopicKeyword>')
+    expect(result.correctedMetadata).toContain('<TermKeyword>AEROSOL ANALYSIS</TermKeyword>')
+    expect(result.correctedMetadata).toContain('<Value>LEGACY AEROSOLS</Value>')
+
+    // Old category should be gone
+    expect(result.correctedMetadata).not.toContain('<CategoryKeyword>EARTH SCIENCE</CategoryKeyword>')
+    expect(result.correctedMetadata).not.toContain('ATMOSPHERE')
+  })
+
+  test('should handle single science keyword (not array) with replacement', async () => {
+    const singleKeywordXml = `<Collection>
+    <ShortName>SINGLE_KEYWORD</ShortName>
+    <ScienceKeywords>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>ATMOSPHERE</TopicKeyword>
+            <TermKeyword>CLOUDS</TermKeyword>
+        </ScienceKeyword>
+    </ScienceKeywords>
+</Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: singleKeywordXml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'replace',
+          ummPath: ['Science_Keywords', 0],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'ATMOSPHERE',
+            Term: 'CLOUDS',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'ATMOSPHERE',
+            Term: 'CLOUD PROPERTIES',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctedMetadata).toContain('CLOUD PROPERTIES')
+    expect(result.correctedMetadata).not.toContain('<TermKeyword>CLOUDS</TermKeyword>')
+  })
+
+  test('should delete only science keyword and removes Science_Keywords element', async () => {
+    const singleKeywordXml = `<Collection>
+    <ShortName>DELETE_ONLY_KEYWORD</ShortName>
+    <ScienceKeywords>
+        <ScienceKeyword>
+            <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+            <TopicKeyword>ATMOSPHERE</TopicKeyword>
+        </ScienceKeyword>
+    </ScienceKeywords>
+</Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: singleKeywordXml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'delete',
+          ummPath: ['Science_Keywords', 0],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'ATMOSPHERE',
+            Term: '',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {}
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    // Science_Keywords element should be completely removed
+    expect(result.correctedMetadata).not.toContain('ScienceKeywords')
+    expect(result.correctedMetadata).not.toContain('ATMOSPHERE')
+  })
+
+  test('should handle multiple deletes reducing array to single element', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockEcho10Xml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'delete',
+          ummPath: ['Science_Keywords', 1],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'LAND SURFACE',
+            Term: 'TOPOGRAPHY',
+            VariableLevel1: 'TERRAIN ELEVATION',
+            VariableLevel2: 'DIGITAL TERRAIN MODEL',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {}
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+
+    // First keyword remains
+    expect(result.correctedMetadata).toContain('LANDFORMS')
+    expect(result.correctedMetadata).toContain('DEM')
+
+    // Second keyword deleted
+    expect(result.correctedMetadata).not.toContain('TERRAIN ELEVATION')
+    expect(result.correctedMetadata).not.toContain('DIGITAL TERRAIN MODEL')
+  })
+
+  test('should skip correction when keyword path does not match any items in document', async () => {
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: mockSimpleEcho10Xml,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'replace',
+          ummPath: ['Science_Keywords', 0],
+          // This path does not exist in mockSimpleEcho10Xml, so lookup fails
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'NON_EXISTENT_TOPIC',
+            Term: 'AEROSOLS',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'AIR QUALITY',
+            Term: 'AEROSOLS',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(0)
+    expect(result.correctionsApplied).toHaveLength(0)
+
+    // Original XML should be unchanged
+    expect(result.correctedMetadata).toContain('LEGACY AEROSOLS')
+  })
+
+  test('should handle missing Science_Keywords element', async () => {
+    const xmlWithoutKeywords = `<Collection>
+    <ShortName>NO_KEYWORDS</ShortName>
+</Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: xmlWithoutKeywords,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'replace',
+          ummPath: ['Science_Keywords', 0],
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'ATMOSPHERE',
+            Term: '',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'AIR QUALITY',
+            Term: '',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(0)
+    expect(result.correctionsApplied).toHaveLength(0)
+  })
+
+  test('should handle science keywords where leaves are parsed as objects with a #text property', async () => {
+    // Simulating an XML snippet where an attribute or formatting causes
+    // fast-xml-parser to turn a node into an object structure rather than a raw string
+    const xmlWithComplexNodes = `<Collection>
+      <ShortName>COMPLEX_LEAF_TEST</ShortName>
+      <ScienceKeywords>
+          <ScienceKeyword>
+              <CategoryKeyword>EARTH SCIENCE</CategoryKeyword>
+              <TopicKeyword>ATMOSPHERE</TopicKeyword>
+              <TermKeyword>CLOUDS</TermKeyword>
+          </ScienceKeyword>
+      </ScienceKeywords>
+  </Collection>`
+
+    const result = await applyEcho10MetadataCorrections({
+      collectionConceptId: 'C1',
+      providerId: 'PROV',
+      nativeId: 'native-1',
+      metadataPayload: xmlWithComplexNodes,
+      corrections: [
+        {
+          scheme: 'sciencekeywords',
+          action: 'replace',
+          ummPath: ['Science_Keywords', 0],
+          // This should match despite <CategoryKeyword> being parsed as an object internally
+          oldKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'ATMOSPHERE',
+            Term: 'CLOUDS',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          },
+          newKeywordObject: {
+            Category: 'EARTH SCIENCE',
+            Topic: 'ATMOSPHERE',
+            Term: 'CLOUD PROPERTIES',
+            VariableLevel1: '',
+            VariableLevel2: '',
+            VariableLevel3: '',
+            DetailedVariable: ''
+          }
+        }
+      ]
+    })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.correctionsApplied).toHaveLength(1)
+
+    // Verify the substitution took place seamlessly
+    expect(result.correctedMetadata).toContain('<TermKeyword>CLOUD PROPERTIES</TermKeyword>')
+    expect(result.correctedMetadata).not.toContain('<TermKeyword>CLOUDS</TermKeyword>')
+  })
+})

--- a/serverless/src/shared/__tests__/applyEcho10MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyEcho10MetadataCorrections.test.js
@@ -1551,6 +1551,24 @@ describe('when applying Dataformat ECHO10 corrections', () => {
       expect(result.correctionCount).toBe(0)
     })
 
+    test('should return true and add a new node if the DataFormat is not present', async () => {
+      const noProcessingLevelXml = '<Collection></Collection>'
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: noProcessingLevelXml,
+        corrections: [{
+          scheme: 'dataformat',
+          action: 'replace',
+          newKeywordObject: {
+            Value: 'HDF5'
+          }
+        }]
+      })
+
+      expect(result.correctionCount).toBe(1)
+
+      expect(result.correctedMetadata).toContain('<DataFormat>HDF5</DataFormat>')
+    })
+
     test('should return false if an unknown action type is provided', async () => {
       const result = await applyEcho10MetadataCorrections({
         metadataPayload: mockEcho10WithDataFormat,
@@ -1637,7 +1655,7 @@ describe('when applying ProcessingLevelId ECHO10 corrections', () => {
     })
 
     test('should return false if trying to delete a ProcessingLevelId that does not exist', async () => {
-      const missingFieldXml = '<Collection><Entry_ID><ShortName>TEST</ShortName></Entry_ID></Collection>'
+      const missingFieldXml = '<Collection><ShortName>TEST</ShortName></Collection>'
       const result = await applyEcho10MetadataCorrections({
         metadataPayload: missingFieldXml,
         corrections: [{
@@ -1681,6 +1699,24 @@ describe('when applying ProcessingLevelId ECHO10 corrections', () => {
       })
 
       expect(result.correctionCount).toBe(0)
+    })
+
+    test('should return true and add a new node if the ProcessingLevelId is not present', async () => {
+      const noProcessingLevelXml = '<Collection></Collection>'
+      const result = await applyEcho10MetadataCorrections({
+        metadataPayload: noProcessingLevelXml,
+        corrections: [{
+          scheme: 'productlevelid',
+          action: 'replace',
+          newKeywordObject: {
+            Value: 'Level 4'
+          }
+        }]
+      })
+
+      expect(result.correctionCount).toBe(1)
+
+      expect(result.correctedMetadata).toContain('<ProcessingLevelId>Level 4</ProcessingLevelId>')
     })
 
     test('should return false if an unknown action type is provided', async () => {

--- a/serverless/src/shared/__tests__/invokeMetadataCorrectionDelegate.test.js
+++ b/serverless/src/shared/__tests__/invokeMetadataCorrectionDelegate.test.js
@@ -12,6 +12,7 @@ import { applyIso19115MetadataCorrections } from '../applyIso19115MetadataCorrec
 import { applyIsoSmapMetadataCorrections } from '../applyIsoSmapMetadataCorrections'
 import { applyUmmMetadataCorrections } from '../applyUmmMetadataCorrections'
 import { invokeMetadataCorrectionDelegate } from '../invokeMetadataCorrectionDelegate'
+import { logger } from '../logger'
 
 vi.mock('../applyUmmMetadataCorrections', () => ({
   applyUmmMetadataCorrections: vi.fn()
@@ -31,6 +32,12 @@ vi.mock('../applyEcho10MetadataCorrections', () => ({
 
 vi.mock('../applyDif10MetadataCorrections', () => ({
   applyDif10MetadataCorrections: vi.fn()
+}))
+
+vi.mock('../logger', () => ({
+  logger: {
+    error: vi.fn()
+  }
 }))
 
 const createExpectedCorrection = (correction = {}) => ({
@@ -272,6 +279,204 @@ describe('invokeMetadataCorrectionDelegate', () => {
         })
       ]
     })
+  })
+
+  test('skips replace corrections when the replacement object is empty', async () => {
+    vi.mocked(applyEcho10MetadataCorrections).mockResolvedValue({ delegateName: 'echo10' })
+
+    await expect(invokeMetadataCorrectionDelegate({
+      nativeFormat: 'ECHO10',
+      collectionConceptId: 'C1',
+      corrections: [
+        {
+          scheme: 'rucontenttype',
+          action: 'replace',
+          keywordConceptUuid: 'uuid-1',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: ''
+          },
+          newKeywordObject: {}
+        }
+      ]
+    })).resolves.toEqual({ delegateName: 'echo10' })
+
+    expect(applyEcho10MetadataCorrections).toHaveBeenCalledWith({
+      collectionConceptId: 'C1',
+      corrections: []
+    })
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[metadata-correction] Skipping invalid replacement correction payload',
+      expect.objectContaining({
+        scheme: 'rucontenttype',
+        action: 'replace',
+        keywordConceptUuid: 'uuid-1'
+      })
+    )
+  })
+
+  test('skips whitespace-only replace corrections when the replacement object has no meaningful values', async () => {
+    vi.mocked(applyEcho10MetadataCorrections).mockResolvedValue({ delegateName: 'echo10' })
+
+    await invokeMetadataCorrectionDelegate({
+      nativeFormat: 'ECHO10',
+      collectionConceptId: 'C1',
+      corrections: [
+        {
+          scheme: 'rucontenttype',
+          action: 'replace',
+          keywordConceptUuid: 'uuid-1',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: ''
+          },
+          newKeywordObject: {
+            URLContentType: '',
+            Type: '   ',
+            Subtype: ''
+          }
+        }
+      ]
+    })
+
+    expect(applyEcho10MetadataCorrections).toHaveBeenCalledWith({
+      collectionConceptId: 'C1',
+      corrections: []
+    })
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[metadata-correction] Skipping invalid replacement correction payload',
+      expect.objectContaining({
+        scheme: 'rucontenttype',
+        action: 'replace',
+        keywordConceptUuid: 'uuid-1'
+      })
+    )
+  })
+
+  test('preserves rucontenttype delete corrections even when the replacement object is empty', async () => {
+    vi.mocked(applyEcho10MetadataCorrections).mockResolvedValue({ delegateName: 'echo10' })
+
+    await invokeMetadataCorrectionDelegate({
+      nativeFormat: 'ECHO10',
+      collectionConceptId: 'C1',
+      corrections: [
+        {
+          scheme: 'rucontenttype',
+          action: 'delete',
+          keywordConceptUuid: 'uuid-1',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: ''
+          },
+          newKeywordObject: {}
+        }
+      ]
+    })
+
+    expect(applyEcho10MetadataCorrections).toHaveBeenCalledWith({
+      collectionConceptId: 'C1',
+      corrections: [
+        createExpectedCorrection({
+          scheme: 'rucontenttype',
+          action: 'delete',
+          keywordConceptUuid: 'uuid-1',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: ''
+          },
+          newKeywordObject: {}
+        })
+      ]
+    })
+  })
+
+  test('preserves rucontenttype replacements when the replacement object contains a meaningful value', async () => {
+    vi.mocked(applyEcho10MetadataCorrections).mockResolvedValue({ delegateName: 'echo10' })
+
+    await invokeMetadataCorrectionDelegate({
+      nativeFormat: 'ECHO10',
+      collectionConceptId: 'C1',
+      corrections: [
+        {
+          scheme: 'rucontenttype',
+          action: 'replace',
+          keywordConceptUuid: 'uuid-1',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: ''
+          },
+          newKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: 'EARTHDATA SEARCH'
+          }
+        }
+      ]
+    })
+
+    expect(applyEcho10MetadataCorrections).toHaveBeenCalledWith({
+      collectionConceptId: 'C1',
+      corrections: [
+        createExpectedCorrection({
+          scheme: 'rucontenttype',
+          action: 'replace',
+          keywordConceptUuid: 'uuid-1',
+          oldKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: ''
+          },
+          newKeywordObject: {
+            URLContentType: 'DistributionURL',
+            Type: 'GET DATA',
+            Subtype: 'EARTHDATA SEARCH'
+          }
+        })
+      ]
+    })
+
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  test('skips empty replacements for other schemes as well', async () => {
+    vi.mocked(applyEcho10MetadataCorrections).mockResolvedValue({ delegateName: 'echo10' })
+
+    await invokeMetadataCorrectionDelegate({
+      nativeFormat: 'ECHO10',
+      collectionConceptId: 'C1',
+      corrections: [
+        {
+          scheme: 'providers',
+          action: 'replace',
+          keywordConceptUuid: 'uuid-2',
+          oldKeywordObject: {
+            ShortName: 'NSIDC'
+          },
+          newKeywordObject: {}
+        }
+      ]
+    })
+
+    expect(applyEcho10MetadataCorrections).toHaveBeenCalledWith({
+      collectionConceptId: 'C1',
+      corrections: []
+    })
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[metadata-correction] Skipping invalid replacement correction payload',
+      expect.objectContaining({
+        scheme: 'providers',
+        action: 'replace',
+        keywordConceptUuid: 'uuid-2'
+      })
+    )
   })
 
   test('routes ISO19115 to the ISO19115 delegate', async () => {

--- a/serverless/src/shared/__tests__/metadataCorrectionDelegateStubs.test.js
+++ b/serverless/src/shared/__tests__/metadataCorrectionDelegateStubs.test.js
@@ -238,20 +238,35 @@ describe('metadata correction delegate stubs', () => {
     })
   })
 
-  test('returns the expected ECHO10 delegate stub shape', async () => {
+  test('returns the expected ECHO10 no-payload shape', async () => {
     await expect(applyEcho10MetadataCorrections({
       collectionConceptId: 'C4',
       providerId: 'PROV',
       nativeId: 'native-4'
     })).resolves.toEqual({
-      nativeFormat: 'ECHO10',
-      delegateName: 'echo10',
+      correctionCount: 0,
+      stubbed: true
+    })
+  })
+
+  test('returns the expected ECHO10 no-payload shape even when corrections are provided', async () => {
+    await expect(applyDif10MetadataCorrections({
       collectionConceptId: 'C4',
       providerId: 'PROV',
       nativeId: 'native-4',
+      corrections: [
+        {
+          scheme: 'platforms',
+          action: 'replace',
+          keywordConceptUuid: 'uuid-5',
+          oldKeywordObject: HU25A_PLATFORM_KEYWORD,
+          newKeywordObject: HU25A_PLATFORM_KEYWORD,
+          oldLongName: 'Dassault HU-25A Guardian Legacy',
+          newLongName: 'Dassault HU-25A Guardian'
+        }
+      ]
+    })).resolves.toEqual({
       correctionCount: 0,
-      correctedMetadata: undefined,
-      correctionsApplied: [],
       stubbed: true
     })
   })

--- a/serverless/src/shared/applyEcho10MetadataCorrections.js
+++ b/serverless/src/shared/applyEcho10MetadataCorrections.js
@@ -1,24 +1,57 @@
+import { createEcho10Editor, ECHO10_SCHEME_EDITORS } from './echo10DomEditor'
+
 /**
- * Stub ECHO10 delegate for KMS-675.
+ * Applies ECHO10 keyword corrections through a DOM-backed editor.
  *
- * Real ECHO10 mutation is follow-on work. For now this delegate only records the handoff shape.
+ * This intentionally avoids the old "XML -> generic JS object -> rebuild whole document"
+ * flow. Instead, we parse the XML into a DOM once, locate the target ECHO10 node by its
+ * current keyword value when possible, mutate only the affected node/field, and serialize
+ * at the end. The shared XML path editor underneath is format-agnostic so the same engine
+ * can be reused by later XML-native delegates.
+ *
+ * @param {Object} params - The parameters object.
+ * @param {string} params.metadataPayload - The raw ECHO10 XML string to be corrected.
+ * @param {Array<Object>} [params.corrections=[]] - Correction instructions.
+ * @returns {Promise<Object>} Correction summary with the updated XML payload.
  */
-export const applyEcho10MetadataCorrections = async ({
-  collectionConceptId,
-  providerId,
-  nativeId,
-  metadataPayload,
-  corrections = []
-}) => ({
-  nativeFormat: 'ECHO10',
-  delegateName: 'echo10',
-  collectionConceptId,
-  providerId,
-  nativeId,
-  correctionCount: corrections.length,
-  correctedMetadata: metadataPayload,
-  correctionsApplied: corrections,
-  stubbed: true
-})
+export const applyEcho10MetadataCorrections = async (params) => {
+  const {
+    metadataPayload,
+    corrections = []
+  } = params
+
+  if (!metadataPayload) {
+    return {
+      correctionCount: 0,
+      stubbed: true
+    }
+  }
+
+  const editor = createEcho10Editor(metadataPayload)
+  const applied = corrections.reduce((acc, correction) => {
+    const scheme = String(correction.scheme || '').toLowerCase()
+    const delegate = ECHO10_SCHEME_EDITORS[scheme]
+
+    if (!delegate) {
+      return acc
+    }
+
+    const isUpdated = delegate(editor, correction)
+
+    if (isUpdated) {
+      acc.push(correction)
+    }
+
+    return acc
+  }, [])
+
+  return {
+    ...params,
+    correctionCount: applied.length,
+    correctedMetadata: editor.serialize(),
+    correctionsApplied: applied,
+    stubbed: false
+  }
+}
 
 export default applyEcho10MetadataCorrections

--- a/serverless/src/shared/echo10DomEditor.js
+++ b/serverless/src/shared/echo10DomEditor.js
@@ -1,24 +1,22 @@
 import XmlMetadataPathEditor, { sequentialValueReplace } from './XmlMetadataPathEditor'
 
-// Wrap a block-style scheme config in the shared editor contract used by the DIF10 delegate.
+// Wrap a block-style scheme config in the shared editor contract used by the ECHO10 delegate.
 const blockScheme = (config) => (editor, correction) => editor.updateBlockNode(correction, config)
-// Wrap a leaf-value scheme config in the shared editor contract used by the DIF10 delegate.
-// const leafScheme = (config) => (editor, correction) => editor.updateLeafNode(correction, config)
-// Wrap a scalar/root-field scheme config in the shared editor contract used by the DIF10 delegate.
+// Wrap a scalar/root-field scheme config in the shared editor contract used by the ECHO10 delegate.
 const scalarScheme = (config) => (editor, correction) => editor.updateScalarNode(correction, config)
 
 /**
  * ECHO10 scheme configuration for the shared XML path editor.
  *
  * The object keys here are the incoming KMS scheme names from `correction.scheme`
- * (for example `sciencekeywords`, `platforms`, or `providers`). The DIF10 delegate
+ * (for example `sciencekeywords`, `platforms`, or `providers`). The ECHO10 delegate
  * lowercases `correction.scheme` and uses it to look up the matching function in
- * this map, so these keys are dispatch identifiers, not DIF10 XML tag names.
+ * this map, so these keys are dispatch identifiers, not ECHO10 XML tag names.
  *
  * Each scheme describes:
- * - the XPath used to find candidate DIF10 nodes
+ * - the XPath used to find candidate ECHO10 nodes
  * - how to match the current normalized keyword object from XML content
- * - how replacement values map back into DIF10 fields
+ * - how replacement values map back into ECHO10 fields
  *
  * @type {Object.<string, Function>}
  */
@@ -95,10 +93,10 @@ export const ECHO10_SCHEME_EDITORS = {
   platforms: blockScheme({
     // Platform corrections are normalized into an object that can carry:
     // - Class: the GCMD platform class, for example "Space-based Platforms"
-    // - Type: DIF10 <Type>
-    // - ShortName: DIF10 <Short_Name>
+    // - Type: ECHO10 <Type>
+    // - ShortName: ECHO10 <Short_Name>
     //
-    // DIF10 Platform only persists `Type` and `ShortName`, so those are the
+    // ECHO10 Platform only persists `Type` and `ShortName`, so those are the
     // only object fields written back into the XML.
     nodeXPath: '//Collection/Platforms/Platform',
     find: {
@@ -340,9 +338,9 @@ export const ECHO10_SCHEME_EDITORS = {
 }
 
 /**
- * Creates a DOM-backed editor for a raw DIF10 XML payload.
+ * Creates a DOM-backed editor for a raw ECHO10 XML payload.
  *
- * @param {string} metadataPayload Raw DIF10 XML string.
+ * @param {string} metadataPayload Raw ECHO10 XML string.
  * @returns {XmlMetadataPathEditor} Shared XML path editor instance.
  */
 export const createEcho10Editor = (metadataPayload) => new XmlMetadataPathEditor(metadataPayload)

--- a/serverless/src/shared/echo10DomEditor.js
+++ b/serverless/src/shared/echo10DomEditor.js
@@ -1,0 +1,350 @@
+import XmlMetadataPathEditor, { sequentialValueReplace } from './XmlMetadataPathEditor'
+
+// Wrap a block-style scheme config in the shared editor contract used by the DIF10 delegate.
+const blockScheme = (config) => (editor, correction) => editor.updateBlockNode(correction, config)
+// Wrap a leaf-value scheme config in the shared editor contract used by the DIF10 delegate.
+// const leafScheme = (config) => (editor, correction) => editor.updateLeafNode(correction, config)
+// Wrap a scalar/root-field scheme config in the shared editor contract used by the DIF10 delegate.
+const scalarScheme = (config) => (editor, correction) => editor.updateScalarNode(correction, config)
+
+/**
+ * ECHO10 scheme configuration for the shared XML path editor.
+ *
+ * The object keys here are the incoming KMS scheme names from `correction.scheme`
+ * (for example `sciencekeywords`, `platforms`, or `providers`). The DIF10 delegate
+ * lowercases `correction.scheme` and uses it to look up the matching function in
+ * this map, so these keys are dispatch identifiers, not DIF10 XML tag names.
+ *
+ * Each scheme describes:
+ * - the XPath used to find candidate DIF10 nodes
+ * - how to match the current normalized keyword object from XML content
+ * - how replacement values map back into DIF10 fields
+ *
+ * @type {Object.<string, Function>}
+ */
+export const ECHO10_SCHEME_EDITORS = {
+  sciencekeywords: blockScheme({
+    nodeXPath: '//Collection/ScienceKeywords/ScienceKeyword',
+    removeEmptyParent: true,
+    find: {
+      fieldPaths: [
+        // XML fields to read from
+        'CategoryKeyword',
+        'TopicKeyword',
+        'TermKeyword',
+        'VariableLevel1Keyword/Value',
+        'VariableLevel1Keyword/VariableLevel2Keyword/Value',
+        'VariableLevel1Keyword/VariableLevel2Keyword/VariableLevel3Keyword/Value',
+        'DetailedVariableKeyword'
+      ],
+      valueKeys: [
+        // Keys from oldKeywordObject to compare against
+        'Category',
+        'Topic',
+        'Term',
+        'VariableLevel1',
+        'VariableLevel2',
+        'VariableLevel3',
+        'DetailedVariable'
+      ]
+    },
+    // Example correction input:
+    // {
+    //   scheme: 'sciencekeywords',
+    //   action: 'replace',
+    //   oldKeywordObject: {
+    //     Category: 'EARTH SCIENCE',
+    //     Topic: 'ATMOSPHERE',
+    //     Term: 'AEROSOLS'
+    //   },
+    //   newKeywordObject: {
+    //     Category: 'EARTH SCIENCE',
+    //     Topic: 'OCEANS',
+    //     Term: 'MARINE SEDIMENTS'
+    //   }
+    // }
+    //
+    // sequentialValueReplace(...) maps the canonical keyword-object values back into the
+    // ordered ECHO10 XML fields:
+    // - CategoryKeyword <- 'EARTH SCIENCE'
+    // - TopicKeyword <- 'OCEANS'
+    // - TermKeyword <- 'MARINE SEDIMENTS'
+    replace: sequentialValueReplace(
+      [
+        // XML fields to write to
+        'CategoryKeyword',
+        'TopicKeyword',
+        'TermKeyword',
+        'VariableLevel1Keyword/Value',
+        'VariableLevel1Keyword/VariableLevel2Keyword/Value',
+        'VariableLevel1Keyword/VariableLevel2Keyword/VariableLevel3Keyword/Value',
+        'DetailedVariableKeyword'
+      ],
+      [
+        // Keys from newKeywordObject to read from
+        'Category',
+        'Topic',
+        'Term',
+        'VariableLevel1',
+        'VariableLevel2',
+        'VariableLevel3',
+        'DetailedVariable'
+      ]
+    )
+  }),
+  platforms: blockScheme({
+    // Platform corrections are normalized into an object that can carry:
+    // - Class: the GCMD platform class, for example "Space-based Platforms"
+    // - Type: DIF10 <Type>
+    // - ShortName: DIF10 <Short_Name>
+    //
+    // DIF10 Platform only persists `Type` and `ShortName`, so those are the
+    // only object fields written back into the XML.
+    nodeXPath: '//Collection/Platforms/Platform',
+    find: {
+      fieldPaths: [
+        // XML fields to read from
+        'ShortName'
+      ],
+      valueKeys: [
+        // Keys from oldKeywordObject to compare against
+        'ShortName'
+      ]
+    },
+    replace: [
+      {
+        // XML field to write to
+        fieldPath: 'Type',
+        source: {
+          // Key from newKeywordObject to read from
+          type: 'value',
+          key: 'Type'
+        }
+      },
+      {
+        // XML field to write to
+        fieldPath: 'ShortName',
+        source: {
+          // Key from newKeywordObject to read from
+          type: 'value',
+          key: 'ShortName'
+        }
+      },
+      {
+        // XML field to write to
+        fieldPath: 'LongName',
+        source: {
+          // Example correction input:
+          // {
+          //   scheme: 'platforms',
+          //   action: 'replace',
+          //   oldKeywordObject: {
+          //     Class: 'Space-based Platforms',
+          //     Type: 'Earth Observation Satellites',
+          //     ShortName: 'SPOT-4'
+          //   },
+          //   newKeywordObject: {
+          //     Class: 'Space-based Platforms',
+          //     Type: 'Earth Observation Satellites',
+          //     ShortName: 'SPOT-4-UPDATED'
+          //   },
+          //   newLongName: 'Systeme Observation de la Terre-4 Updated'
+          // }
+          //
+          // This reads the replacement value directly from correction.newLongName
+          // instead of taking it from the normalized keyword object.
+          // Correction param to read from
+          type: 'param',
+          key: 'newLongName'
+        }
+      }
+    ]
+  }),
+  instruments: blockScheme({
+    nodeXPath: '//Collection/Platforms/Platform/Instruments/Instrument',
+    find: {
+      fieldPaths: [
+        // XML fields to read from
+        'ShortName'
+      ],
+      valueKeys: [
+        // Keys from oldKeywordObject to compare against
+        'ShortName'
+      ]
+    },
+    replace: [
+      {
+        // XML field to write to
+        fieldPath: 'ShortName',
+        source: {
+          // Key from newKeywordObject to read from
+          type: 'value',
+          key: 'ShortName'
+        }
+      },
+      {
+        // XML field to write to
+        fieldPath: 'LongName',
+        source: {
+          // Correction param to read from
+          type: 'param',
+          key: 'newLongName'
+        }
+      }
+    ]
+  }),
+  projects: blockScheme({
+    nodeXPath: '//Collection/Campaigns/Campaign',
+    find: {
+      fieldPaths: [
+        // XML fields to read from
+        'ShortName'
+      ],
+      valueKeys: [
+        // Keys from oldKeywordObject to compare against
+        'ShortName'
+      ]
+    },
+    replace: [
+      {
+        // XML field to write to
+        fieldPath: 'ShortName',
+        source: {
+          // Key from newKeywordObject to read from
+          type: 'value',
+          key: 'ShortName'
+        }
+      },
+      {
+        // XML field to write to
+        fieldPath: 'LongName',
+        source: {
+          // Correction param to read from
+          type: 'param',
+          key: 'newLongName'
+        }
+      }
+    ]
+  }),
+  providers: blockScheme({
+    nodeXPath: '//Collection/Contacts/Contact',
+    removeEmptyParent: true,
+    find: {
+      fieldPaths: [
+        // XML fields to read from
+        'Role',
+        'OrganizationName'
+      ],
+      valueKeys: [
+        // Keys from oldKeywordObject to compare against
+        'BucketLevel0',
+        'ShortName'
+      ]
+    },
+    replace: [
+      {
+        // XML field to write to
+        fieldPath: 'OrganizationName',
+        source: {
+          // Key from newKeywordObject to read from
+          type: 'value',
+          key: 'ShortName'
+        }
+      },
+      {
+        // XML field to write to
+        fieldPath: '//Collection/ProcessingCenter',
+        // Condition to satisfy before replacement can occur
+        condition: ({ correction, editor: currentEditor }) => (
+          correction.oldKeywordObject?.BucketLevel0 === 'PROCESSOR'
+          && currentEditor.getNestedText(null, '//Collection/ProcessingCenter')
+          === correction.oldKeywordObject?.ShortName
+        ),
+        source: {
+          // Key from newKeywordObject to read from
+          type: 'value',
+          key: 'ShortName'
+        }
+      },
+      {
+        // XML field to write to
+        fieldPath: '//Collection/ArchiveCenter',
+        // Condition to satisfy before replacement can occur
+        condition: ({ correction, editor: currentEditor }) => (
+          correction.oldKeywordObject?.BucketLevel0 === 'ARCHIVER'
+          && currentEditor.getNestedText(null, '//Collection/ArchiveCenter')
+          === correction.oldKeywordObject?.ShortName
+        ),
+        source: {
+          // Key from newKeywordObject to read from
+          type: 'value',
+          key: 'ShortName'
+        }
+      }
+    ]
+  }),
+  rucontenttype: blockScheme({
+    nodeXPath: '//Collection/OnlineResources/OnlineResource',
+    find: {
+      fieldPaths: [
+        // XML fields to read from
+        'Type'
+      ],
+      valueKeys: ['CombinedType'],
+      getExpectedValueObject: ({ correction }) => ({
+        CombinedType: [
+          correction.oldKeywordObject?.URLContentType,
+          correction.oldKeywordObject?.Type,
+          correction.oldKeywordObject?.Subtype
+        ].filter(Boolean).join(' : ')
+      })
+    },
+    replace: [
+      {
+        // XML fields to write to and keys from newKeywordObject to read from
+        fieldPath: 'Type',
+        source: {
+          type: 'computed',
+          getValue: ({ correction }) => [
+            correction.newKeywordObject?.URLContentType,
+            correction.newKeywordObject?.Type,
+            correction.newKeywordObject?.Subtype
+          ].filter(Boolean).join(' : ')
+        }
+      }
+    ]
+  }),
+  dataformat: scalarScheme({
+    nodeXPath: '//Collection/DataFormat',
+    tagName: 'DataFormat'
+  }),
+  productlevelid: scalarScheme({
+    // Example correction input:
+    // {
+    //   scheme: 'productlevelid',
+    //   action: 'replace',
+    //   oldKeywordObject: {
+    //     Value: 'NA'
+    //   },
+    //   newKeywordObject: {
+    //     Value: '1A'
+    //   }
+    // }
+    //
+    // Scalar schemes ignore block/path matching and update the one target field
+    // selected by nodeXPath. `tagName` is only used when that field is missing
+    // and the editor needs to create the scalar element under the DIF root.
+    nodeXPath: '//Collection/ProcessingLevelId',
+    tagName: 'ProcessingLevelId'
+  })
+}
+
+/**
+ * Creates a DOM-backed editor for a raw DIF10 XML payload.
+ *
+ * @param {string} metadataPayload Raw DIF10 XML string.
+ * @returns {XmlMetadataPathEditor} Shared XML path editor instance.
+ */
+export const createEcho10Editor = (metadataPayload) => new XmlMetadataPathEditor(metadataPayload)
+
+export default ECHO10_SCHEME_EDITORS

--- a/serverless/src/shared/invokeMetadataCorrectionDelegate.js
+++ b/serverless/src/shared/invokeMetadataCorrectionDelegate.js
@@ -3,6 +3,7 @@ import { applyEcho10MetadataCorrections } from './applyEcho10MetadataCorrections
 import { applyIso19115MetadataCorrections } from './applyIso19115MetadataCorrections'
 import { applyIsoSmapMetadataCorrections } from './applyIsoSmapMetadataCorrections'
 import { applyUmmMetadataCorrections } from './applyUmmMetadataCorrections'
+import { logger } from './logger'
 
 const normalizeKeywordObject = (keywordObject) => (
   keywordObject
@@ -12,20 +13,52 @@ const normalizeKeywordObject = (keywordObject) => (
     : {}
 )
 
-const normalizeCorrection = (correction = {}) => ({
-  scheme: correction.scheme,
-  action: correction.action,
-  keywordConceptUuid: correction.keywordConceptUuid,
-  oldKeywordObject: normalizeKeywordObject(correction.oldKeywordObject),
-  newKeywordObject: normalizeKeywordObject(correction.newKeywordObject),
-  ummPath: correction.ummPath,
-  oldLongName: correction.oldLongName,
-  newLongName: correction.newLongName
-})
+const normalizeCorrection = (correction) => {
+  const safeCorrection = correction || {}
+
+  return {
+    scheme: safeCorrection.scheme,
+    action: safeCorrection.action,
+    keywordConceptUuid: safeCorrection.keywordConceptUuid,
+    oldKeywordObject: normalizeKeywordObject(safeCorrection.oldKeywordObject),
+    newKeywordObject: normalizeKeywordObject(safeCorrection.newKeywordObject),
+    ummPath: safeCorrection.ummPath,
+    oldLongName: safeCorrection.oldLongName,
+    newLongName: safeCorrection.newLongName
+  }
+}
+
+const hasMeaningfulKeywordValue = (keywordObject) => Object.values(keywordObject)
+  .some((value) => String(value || '').trim().length > 0)
+
+const shouldSkipCorrection = (correction) => {
+  const normalizedAction = String(correction.action || '').trim().toLowerCase()
+
+  return (
+    normalizedAction === 'replace'
+    && !hasMeaningfulKeywordValue(correction.newKeywordObject)
+  )
+}
 
 const normalizeCorrections = (corrections = []) => (
   Array.isArray(corrections)
-    ? corrections.map((correction = {}) => normalizeCorrection(correction))
+    ? corrections
+      .map((correction) => normalizeCorrection(correction))
+      .filter((correction) => {
+        if (!shouldSkipCorrection(correction)) {
+          return true
+        }
+
+        logger.error('[metadata-correction] Skipping invalid replacement correction payload', {
+          scheme: correction.scheme,
+          action: correction.action,
+          keywordConceptUuid: correction.keywordConceptUuid,
+          oldKeywordObject: correction.oldKeywordObject,
+          newKeywordObject: correction.newKeywordObject
+        })
+
+        return false
+      })
     : []
 )
 


### PR DESCRIPTION
# Overview

### What is the feature?

KMS-666 adds safe ECHO10 native metadata correction handling for prepared metadata-correction
requests.

### What is the Solution?

Update keywords in following schemes as they appear in ECHO10 records, according to correction requests:

sciencekeywords
platforms
instruments
projects
providers
rucontenttype
dataformat
productlevelid

### What areas of the application does this impact?

Consumer - Update Keywords in UMM-C native records

# Testing

### Reproduction steps

Run:

```
npx vite-node --config vite.config.js scripts/local/run_metadata_correction_echo10_smoke.mjs
```
The request fixture currently includes the full supported ECHO10 correction matrix:

sciencekeywords
platforms
instruments
projects
providers
rucontenttype
dataformat
productlevelid
The script prints a JSON summary like:

```
{
  "fixturePath": "/kms/scripts/local/fixtures/metadata_correction_service.echo10.example.json",
  "collectionConceptId": "C1234567890-LOCAL",
  "nativeFormat": "ECHO10",
  "requestedCorrections": 8,
  "appliedCorrections": 8,
  "outputPath": "/kms/tmp/metadata_correction_echo10_smoke_output.xml",
  "writeResult": {
    "stubbed": true,
    "targetComponent": "cmr-writeback",
    "collectionConceptId": "C1234567890-LOCAL",
    "providerId": null,
    "nativeId": null,
    "nativeFormat": "ECHO10",
    "correctionCount": 8,
    "correctionsAppliedCount": 8,
    "correctedMetadataBytes": 21452,
    "source": "local-smoke",
    "ingestResult": {
      "collectionConceptId": "C1234567890-LOCAL",
      "providerId": null,
      "nativeId": null,
      "nativeFormat": "ECHO10",
      "correctionCount": 8,
      "ingested": false,
      "updated": false,
      "enabled": false,
      "stubbed": true
    }
  }
}
```
The important signals are:

nativeFormat is ECHO10
requestedCorrections matches the fixture
appliedCorrections matches the expected applied count
writeResult.stubbed is true
writeResult.targetComponent is cmr-writeback
The corrected XML is written to:

tmp/metadata_correction_echo10_smoke_output.xml
Useful spot checks:

science keyword topic/term moved from the old aerosol path to the new oceans path
platform Short_Name changed to SPOT-4-UPDATED
platform Long_Name changed to Systeme Observation de la Terre-4 Updated
instrument GEOPHONES is gone
project ALIENS changed to ALIENS-UPDATED
provider short name changed to NZ/NZAI/ANZ-UPDATED
related URL content subtype changed from OpenSearch to OGC WMS
DataFormat is changed to HDF5
Product_Level_Id changed to 1A

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
