### PR TITLE
KMS-669: Add monitoring and metrics for event processing

### DIFF
--- a/cdk/app/lib/helper/MetadataCorrectionSetup.ts
+++ b/cdk/app/lib/helper/MetadataCorrectionSetup.ts
@@ -161,7 +161,12 @@ export class MetadataCorrectionSetup extends Construct {
     this.metadataCorrectionRequestsQueue.grantConsumeMessages(this.metadataCorrectionServiceLambda)
     this.metadataCorrectionServiceLambda.addToRolePolicy(new iam.PolicyStatement({
       actions: ['cloudwatch:PutMetricData'],
-      resources: ['*']
+      resources: ['*'],
+      conditions: {
+        StringEquals: {
+          'cloudwatch:namespace': 'CMR/KeywordSync'
+        }
+      }
     }))
 
     this.metadataCorrectionRequestsTopicArnOutput = new cdk.CfnOutput(this, 'MetadataCorrectionRequestsTopicArn', {

--- a/cdk/app/lib/helper/MetadataCorrectionSetup.ts
+++ b/cdk/app/lib/helper/MetadataCorrectionSetup.ts
@@ -2,6 +2,7 @@ import * as path from 'path'
 
 import * as cdk from 'aws-cdk-lib'
 import * as ec2 from 'aws-cdk-lib/aws-ec2'
+import * as iam from 'aws-cdk-lib/aws-iam'
 import * as eventsources from 'aws-cdk-lib/aws-lambda-event-sources'
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs'
 import * as sns from 'aws-cdk-lib/aws-sns'
@@ -158,6 +159,10 @@ export class MetadataCorrectionSetup extends Construct {
     ))
 
     this.metadataCorrectionRequestsQueue.grantConsumeMessages(this.metadataCorrectionServiceLambda)
+    this.metadataCorrectionServiceLambda.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['cloudwatch:PutMetricData'],
+      resources: ['*']
+    }))
 
     this.metadataCorrectionRequestsTopicArnOutput = new cdk.CfnOutput(this, 'MetadataCorrectionRequestsTopicArn', {
       description: 'SNS topic ARN for metadata correction request publishing',

--- a/scripts/local/find_collection_with_positive_manual_sync_result.mjs
+++ b/scripts/local/find_collection_with_positive_manual_sync_result.mjs
@@ -37,6 +37,7 @@ const showUsageAndExit = (exitCode) => {
     '  MIN_VALUE            Minimum numeric value to count as a match. Defaults to 1.',
     '  MAX_CONCEPTS         Optional cap on how many concept ids to try.',
     '  REQUEST_DELAY_MS     Optional delay between endpoint calls. Defaults to 0.',
+    '  STOP_ON_ERROR        When true, throw on the first non-2xx response instead of skipping it.',
     '  KMS_BASE_URL         Optional KMS base URL override.',
     '',
     'Safety:',
@@ -206,6 +207,17 @@ const getFieldValue = (responseBody, fieldPath) => fieldPath
   ), responseBody)
 
 /**
+ * Compacts an error response body into a one-line snippet for stderr logging.
+ *
+ * @param {string} bodyText Raw HTTP response body.
+ * @returns {string} Trimmed one-line body preview.
+ */
+const formatErrorBodySnippet = (bodyText) => String(bodyText || '')
+  .replace(/\s+/g, ' ')
+  .trim()
+  .slice(0, 500)
+
+/**
  * Calls the synchronous metadata-correction endpoint for one concept id.
  *
  * @param {object} params Request inputs.
@@ -303,6 +315,7 @@ const buildMatchSummary = ({
  * @param {string} params.resultField Dot-path field to inspect on the JSON response.
  * @param {number} params.minValue Minimum numeric value that counts as a match.
  * @param {number} params.requestDelayMs Delay between requests.
+ * @param {boolean} params.stopOnError When true, throw on the first non-2xx response.
  * @param {number} [params.inspectedCount=0] Number of requests already attempted.
  * @returns {Promise<object>} Match summary or a no-match summary when exhausted.
  */
@@ -313,6 +326,7 @@ const findFirstMatchingCollection = async ({
   resultField,
   minValue,
   requestDelayMs,
+  stopOnError,
   inspectedCount = 0
 }) => {
   if (candidateConceptIds.length === 0) {
@@ -340,10 +354,19 @@ const findFirstMatchingCollection = async ({
   })
 
   if (!result.ok) {
+    const errorBodySnippet = formatErrorBodySnippet(result.bodyText)
+
     process.stderr.write(
       `[find-positive-manual-sync-result] Skipping ${collectionConceptId}; `
-      + `endpoint returned ${result.status}\n`
+      + `endpoint returned ${result.status}${errorBodySnippet ? ` body=${errorBodySnippet}` : ''}\n`
     )
+
+    if (stopOnError) {
+      throw new Error(
+        `Manual sync endpoint failed for ${collectionConceptId} `
+        + `with status ${result.status}. ${errorBodySnippet || 'No response body returned.'}`
+      )
+    }
 
     if (requestDelayMs > 0) {
       await sleep(requestDelayMs)
@@ -356,6 +379,7 @@ const findFirstMatchingCollection = async ({
       resultField,
       minValue,
       requestDelayMs,
+      stopOnError,
       inspectedCount: nextInspectedCount
     })
   }
@@ -387,6 +411,7 @@ const findFirstMatchingCollection = async ({
     resultField,
     minValue,
     requestDelayMs,
+    stopOnError,
     inspectedCount: nextInspectedCount
   })
 }
@@ -420,6 +445,7 @@ const main = async () => {
   const resultField = String(process.env.RESULT_FIELD || 'resolvedCorrectionCount').trim()
   const minValue = parsePositiveInteger(process.env.MIN_VALUE, 1, 'MIN_VALUE')
   const requestDelayMs = parseNonNegativeInteger(process.env.REQUEST_DELAY_MS, 0, 'REQUEST_DELAY_MS')
+  const stopOnError = String(process.env.STOP_ON_ERROR || '').toLowerCase() === 'true'
   const maxConcepts = process.env.MAX_CONCEPTS
     ? parsePositiveInteger(process.env.MAX_CONCEPTS, 1, 'MAX_CONCEPTS')
     : undefined
@@ -455,7 +481,8 @@ const main = async () => {
     authorizationValue,
     resultField,
     minValue,
-    requestDelayMs
+    requestDelayMs,
+    stopOnError
   })
 
   process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`)

--- a/scripts/local/find_collection_with_positive_manual_sync_result.mjs
+++ b/scripts/local/find_collection_with_positive_manual_sync_result.mjs
@@ -1,0 +1,464 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+
+const ENVIRONMENT_BASE_URLS = {
+  sit: 'https://cmr.sit.earthdata.nasa.gov/kms',
+  uat: 'https://cmr.uat.earthdata.nasa.gov/kms',
+  prod: 'https://cmr.earthdata.nasa.gov/kms'
+}
+
+/**
+ * Prints usage guidance and exits.
+ *
+ * This helper calls the real synchronous metadata-correction endpoint, so it can
+ * mutate CMR metadata when writer-token rollout is enabled in the deployed env.
+ *
+ * @param {number} exitCode Process exit code.
+ * @returns {never} Always exits the process.
+ */
+const showUsageAndExit = (exitCode) => {
+  const message = [
+    'Usage:',
+    '  KMS_AUTHORIZATION=\'Bearer <token>\' \\',
+    '  ALLOW_MUTATING_CORRECTION_ENDPOINT=true \\',
+    '  node scripts/local/find_collection_with_positive_manual_sync_result.mjs <sit|uat|prod> [format] [providerId]',
+    '',
+    'Examples:',
+    '  KMS_AUTHORIZATION=\'Bearer eyJ...\' ALLOW_MUTATING_CORRECTION_ENDPOINT=true \\',
+    '    node scripts/local/find_collection_with_positive_manual_sync_result.mjs sit dif10 AMD_KOPRI',
+    '',
+    '  KMS_AUTHORIZATION=\'Bearer eyJ...\' ALLOW_MUTATING_CORRECTION_ENDPOINT=true \\',
+    '    RESULT_FIELD=keywordValidationFailureCount node scripts/local/find_collection_with_positive_manual_sync_result.mjs uat echo10',
+    '',
+    'Optional environment variables:',
+    '  RESULT_FIELD         JSON field to test. Defaults to resolvedCorrectionCount.',
+    '                       Dot paths are supported, e.g. correctionResult.correctionsAppliedCount',
+    '  MIN_VALUE            Minimum numeric value to count as a match. Defaults to 1.',
+    '  MAX_CONCEPTS         Optional cap on how many concept ids to try.',
+    '  REQUEST_DELAY_MS     Optional delay between endpoint calls. Defaults to 0.',
+    '  KMS_BASE_URL         Optional KMS base URL override.',
+    '',
+    'Safety:',
+    '  This script calls PUT /metadata_correction/{collectionConceptId}.',
+    '  Set ALLOW_MUTATING_CORRECTION_ENDPOINT=true to acknowledge that it may',
+    '  write corrected metadata back to CMR when writeback is enabled.'
+  ].join('\n')
+
+  const output = exitCode === 0 ? process.stdout : process.stderr
+  output.write(`${message}\n`)
+  process.exit(exitCode)
+}
+
+/**
+ * Resolves the requested environment into a KMS base URL.
+ *
+ * @param {string|undefined} environmentArg CLI environment argument.
+ * @returns {{environment: string, baseUrl: string}} Normalized environment and base URL.
+ */
+const resolveEnvironment = (environmentArg) => {
+  const environment = String(environmentArg || '').trim().toLowerCase()
+  const baseUrl = process.env.KMS_BASE_URL || ENVIRONMENT_BASE_URLS[environment]
+
+  if (!baseUrl) {
+    throw new Error(`Unsupported environment "${environmentArg}". Expected one of: sit, uat, prod`)
+  }
+
+  return {
+    environment,
+    baseUrl
+  }
+}
+
+/**
+ * Parses a positive integer from an environment variable, with a fallback.
+ *
+ * @param {string|undefined} rawValue Raw environment variable value.
+ * @param {number} defaultValue Value to use when the env var is absent.
+ * @param {string} variableName Variable name for error messages.
+ * @returns {number} Parsed positive integer.
+ */
+const parsePositiveInteger = (rawValue, defaultValue, variableName) => {
+  if (rawValue === undefined || rawValue === null || rawValue === '') {
+    return defaultValue
+  }
+
+  const parsed = Number(rawValue)
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${variableName} must be a positive integer, received "${rawValue}"`)
+  }
+
+  return parsed
+}
+
+/**
+ * Parses a non-negative integer from an environment variable, with a fallback.
+ *
+ * @param {string|undefined} rawValue Raw environment variable value.
+ * @param {number} defaultValue Value to use when the env var is absent.
+ * @param {string} variableName Variable name for error messages.
+ * @returns {number} Parsed non-negative integer.
+ */
+const parseNonNegativeInteger = (rawValue, defaultValue, variableName) => {
+  if (rawValue === undefined || rawValue === null || rawValue === '') {
+    return defaultValue
+  }
+
+  const parsed = Number(rawValue)
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${variableName} must be a non-negative integer, received "${rawValue}"`)
+  }
+
+  return parsed
+}
+
+/**
+ * Sleeps for a short delay between endpoint calls when throttling is desired.
+ *
+ * @param {number} ms Milliseconds to pause.
+ * @returns {Promise<void>} Resolves after the delay.
+ */
+const sleep = (ms) => new Promise((resolve) => {
+  setTimeout(resolve, ms)
+})
+
+/**
+ * Runs the existing concept-listing helper and parses its JSON stdout.
+ *
+ * @param {object} params Script inputs.
+ * @param {string} params.environment Target CMR/KMS environment.
+ * @param {string} params.format Native format alias or MIME type.
+ * @returns {Promise<string[]>} Concept ids returned by the listing script.
+ */
+const listCollectionConceptIds = async ({
+  environment,
+  format
+}) => new Promise((resolve, reject) => {
+  const child = spawn(
+    'node',
+    [
+      'scripts/local/list_collection_concept_ids_by_native_format.mjs',
+      environment,
+      format
+    ],
+    {
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe']
+    }
+  )
+
+  let stdout = ''
+  let stderr = ''
+
+  child.stdout.on('data', (chunk) => {
+    stdout += String(chunk)
+  })
+
+  child.stderr.on('data', (chunk) => {
+    stderr += String(chunk)
+    process.stderr.write(String(chunk))
+  })
+
+  child.on('error', reject)
+
+  child.on('close', (code) => {
+    if (code !== 0) {
+      reject(new Error(
+        'Failed to list collection concept ids. '
+        + `Exit code: ${code}. ${stderr.trim()}`
+      ))
+
+      return
+    }
+
+    try {
+      const conceptIds = JSON.parse(stdout)
+
+      if (!Array.isArray(conceptIds)) {
+        throw new Error('Expected a JSON array of concept ids.')
+      }
+
+      resolve(conceptIds)
+    } catch (error) {
+      reject(new Error(
+        'Failed to parse concept id list output. '
+        + `Error: ${error.message}`
+      ))
+    }
+  })
+})
+
+/**
+ * Reads a nested value from an object using dot-path syntax.
+ *
+ * @param {object} responseBody Parsed JSON response body.
+ * @param {string} fieldPath Dot-path to read.
+ * @returns {unknown} Nested value or `undefined`.
+ */
+const getFieldValue = (responseBody, fieldPath) => fieldPath
+  .split('.')
+  .reduce((value, segment) => (
+    value && typeof value === 'object'
+      ? value[segment]
+      : undefined
+  ), responseBody)
+
+/**
+ * Calls the synchronous metadata-correction endpoint for one concept id.
+ *
+ * @param {object} params Request inputs.
+ * @param {string} params.baseUrl Target KMS base URL.
+ * @param {string} params.authorizationValue Authorization header value.
+ * @param {string} params.collectionConceptId Collection concept id to test.
+ * @returns {Promise<{ok: boolean, status: number, bodyText: string, responseBody?: object}>}
+ * Raw response details plus parsed JSON when available.
+ */
+const callManualSyncEndpoint = async ({
+  baseUrl,
+  authorizationValue,
+  collectionConceptId
+}) => {
+  const requestUrl = `${baseUrl}/metadata_correction/${encodeURIComponent(collectionConceptId)}`
+  const response = await fetch(requestUrl, {
+    method: 'PUT',
+    headers: {
+      Authorization: authorizationValue,
+      Accept: 'application/json'
+    }
+  })
+
+  const bodyText = await response.text()
+  let responseBody
+
+  try {
+    responseBody = JSON.parse(bodyText)
+  } catch {
+    // Keep the raw body for debug output when the response is not JSON.
+  }
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    bodyText,
+    responseBody
+  }
+}
+
+/**
+ * Filters concept ids down to one provider when requested.
+ *
+ * @param {string[]} conceptIds Candidate concept ids.
+ * @param {string|undefined} providerId Optional provider id suffix filter.
+ * @returns {string[]} Filtered concept ids.
+ */
+const filterConceptIdsByProvider = (conceptIds, providerId) => {
+  const normalizedProviderId = String(providerId || '').trim()
+
+  if (!normalizedProviderId) {
+    return conceptIds
+  }
+
+  const suffix = `-${normalizedProviderId}`
+
+  return conceptIds.filter((conceptId) => String(conceptId).endsWith(suffix))
+}
+
+/**
+ * Formats the result summary returned to stdout when a match is found.
+ *
+ * @param {object} params Summary inputs.
+ * @param {string} params.collectionConceptId Matching concept id.
+ * @param {number} params.inspectedCount Number of collections tried.
+ * @param {string} params.resultField JSON field that matched.
+ * @param {number} params.resultValue Numeric field value that matched.
+ * @param {object} params.responseBody Full endpoint response body.
+ * @returns {object} Serializable match summary.
+ */
+const buildMatchSummary = ({
+  collectionConceptId,
+  inspectedCount,
+  resultField,
+  resultValue,
+  responseBody
+}) => ({
+  collectionConceptId,
+  inspectedCount,
+  matchedField: resultField,
+  matchedValue: resultValue,
+  response: responseBody
+})
+
+/**
+ * Walks collection ids one at a time until the requested response field exceeds the threshold.
+ *
+ * This is intentionally sequential so we do not blast the live sync endpoint with parallel
+ * mutation requests while searching for a useful test collection.
+ *
+ * @param {object} params Search inputs.
+ * @param {string[]} params.candidateConceptIds Remaining concept ids to inspect.
+ * @param {string} params.baseUrl Target KMS base URL.
+ * @param {string} params.authorizationValue Authorization header value.
+ * @param {string} params.resultField Dot-path field to inspect on the JSON response.
+ * @param {number} params.minValue Minimum numeric value that counts as a match.
+ * @param {number} params.requestDelayMs Delay between requests.
+ * @param {number} [params.inspectedCount=0] Number of requests already attempted.
+ * @returns {Promise<object>} Match summary or a no-match summary when exhausted.
+ */
+const findFirstMatchingCollection = async ({
+  candidateConceptIds,
+  baseUrl,
+  authorizationValue,
+  resultField,
+  minValue,
+  requestDelayMs,
+  inspectedCount = 0
+}) => {
+  if (candidateConceptIds.length === 0) {
+    return {
+      collectionConceptId: null,
+      inspectedCount,
+      matchedField: resultField,
+      matchedValue: 0,
+      response: null
+    }
+  }
+
+  const [collectionConceptId, ...remainingConceptIds] = candidateConceptIds
+  const nextInspectedCount = inspectedCount + 1
+
+  process.stderr.write(
+    `[find-positive-manual-sync-result] (${nextInspectedCount}/${nextInspectedCount + remainingConceptIds.length}) `
+    + `PUT ${collectionConceptId}\n`
+  )
+
+  const result = await callManualSyncEndpoint({
+    baseUrl,
+    authorizationValue,
+    collectionConceptId
+  })
+
+  if (!result.ok) {
+    process.stderr.write(
+      `[find-positive-manual-sync-result] Skipping ${collectionConceptId}; `
+      + `endpoint returned ${result.status}\n`
+    )
+
+    if (requestDelayMs > 0) {
+      await sleep(requestDelayMs)
+    }
+
+    return findFirstMatchingCollection({
+      candidateConceptIds: remainingConceptIds,
+      baseUrl,
+      authorizationValue,
+      resultField,
+      minValue,
+      requestDelayMs,
+      inspectedCount: nextInspectedCount
+    })
+  }
+
+  const resultValue = Number(getFieldValue(result.responseBody, resultField) || 0)
+
+  process.stderr.write(
+    `[find-positive-manual-sync-result] ${collectionConceptId} -> ${resultField}=${resultValue}\n`
+  )
+
+  if (resultValue >= minValue) {
+    return buildMatchSummary({
+      collectionConceptId,
+      inspectedCount: nextInspectedCount,
+      resultField,
+      resultValue,
+      responseBody: result.responseBody
+    })
+  }
+
+  if (requestDelayMs > 0) {
+    await sleep(requestDelayMs)
+  }
+
+  return findFirstMatchingCollection({
+    candidateConceptIds: remainingConceptIds,
+    baseUrl,
+    authorizationValue,
+    resultField,
+    minValue,
+    requestDelayMs,
+    inspectedCount: nextInspectedCount
+  })
+}
+
+const main = async () => {
+  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    showUsageAndExit(0)
+  }
+
+  if (String(process.env.ALLOW_MUTATING_CORRECTION_ENDPOINT || '').toLowerCase() !== 'true') {
+    throw new Error(
+      'Refusing to call the mutating metadata correction endpoint. '
+      + 'Set ALLOW_MUTATING_CORRECTION_ENDPOINT=true to continue.'
+    )
+  }
+
+  const environmentArg = process.argv[2]
+  const format = String(process.argv[3] || 'dif10').trim()
+  const providerId = process.argv[4]
+  const authorizationValue = String(process.env.KMS_AUTHORIZATION || '').trim()
+
+  if (!environmentArg) {
+    showUsageAndExit(1)
+  }
+
+  if (!authorizationValue) {
+    throw new Error('Missing KMS_AUTHORIZATION environment variable.')
+  }
+
+  const { environment, baseUrl } = resolveEnvironment(environmentArg)
+  const resultField = String(process.env.RESULT_FIELD || 'resolvedCorrectionCount').trim()
+  const minValue = parsePositiveInteger(process.env.MIN_VALUE, 1, 'MIN_VALUE')
+  const requestDelayMs = parseNonNegativeInteger(process.env.REQUEST_DELAY_MS, 0, 'REQUEST_DELAY_MS')
+  const maxConcepts = process.env.MAX_CONCEPTS
+    ? parsePositiveInteger(process.env.MAX_CONCEPTS, 1, 'MAX_CONCEPTS')
+    : undefined
+
+  process.stderr.write(
+    `[find-positive-manual-sync-result] Listing ${format} collections in ${environment}\n`
+  )
+
+  const conceptIds = filterConceptIdsByProvider(
+    await listCollectionConceptIds({
+      environment,
+      format
+    }),
+    providerId
+  )
+
+  if (conceptIds.length === 0) {
+    throw new Error('No candidate collection concept ids were found for the requested filter.')
+  }
+
+  const candidateConceptIds = maxConcepts
+    ? conceptIds.slice(0, maxConcepts)
+    : conceptIds
+
+  process.stderr.write(
+    `[find-positive-manual-sync-result] Trying ${candidateConceptIds.length} collection concept ids `
+    + `against ${baseUrl}/metadata_correction/{collectionConceptId}\n`
+  )
+
+  const summary = await findFirstMatchingCollection({
+    candidateConceptIds,
+    baseUrl,
+    authorizationValue,
+    resultField,
+    minValue,
+    requestDelayMs
+  })
+
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`)
+}
+
+await main()

--- a/scripts/local/find_collection_with_positive_manual_sync_result.mjs
+++ b/scripts/local/find_collection_with_positive_manual_sync_result.mjs
@@ -40,6 +40,9 @@ const showUsageAndExit = (exitCode) => {
     '  STOP_ON_ERROR        When true, throw on the first non-2xx response instead of skipping it.',
     '  KMS_BASE_URL         Optional KMS base URL override.',
     '',
+    'UAT/Prod safety:',
+    '  For uat and prod runs, you must provide either MAX_CONCEPTS or a providerId filter.',
+    '',
     'Safety:',
     '  This script calls PUT /metadata_correction/{collectionConceptId}.',
     '  Set ALLOW_MUTATING_CORRECTION_ENDPOINT=true to acknowledge that it may',
@@ -205,6 +208,35 @@ const getFieldValue = (responseBody, fieldPath) => fieldPath
       ? value[segment]
       : undefined
   ), responseBody)
+
+/**
+ * Reads and validates the numeric result field used to decide whether a collection matched.
+ *
+ * @param {object|undefined} responseBody Parsed JSON response body from the sync endpoint.
+ * @param {string} fieldPath Dot-path field to read from the response.
+ * @returns {number} Numeric result value for comparison.
+ * @throws {Error} If the field is missing or does not resolve to a finite number.
+ */
+const getNumericResultFieldValue = (responseBody, fieldPath) => {
+  const rawValue = getFieldValue(responseBody, fieldPath)
+
+  if (rawValue === undefined) {
+    throw new Error(
+      `Requested RESULT_FIELD "${fieldPath}" was not present in the metadata correction response.`
+    )
+  }
+
+  const numericValue = Number(rawValue)
+
+  if (!Number.isFinite(numericValue)) {
+    throw new Error(
+      `Requested RESULT_FIELD "${fieldPath}" must resolve to a numeric value. `
+      + `Received: ${JSON.stringify(rawValue)}`
+    )
+  }
+
+  return numericValue
+}
 
 /**
  * Compacts an error response body into a one-line snippet for stderr logging.
@@ -384,7 +416,7 @@ const findFirstMatchingCollection = async ({
     })
   }
 
-  const resultValue = Number(getFieldValue(result.responseBody, resultField) || 0)
+  const resultValue = getNumericResultFieldValue(result.responseBody, resultField)
 
   process.stderr.write(
     `[find-positive-manual-sync-result] ${collectionConceptId} -> ${resultField}=${resultValue}\n`
@@ -449,6 +481,13 @@ const main = async () => {
   const maxConcepts = process.env.MAX_CONCEPTS
     ? parsePositiveInteger(process.env.MAX_CONCEPTS, 1, 'MAX_CONCEPTS')
     : undefined
+
+  if ((environment === 'uat' || environment === 'prod') && !maxConcepts && !providerId) {
+    throw new Error(
+      'UAT and prod runs require either MAX_CONCEPTS or a providerId filter to limit the '
+      + 'number of mutating metadata correction requests.'
+    )
+  }
 
   process.stderr.write(
     `[find-positive-manual-sync-result] Listing ${format} collections in ${environment}\n`

--- a/scripts/local/fixtures/metadata_correction_smoke.full_path.example.json
+++ b/scripts/local/fixtures/metadata_correction_smoke.full_path.example.json
@@ -132,7 +132,7 @@
         "nativeId": "local-smoke-collection-1",
         "providerId": "LOCAL",
         "format": "application/vnd.nasa.cmr.umm+json",
-        "nativeMetadataContentType": "application/vnd.nasa.cmr.umm+json;version=1.16.2; charset=utf-8",
+        "nativeResponseContentType": "application/vnd.nasa.cmr.umm+json;version=1.16.2; charset=utf-8",
         "revisionId": 1,
         "umm": {
           "ShortName": "LOCAL-METADATA-CORRECTION-SMOKE",

--- a/scripts/local/fixtures/metadata_correction_smoke.full_path.example.json
+++ b/scripts/local/fixtures/metadata_correction_smoke.full_path.example.json
@@ -132,6 +132,7 @@
         "nativeId": "local-smoke-collection-1",
         "providerId": "LOCAL",
         "format": "application/vnd.nasa.cmr.umm+json",
+        "nativeMetadataContentType": "application/vnd.nasa.cmr.umm+json;version=1.16.2; charset=utf-8",
         "revisionId": 1,
         "umm": {
           "ShortName": "LOCAL-METADATA-CORRECTION-SMOKE",

--- a/scripts/local/mock_cmr_server.mjs
+++ b/scripts/local/mock_cmr_server.mjs
@@ -77,6 +77,10 @@ const getNativeMetadataPayload = (collection) => {
 
 // Infer a reasonable content type for the fixture-backed native metadata response.
 const getNativeMetadataContentType = (collection) => {
+  if (collection.nativeMetadataContentType) {
+    return String(collection.nativeMetadataContentType).trim()
+  }
+
   const format = String(collection.format || '').trim()
 
   return format || 'application/octet-stream'

--- a/scripts/local/mock_cmr_server.mjs
+++ b/scripts/local/mock_cmr_server.mjs
@@ -76,9 +76,10 @@ const getNativeMetadataPayload = (collection) => {
 }
 
 // Infer a reasonable content type for the fixture-backed native metadata response.
+// This is mock server response metadata, not part of the embedded native metadata payload.
 const getNativeMetadataContentType = (collection) => {
-  if (collection.nativeMetadataContentType) {
-    return String(collection.nativeMetadataContentType).trim()
+  if (collection.nativeResponseContentType) {
+    return String(collection.nativeResponseContentType).trim()
   }
 
   const format = String(collection.format || '').trim()

--- a/scripts/local/run_metadata_correction_consumer_metrics_async_smoke.mjs
+++ b/scripts/local/run_metadata_correction_consumer_metrics_async_smoke.mjs
@@ -18,7 +18,7 @@ import {
  * expected consumer metrics incremented in the `CMR/KeywordSync` namespace.
  *
  * Prerequisites:
- * - LocalStack is running and reachable on `AWS_ENDPOINT_URL` or `http://localhost:4566`
+ * - LocalStack is running on `http://127.0.0.1:4566`
  * - local Redis is running
  * - local RDF4J is running
  *
@@ -33,9 +33,10 @@ const fixturePath = path.resolve(
 const outputDir = path.resolve(rootDir, 'tmp/metadata-correction-consumer-metrics-async-smoke')
 const outputPath = path.resolve(outputDir, 'result.json')
 const mockCmrPort = Number(process.env.MOCK_CMR_PORT || 3020)
-const cmrBaseUrl = process.env.CMR_BASE_URL || `http://127.0.0.1:${mockCmrPort}`
-const cloudWatchEndpoint = process.env.AWS_ENDPOINT_URL || 'http://127.0.0.1:4566'
 const startMockServer = String(process.env.START_MOCK_CMR || 'true').toLowerCase() !== 'false'
+const localMockCmrBaseUrl = `http://127.0.0.1:${mockCmrPort}`
+const cmrBaseUrl = localMockCmrBaseUrl
+const cloudWatchEndpoint = 'http://127.0.0.1:4566'
 const cloudWatchApiVersion = '2010-08-01'
 const metricNamespace = CONSUMER_METRIC_NAMESPACE
 const metricPeriodSeconds = 60

--- a/scripts/local/run_metadata_correction_consumer_metrics_async_smoke.mjs
+++ b/scripts/local/run_metadata_correction_consumer_metrics_async_smoke.mjs
@@ -1,0 +1,676 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import {
+  CONSUMER_METRIC_NAMES,
+  CONSUMER_METRIC_NAMESPACE
+} from '../../serverless/src/shared/emitConsumerMetrics'
+
+/**
+ * Local end-to-end smoke for async consumer metrics.
+ *
+ * This smoke test drives the real `metadataCorrectionService` handler with an
+ * SQS-like event, verifies the collection was corrected through the mock CMR
+ * writeback path, and then checks LocalStack CloudWatch to confirm the
+ * expected consumer metrics incremented in the `CMR/KeywordSync` namespace.
+ *
+ * Prerequisites:
+ * - LocalStack is running and reachable on `AWS_ENDPOINT_URL` or `http://localhost:4566`
+ * - local Redis is running
+ * - local RDF4J is running
+ *
+ * Run with:
+ *   npx vite-node --config vite.config.js scripts/local/run_metadata_correction_consumer_metrics_async_smoke.mjs
+ */
+const rootDir = path.resolve(import.meta.dirname, '../..')
+const fixturePath = path.resolve(
+  rootDir,
+  'scripts/local/fixtures/metadata_correction_smoke.full_path.example.json'
+)
+const outputDir = path.resolve(rootDir, 'tmp/metadata-correction-consumer-metrics-async-smoke')
+const outputPath = path.resolve(outputDir, 'result.json')
+const mockCmrPort = Number(process.env.MOCK_CMR_PORT || 3020)
+const cmrBaseUrl = process.env.CMR_BASE_URL || `http://127.0.0.1:${mockCmrPort}`
+const cloudWatchEndpoint = process.env.AWS_ENDPOINT_URL || 'http://127.0.0.1:4566'
+const startMockServer = String(process.env.START_MOCK_CMR || 'true').toLowerCase() !== 'false'
+const cloudWatchApiVersion = '2010-08-01'
+const metricNamespace = CONSUMER_METRIC_NAMESPACE
+const metricPeriodSeconds = 60
+
+const fixture = JSON.parse(await fs.readFile(fixturePath, 'utf8'))
+const collection = fixture.cmr.collections[0]
+const rawKeywordEvent = fixture.keywordEvents[0]
+const collectionConceptId = process.env.COLLECTION_CONCEPT_ID || collection.conceptId
+const providerId = process.env.PROVIDER_ID || collection.providerId
+const measurementWindowStart = new Date(Date.now() - (10 * 60 * 1000)).toISOString()
+
+/**
+ * Sleeps for a short interval while polling local dependencies.
+ *
+ * @param {number} ms Milliseconds to pause.
+ * @returns {Promise<void>} Resolves after the delay.
+ */
+const sleep = (ms) => new Promise((resolve) => {
+  setTimeout(resolve, ms)
+})
+
+/**
+ * Waits for an HTTP health endpoint to begin returning 200 responses.
+ *
+ * @param {string} healthUrl Health-check URL to poll.
+ * @param {number} [attempt=1] Current retry attempt.
+ * @returns {Promise<void>} Resolves when the endpoint becomes healthy.
+ */
+const waitForHealth = async (healthUrl, attempt = 1) => {
+  try {
+    const response = await fetch(healthUrl)
+
+    if (response.ok) {
+      return
+    }
+  } catch {
+    // Keep polling until the dependency is reachable.
+  }
+
+  if (attempt >= 40) {
+    throw new Error(`Timed out waiting for health endpoint: ${healthUrl}`)
+  }
+
+  await sleep(250)
+  await waitForHealth(healthUrl, attempt + 1)
+}
+
+/**
+ * Wraps cached concept payloads in the Redis response envelope used locally.
+ *
+ * @param {object} responseBody Cached concept response body.
+ * @returns {{statusCode: number, body: string}} Serialized Redis cache entry.
+ */
+const buildCacheResponse = (responseBody) => ({
+  statusCode: 200,
+  body: JSON.stringify(responseBody)
+})
+
+/**
+ * Normalizes a fixture keyword event into the runtime shape expected by the consumer.
+ *
+ * @param {object} keywordEvent Fixture keyword event.
+ * @returns {object} Normalized keyword event payload.
+ */
+const normalizeKeywordEvent = (keywordEvent) => ({
+  eventType: keywordEvent.EventType,
+  scheme: keywordEvent.Scheme,
+  uuid: keywordEvent.UUID,
+  oldKeywordObject: keywordEvent.OldKeywordObject,
+  newKeywordObject: keywordEvent.NewKeywordObject
+})
+
+/**
+ * Seeds the local Redis caches with the historical and published keyword fixtures.
+ *
+ * @returns {Promise<object>} Connected Redis client for later cleanup.
+ */
+const seedKeywordCaches = async () => {
+  process.env.REDIS_ENABLED = process.env.REDIS_ENABLED || 'true'
+  process.env.REDIS_HOST = process.env.REDIS_HOST_SERVICE_HOST || process.env.REDIS_HOST || 'localhost'
+  process.env.REDIS_PORT = process.env.REDIS_HOST_PORT || process.env.REDIS_PORT || '6380'
+  process.env.REDIS_FAIL_FAST = process.env.REDIS_FAIL_FAST || 'true'
+
+  const {
+    createConceptResponseCacheKeyByFullPath,
+    createConceptResponseCacheKeyByShortName,
+    createPublishedConceptResponseCacheKeyByFullPath,
+    createPublishedConceptResponseCacheKeyByShortName,
+    createPublishedConceptResponseCacheKeyByUuid
+  } = await import('../../serverless/src/shared/redisCacheKeys')
+  const { getRedisClient } = await import('../../serverless/src/shared/redisCacheStore')
+
+  const redisClient = await getRedisClient()
+
+  if (!redisClient) {
+    throw new Error('Unable to connect to Redis for async consumer metrics smoke seeding.')
+  }
+
+  /**
+   * Seeds one set of fixture concepts into the appropriate Redis key-space.
+   *
+   * @param {object} params Seeding parameters.
+   * @param {Array<object>} params.concepts Historical or published concept fixtures.
+   * @param {Function} params.createFullPathCacheKey Full-path cache-key builder.
+   * @param {Function} params.createShortNameCacheKey Short-name cache-key builder.
+   * @param {Function} [params.createUuidCacheKey] Optional UUID cache-key builder.
+   * @returns {Promise<void[]>} Resolves once the concepts are seeded.
+   */
+  const seedConcepts = async ({
+    concepts,
+    createFullPathCacheKey,
+    createShortNameCacheKey,
+    createUuidCacheKey
+  }) => Promise.all(concepts.map(async (concept) => {
+    const {
+      lookupType,
+      responseBody,
+      scheme
+    } = concept
+
+    let cacheKey
+
+    if (lookupType === 'fullPath') {
+      cacheKey = createFullPathCacheKey({
+        fullPath: concept.fullPath.toLowerCase(),
+        scheme: scheme.toLowerCase()
+      })
+    } else {
+      cacheKey = createShortNameCacheKey({
+        shortName: concept.shortName.toLowerCase(),
+        scheme: scheme.toLowerCase()
+      })
+    }
+
+    await redisClient.set(cacheKey, JSON.stringify(buildCacheResponse(responseBody)))
+
+    if (createUuidCacheKey) {
+      const uuidCacheKey = createUuidCacheKey({
+        uuid: responseBody.uuid.toLowerCase(),
+        scheme: scheme.toLowerCase()
+      })
+
+      await redisClient.set(uuidCacheKey, JSON.stringify(buildCacheResponse(responseBody)))
+    }
+  }))
+
+  await seedConcepts({
+    concepts: fixture.historicalConcepts || [],
+    createFullPathCacheKey: createConceptResponseCacheKeyByFullPath,
+    createShortNameCacheKey: createConceptResponseCacheKeyByShortName
+  })
+
+  await seedConcepts({
+    concepts: fixture.publishedConcepts || [],
+    createFullPathCacheKey: createPublishedConceptResponseCacheKeyByFullPath,
+    createShortNameCacheKey: createPublishedConceptResponseCacheKeyByShortName,
+    createUuidCacheKey: createPublishedConceptResponseCacheKeyByUuid
+  })
+
+  return redisClient
+}
+
+/**
+ * Removes any existing audit rows for the smoke collection.
+ *
+ * @returns {Promise<void>} Resolves once prior audit rows are deleted.
+ */
+const clearAuditRowsForCollection = async () => {
+  process.env.RDF4J_SERVICE_URL = process.env.RDF4J_SERVICE_URL || 'http://localhost:8081'
+  process.env.RDF4J_USER_NAME = process.env.RDF4J_USER_NAME || 'rdf4j'
+  process.env.RDF4J_PASSWORD = process.env.RDF4J_PASSWORD || 'rdf4j'
+
+  const {
+    escapeSparqlLiteral,
+    METADATA_CORRECTION_AUDIT_GRAPH
+  } = await import('../../serverless/src/shared/metadataCorrectionAudit')
+  const { sparqlRequest } = await import('../../serverless/src/shared/sparqlRequest')
+
+  const query = `
+    PREFIX gcmd: <https://gcmd.earthdata.nasa.gov/kms#>
+
+    DELETE {
+      GRAPH <${METADATA_CORRECTION_AUDIT_GRAPH}> {
+        ?record ?predicate ?object .
+      }
+    }
+    WHERE {
+      GRAPH <${METADATA_CORRECTION_AUDIT_GRAPH}> {
+        ?record a gcmd:MetadataCorrectionAuditRecord ;
+                gcmd:collectionConceptId "${escapeSparqlLiteral(collectionConceptId)}" ;
+                ?predicate ?object .
+      }
+    }
+  `
+
+  await sparqlRequest({
+    method: 'POST',
+    contentType: 'application/sparql-update',
+    accept: 'application/json',
+    body: query
+  })
+}
+
+/**
+ * Creates an XML parser for CloudWatch Query API responses.
+ *
+ * @returns {Promise<object>} XML parser instance.
+ */
+const createParser = async () => {
+  const { XMLParser } = await import('fast-xml-parser')
+
+  return new XMLParser({
+    ignoreAttributes: false,
+    parseAttributeValue: false,
+    parseTagValue: false,
+    trimValues: true
+  })
+}
+
+/**
+ * Normalizes an optional list value into an array.
+ *
+ * @param {unknown} value Candidate scalar-or-array value.
+ * @returns {Array<unknown>} Array representation.
+ */
+const toArray = (value) => {
+  if (!value) {
+    return []
+  }
+
+  return Array.isArray(value) ? value : [value]
+}
+
+/**
+ * Posts a CloudWatch Query API request to LocalStack.
+ *
+ * @param {object} params Query request parameters.
+ * @param {string} params.endpoint LocalStack CloudWatch endpoint.
+ * @param {object} params.queryParams Query string parameters for the CloudWatch API call.
+ * @returns {Promise<string>} Raw XML response body.
+ */
+const postCloudWatchQuery = async ({
+  endpoint,
+  queryParams
+}) => {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
+    },
+    body: new URLSearchParams(queryParams).toString()
+  })
+
+  if (!response.ok) {
+    const responseBody = await response.text()
+
+    throw new Error(
+      `CloudWatch query failed. Status=${response.status}. Response=${responseBody}`
+    )
+  }
+
+  return response.text()
+}
+
+/**
+ * Waits for the LocalStack CloudWatch Query API to begin responding successfully.
+ *
+ * @param {object} params Probe parameters.
+ * @param {string} params.endpoint LocalStack CloudWatch endpoint.
+ * @param {number} [params.attempt=1] Current retry attempt.
+ * @returns {Promise<void>} Resolves once LocalStack CloudWatch is reachable.
+ */
+const waitForCloudWatch = async ({
+  endpoint,
+  attempt = 1
+}) => {
+  try {
+    await postCloudWatchQuery({
+      endpoint,
+      queryParams: {
+        Action: 'ListMetrics',
+        Version: cloudWatchApiVersion,
+        Namespace: metricNamespace
+      }
+    })
+
+    return
+  } catch {
+    // Keep polling until the LocalStack CloudWatch query API is reachable.
+  }
+
+  if (attempt >= 40) {
+    throw new Error(`Timed out waiting for LocalStack CloudWatch endpoint: ${endpoint}`)
+  }
+
+  await sleep(250)
+  await waitForCloudWatch({
+    endpoint,
+    attempt: attempt + 1
+  })
+}
+
+/**
+ * Reads all datapoints for one metric in the smoke's measurement window.
+ *
+ * @param {object} params Metric query parameters.
+ * @param {string} params.endpoint LocalStack CloudWatch endpoint.
+ * @param {string} params.metricName CloudWatch metric name.
+ * @param {string} params.startTime ISO start time for the smoke window.
+ * @param {string} params.endTime ISO end time for the smoke window.
+ * @param {object} params.parser XML parser instance.
+ * @returns {Promise<Array<{timestamp: string, value: number}>>} Parsed metric datapoints.
+ */
+const getMetricDatapoints = async ({
+  endpoint,
+  metricName,
+  startTime,
+  endTime,
+  parser
+}) => {
+  const responseXml = await postCloudWatchQuery({
+    endpoint,
+    queryParams: {
+      Action: 'GetMetricStatistics',
+      Version: cloudWatchApiVersion,
+      Namespace: metricNamespace,
+      MetricName: metricName,
+      StartTime: startTime,
+      EndTime: endTime,
+      Period: String(metricPeriodSeconds),
+      'Statistics.member.1': 'Sum'
+    }
+  })
+
+  const result = parser.parse(responseXml)
+  const datapoints = toArray(
+    result?.GetMetricStatisticsResponse?.GetMetricStatisticsResult?.Datapoints?.member
+  )
+
+  return datapoints
+    .map((datapoint) => ({
+      timestamp: datapoint?.Timestamp,
+      value: Number(datapoint?.Sum || 0)
+    }))
+    .filter((datapoint) => datapoint.timestamp && Number.isFinite(datapoint.value))
+}
+
+/**
+ * Computes the total observed Sum statistic for one metric across the smoke window.
+ *
+ * @param {object} params Metric total query parameters.
+ * @param {string} params.endpoint LocalStack CloudWatch endpoint.
+ * @param {string} params.metricName CloudWatch metric name.
+ * @param {string} params.startTime ISO start time for the smoke window.
+ * @param {string} params.endTime ISO end time for the smoke window.
+ * @param {object} params.parser XML parser instance.
+ * @returns {Promise<number>} Total metric sum across all datapoints in the window.
+ */
+const getMetricTotal = async ({
+  endpoint,
+  metricName,
+  startTime,
+  endTime,
+  parser
+}) => {
+  const datapoints = await getMetricDatapoints({
+    endpoint,
+    metricName,
+    startTime,
+    endTime,
+    parser
+  })
+
+  return datapoints.reduce((sum, datapoint) => sum + datapoint.value, 0)
+}
+
+/**
+ * Captures a baseline or post-run snapshot for the metrics relevant to the consumer smoke.
+ *
+ * @param {object} params Snapshot parameters.
+ * @param {string} params.endpoint LocalStack CloudWatch endpoint.
+ * @param {Array<string>} params.metricNames CloudWatch metric names to read.
+ * @param {string} params.startTime ISO start time for the smoke window.
+ * @param {string} params.endTime ISO end time for the smoke window.
+ * @param {object} params.parser XML parser instance.
+ * @returns {Promise<object>} Map of metric names to total observed sums.
+ */
+const captureMetricSnapshot = async ({
+  endpoint,
+  metricNames,
+  startTime,
+  endTime,
+  parser
+}) => {
+  const totals = await Promise.all(metricNames.map(async (metricName) => ([
+    metricName,
+    await getMetricTotal({
+      endpoint,
+      metricName,
+      startTime,
+      endTime,
+      parser
+    })
+  ])))
+
+  return Object.fromEntries(totals)
+}
+
+/**
+ * Computes per-metric deltas between two snapshots.
+ *
+ * @param {object} params Delta parameters.
+ * @param {object} params.before Baseline metric totals.
+ * @param {object} params.after Post-run metric totals.
+ * @returns {object} Map of metric names to delta values.
+ */
+const buildMetricDeltas = ({
+  before,
+  after
+}) => Object.fromEntries(
+  Object.keys(after).map((metricName) => [
+    metricName,
+    (after[metricName] || 0) - (before[metricName] || 0)
+  ])
+)
+
+/**
+ * Polls LocalStack until the expected metric deltas appear or times out.
+ *
+ * @param {object} params Polling parameters.
+ * @param {string} params.endpoint LocalStack CloudWatch endpoint.
+ * @param {Array<string>} params.metricNames CloudWatch metric names to read.
+ * @param {string} params.startTime ISO start time for the smoke window.
+ * @param {object} params.expectedDeltas Expected minimum delta by metric name.
+ * @param {object} params.parser XML parser instance.
+ * @param {number} [params.attempt=1] Current polling attempt.
+ * @returns {Promise<{afterSnapshot: object, deltas: object}>} Final snapshot and deltas.
+ */
+const waitForMetricDeltas = async ({
+  endpoint,
+  metricNames,
+  startTime,
+  expectedDeltas,
+  parser,
+  attempt = 1
+}) => {
+  const afterSnapshot = await captureMetricSnapshot({
+    endpoint,
+    metricNames,
+    startTime,
+    endTime: new Date().toISOString(),
+    parser
+  })
+  const deltas = buildMetricDeltas({
+    before: expectedDeltas.beforeSnapshot,
+    after: afterSnapshot
+  })
+
+  const allSatisfied = Object.entries(expectedDeltas.minimums).every(
+    ([metricName, expectedDelta]) => (deltas[metricName] || 0) >= expectedDelta
+  )
+
+  if (allSatisfied) {
+    return {
+      afterSnapshot,
+      deltas
+    }
+  }
+
+  if (attempt >= 20) {
+    throw new Error(
+      `Timed out waiting for expected consumer metric deltas. Observed deltas=${JSON.stringify(deltas)}`
+    )
+  }
+
+  await sleep(500)
+
+  return waitForMetricDeltas({
+    endpoint,
+    metricNames,
+    startTime,
+    expectedDeltas,
+    parser,
+    attempt: attempt + 1
+  })
+}
+
+let mockServerProcess
+let redisClient
+
+try {
+  if (startMockServer) {
+    mockServerProcess = spawn(
+      process.execPath,
+      [path.resolve(rootDir, 'scripts/local/mock_cmr_server.mjs'), fixturePath],
+      {
+        env: {
+          ...process.env,
+          FIXTURE_FILE: fixturePath,
+          MOCK_CMR_PORT: String(mockCmrPort)
+        },
+        stdio: 'inherit'
+      }
+    )
+
+    await waitForHealth(`${cmrBaseUrl}/health`)
+  }
+
+  await waitForCloudWatch({
+    endpoint: cloudWatchEndpoint
+  })
+
+  process.env.CMR_BASE_URL = cmrBaseUrl
+  process.env.CMR_WRITEBACK_PROVIDERS = process.env.CMR_WRITEBACK_PROVIDERS || providerId
+  process.env.CMR_WRITER_TOKEN = process.env.CMR_WRITER_TOKEN || 'local-writer-token'
+  process.env.AWS_ENDPOINT_URL = cloudWatchEndpoint
+
+  redisClient = await seedKeywordCaches()
+  await clearAuditRowsForCollection()
+
+  const { metadataCorrectionService } = await import('../../serverless/src/metadataCorrectionService/handler')
+  const { getCmrCollectionNativeMetadata } = await import('../../serverless/src/shared/getCmrCollectionNativeMetadata')
+  const parser = await createParser()
+
+  const metricNames = [
+    CONSUMER_METRIC_NAMES.EVENTS_CONSUMED,
+    CONSUMER_METRIC_NAMES.EVENTS_PROCESSED,
+    CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES,
+    CONSUMER_METRIC_NAMES.INVALID_KEYWORD_COUNT,
+    CONSUMER_METRIC_NAMES.KEYWORDS_RESOLVED,
+    CONSUMER_METRIC_NAMES.CORRECTIONS_APPLIED_TO_METADATA,
+    CONSUMER_METRIC_NAMES.CORRECTIONS_WRITTEN_TO_CMR,
+    CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_EVENT,
+    CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_MANUAL
+  ]
+
+  const beforeSnapshot = await captureMetricSnapshot({
+    endpoint: cloudWatchEndpoint,
+    metricNames,
+    startTime: measurementWindowStart,
+    endTime: new Date().toISOString(),
+    parser
+  })
+
+  await metadataCorrectionService({
+    Records: [
+      {
+        messageId: 'local-consumer-metrics-async-smoke-1',
+        body: JSON.stringify({
+          source: 'local-smoke',
+          collectionConceptId,
+          keywordEvent: normalizeKeywordEvent(rawKeywordEvent)
+        })
+      }
+    ]
+  })
+
+  const updatedNativeMetadata = await getCmrCollectionNativeMetadata({
+    collectionConceptId
+  })
+  const updatedPlatform = updatedNativeMetadata?.Platforms?.[0]
+
+  if (!updatedPlatform) {
+    throw new Error(`Expected updated UMM Platforms[0] for ${collectionConceptId}`)
+  }
+
+  if (updatedPlatform.ShortName !== 'Aqua') {
+    throw new Error(`Expected corrected UMM Platforms[0].ShortName to be Aqua, received ${updatedPlatform.ShortName}`)
+  }
+
+  const {
+    afterSnapshot,
+    deltas
+  } = await waitForMetricDeltas({
+    endpoint: cloudWatchEndpoint,
+    metricNames,
+    startTime: measurementWindowStart,
+    expectedDeltas: {
+      beforeSnapshot,
+      minimums: {
+        [CONSUMER_METRIC_NAMES.EVENTS_CONSUMED]: 1,
+        [CONSUMER_METRIC_NAMES.EVENTS_PROCESSED]: 1,
+        [CONSUMER_METRIC_NAMES.INVALID_KEYWORD_COUNT]: 1,
+        [CONSUMER_METRIC_NAMES.KEYWORDS_RESOLVED]: 1,
+        [CONSUMER_METRIC_NAMES.CORRECTIONS_APPLIED_TO_METADATA]: 1,
+        [CONSUMER_METRIC_NAMES.CORRECTIONS_WRITTEN_TO_CMR]: 1,
+        [CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_EVENT]: 1
+      }
+    },
+    parser
+  })
+
+  if ((deltas[CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES] || 0) !== 0) {
+    throw new Error(
+      'Expected EventProcessingFailures delta to remain 0, '
+      + `received ${deltas[CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES]}`
+    )
+  }
+
+  if ((deltas[CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_MANUAL] || 0) !== 0) {
+    throw new Error(
+      'Expected RecordsUpdatedFromManual delta to remain 0, '
+      + `received ${deltas[CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_MANUAL]}`
+    )
+  }
+
+  await fs.mkdir(outputDir, { recursive: true })
+  await fs.writeFile(outputPath, JSON.stringify({
+    collectionConceptId,
+    providerId,
+    cmrBaseUrl,
+    cloudWatchEndpoint,
+    metricNamespace,
+    beforeSnapshot,
+    afterSnapshot,
+    deltas,
+    updatedPlatform
+  }, null, 2), 'utf8')
+
+  console.log('[metadata-correction-consumer-metrics-async-smoke] Completed successfully')
+  console.log(JSON.stringify({
+    collectionConceptId,
+    providerId,
+    cmrBaseUrl,
+    cloudWatchEndpoint,
+    metricNamespace,
+    deltas,
+    outputPath
+  }, null, 2))
+} finally {
+  if (redisClient) {
+    await redisClient.quit()
+  }
+
+  if (mockServerProcess) {
+    mockServerProcess.kill('SIGTERM')
+  }
+}

--- a/scripts/local/run_metadata_correction_consumer_metrics_manual_sync_smoke.mjs
+++ b/scripts/local/run_metadata_correction_consumer_metrics_manual_sync_smoke.mjs
@@ -1,0 +1,687 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import {
+  CONSUMER_METRIC_NAMES,
+  CONSUMER_METRIC_NAMESPACE
+} from '../../serverless/src/shared/emitConsumerMetrics'
+
+/**
+ * Local end-to-end smoke for manual sync consumer metrics.
+ *
+ * This smoke test drives the real `runMetadataCorrection` API handler with an
+ * API-Gateway-like event, verifies the collection was corrected through the
+ * mock CMR writeback path, and then checks LocalStack CloudWatch to confirm
+ * the expected consumer metrics incremented in the `CMR/KeywordSync`
+ * namespace for the manual single-collection flow.
+ *
+ * Prerequisites:
+ * - LocalStack is running and reachable on `AWS_ENDPOINT_URL` or `http://localhost:4566`
+ * - local Redis is running
+ * - local RDF4J is running
+ *
+ * Run with:
+ *   npx vite-node --config vite.config.js scripts/local/run_metadata_correction_consumer_metrics_manual_sync_smoke.mjs
+ */
+const rootDir = path.resolve(import.meta.dirname, '../..')
+const fixturePath = path.resolve(
+  rootDir,
+  'scripts/local/fixtures/metadata_correction_smoke.full_path.example.json'
+)
+const outputDir = path.resolve(rootDir, 'tmp/metadata-correction-consumer-metrics-manual-sync-smoke')
+const outputPath = path.resolve(outputDir, 'result.json')
+const mockCmrPort = Number(process.env.MOCK_CMR_PORT || 3020)
+const cmrBaseUrl = process.env.CMR_BASE_URL || `http://127.0.0.1:${mockCmrPort}`
+const cloudWatchEndpoint = process.env.AWS_ENDPOINT_URL || 'http://127.0.0.1:4566'
+const startMockServer = String(process.env.START_MOCK_CMR || 'true').toLowerCase() !== 'false'
+const cloudWatchApiVersion = '2010-08-01'
+const metricNamespace = CONSUMER_METRIC_NAMESPACE
+const metricPeriodSeconds = 60
+
+const fixture = JSON.parse(await fs.readFile(fixturePath, 'utf8'))
+const collection = fixture.cmr.collections[0]
+const collectionConceptId = process.env.COLLECTION_CONCEPT_ID || collection.conceptId
+const providerId = process.env.PROVIDER_ID || collection.providerId
+const measurementWindowStart = new Date(Date.now() - (10 * 60 * 1000)).toISOString()
+
+/**
+ * Sleeps for a short interval while polling local dependencies.
+ *
+ * @param {number} ms Milliseconds to pause.
+ * @returns {Promise<void>} Resolves after the delay.
+ */
+const sleep = (ms) => new Promise((resolve) => {
+  setTimeout(resolve, ms)
+})
+
+/**
+ * Waits for an HTTP health endpoint to begin returning 200 responses.
+ *
+ * @param {string} healthUrl Health-check URL to poll.
+ * @param {number} [attempt=1] Current retry attempt.
+ * @returns {Promise<void>} Resolves when the endpoint becomes healthy.
+ */
+const waitForHealth = async (healthUrl, attempt = 1) => {
+  try {
+    const response = await fetch(healthUrl)
+
+    if (response.ok) {
+      return
+    }
+  } catch {
+    // Keep polling until the dependency is reachable.
+  }
+
+  if (attempt >= 40) {
+    throw new Error(`Timed out waiting for health endpoint: ${healthUrl}`)
+  }
+
+  await sleep(250)
+  await waitForHealth(healthUrl, attempt + 1)
+}
+
+/**
+ * Wraps cached concept payloads in the Redis response envelope used locally.
+ *
+ * @param {object} responseBody Cached concept response body.
+ * @returns {{statusCode: number, body: string}} Serialized Redis cache entry.
+ */
+const buildCacheResponse = (responseBody) => ({
+  statusCode: 200,
+  body: JSON.stringify(responseBody)
+})
+
+/**
+ * Seeds the local Redis caches with the historical and published keyword fixtures.
+ *
+ * @returns {Promise<object>} Connected Redis client for later cleanup.
+ */
+const seedKeywordCaches = async () => {
+  process.env.REDIS_ENABLED = process.env.REDIS_ENABLED || 'true'
+  process.env.REDIS_HOST = process.env.REDIS_HOST_SERVICE_HOST || process.env.REDIS_HOST || 'localhost'
+  process.env.REDIS_PORT = process.env.REDIS_HOST_PORT || process.env.REDIS_PORT || '6380'
+  process.env.REDIS_FAIL_FAST = process.env.REDIS_FAIL_FAST || 'true'
+
+  const {
+    createConceptResponseCacheKeyByFullPath,
+    createConceptResponseCacheKeyByShortName,
+    createPublishedConceptResponseCacheKeyByFullPath,
+    createPublishedConceptResponseCacheKeyByShortName,
+    createPublishedConceptResponseCacheKeyByUuid
+  } = await import('../../serverless/src/shared/redisCacheKeys')
+  const { getRedisClient } = await import('../../serverless/src/shared/redisCacheStore')
+
+  const redisClient = await getRedisClient()
+
+  if (!redisClient) {
+    throw new Error('Unable to connect to Redis for manual sync consumer metrics smoke seeding.')
+  }
+
+  /**
+   * Seeds one set of fixture concepts into the appropriate Redis key-space.
+   *
+   * @param {object} params Seeding parameters.
+   * @param {Array<object>} params.concepts Historical or published concept fixtures.
+   * @param {Function} params.createFullPathCacheKey Full-path cache-key builder.
+   * @param {Function} params.createShortNameCacheKey Short-name cache-key builder.
+   * @param {Function} [params.createUuidCacheKey] Optional UUID cache-key builder.
+   * @returns {Promise<void[]>} Resolves once the concepts are seeded.
+   */
+  const seedConcepts = async ({
+    concepts,
+    createFullPathCacheKey,
+    createShortNameCacheKey,
+    createUuidCacheKey
+  }) => Promise.all(concepts.map(async (concept) => {
+    const {
+      lookupType,
+      responseBody,
+      scheme
+    } = concept
+
+    let cacheKey
+
+    if (lookupType === 'fullPath') {
+      cacheKey = createFullPathCacheKey({
+        fullPath: concept.fullPath.toLowerCase(),
+        scheme: scheme.toLowerCase()
+      })
+    } else {
+      cacheKey = createShortNameCacheKey({
+        shortName: concept.shortName.toLowerCase(),
+        scheme: scheme.toLowerCase()
+      })
+    }
+
+    await redisClient.set(cacheKey, JSON.stringify(buildCacheResponse(responseBody)))
+
+    if (createUuidCacheKey) {
+      const uuidCacheKey = createUuidCacheKey({
+        uuid: responseBody.uuid.toLowerCase(),
+        scheme: scheme.toLowerCase()
+      })
+
+      await redisClient.set(uuidCacheKey, JSON.stringify(buildCacheResponse(responseBody)))
+    }
+  }))
+
+  await seedConcepts({
+    concepts: fixture.historicalConcepts || [],
+    createFullPathCacheKey: createConceptResponseCacheKeyByFullPath,
+    createShortNameCacheKey: createConceptResponseCacheKeyByShortName
+  })
+
+  await seedConcepts({
+    concepts: fixture.publishedConcepts || [],
+    createFullPathCacheKey: createPublishedConceptResponseCacheKeyByFullPath,
+    createShortNameCacheKey: createPublishedConceptResponseCacheKeyByShortName,
+    createUuidCacheKey: createPublishedConceptResponseCacheKeyByUuid
+  })
+
+  return redisClient
+}
+
+/**
+ * Removes any existing audit rows for the smoke collection.
+ *
+ * @returns {Promise<void>} Resolves once prior audit rows are deleted.
+ */
+const clearAuditRowsForCollection = async () => {
+  process.env.RDF4J_SERVICE_URL = process.env.RDF4J_SERVICE_URL || 'http://localhost:8081'
+  process.env.RDF4J_USER_NAME = process.env.RDF4J_USER_NAME || 'rdf4j'
+  process.env.RDF4J_PASSWORD = process.env.RDF4J_PASSWORD || 'rdf4j'
+
+  const {
+    escapeSparqlLiteral,
+    METADATA_CORRECTION_AUDIT_GRAPH
+  } = await import('../../serverless/src/shared/metadataCorrectionAudit')
+  const { sparqlRequest } = await import('../../serverless/src/shared/sparqlRequest')
+
+  const query = `
+    PREFIX gcmd: <https://gcmd.earthdata.nasa.gov/kms#>
+
+    DELETE {
+      GRAPH <${METADATA_CORRECTION_AUDIT_GRAPH}> {
+        ?record ?predicate ?object .
+      }
+    }
+    WHERE {
+      GRAPH <${METADATA_CORRECTION_AUDIT_GRAPH}> {
+        ?record a gcmd:MetadataCorrectionAuditRecord ;
+                gcmd:collectionConceptId "${escapeSparqlLiteral(collectionConceptId)}" ;
+                ?predicate ?object .
+      }
+    }
+  `
+
+  await sparqlRequest({
+    method: 'POST',
+    contentType: 'application/sparql-update',
+    accept: 'application/json',
+    body: query
+  })
+}
+
+/**
+ * Creates an XML parser for CloudWatch Query API responses.
+ *
+ * @returns {Promise<object>} XML parser instance.
+ */
+const createParser = async () => {
+  const { XMLParser } = await import('fast-xml-parser')
+
+  return new XMLParser({
+    ignoreAttributes: false,
+    parseAttributeValue: false,
+    parseTagValue: false,
+    trimValues: true
+  })
+}
+
+/**
+ * Normalizes an optional list value into an array.
+ *
+ * @param {unknown} value Candidate scalar-or-array value.
+ * @returns {Array<unknown>} Array representation.
+ */
+const toArray = (value) => {
+  if (!value) {
+    return []
+  }
+
+  return Array.isArray(value) ? value : [value]
+}
+
+/**
+ * Posts a CloudWatch Query API request to LocalStack.
+ *
+ * @param {object} params Query request parameters.
+ * @param {string} params.endpoint LocalStack CloudWatch endpoint.
+ * @param {object} params.queryParams Query string parameters for the CloudWatch API call.
+ * @returns {Promise<string>} Raw XML response body.
+ */
+const postCloudWatchQuery = async ({
+  endpoint,
+  queryParams
+}) => {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
+    },
+    body: new URLSearchParams(queryParams).toString()
+  })
+
+  if (!response.ok) {
+    const responseBody = await response.text()
+
+    throw new Error(
+      `CloudWatch query failed. Status=${response.status}. Response=${responseBody}`
+    )
+  }
+
+  return response.text()
+}
+
+/**
+ * Waits for the LocalStack CloudWatch Query API to begin responding successfully.
+ *
+ * @param {object} params Probe parameters.
+ * @param {string} params.endpoint LocalStack CloudWatch endpoint.
+ * @param {number} [params.attempt=1] Current retry attempt.
+ * @returns {Promise<void>} Resolves once LocalStack CloudWatch is reachable.
+ */
+const waitForCloudWatch = async ({
+  endpoint,
+  attempt = 1
+}) => {
+  try {
+    await postCloudWatchQuery({
+      endpoint,
+      queryParams: {
+        Action: 'ListMetrics',
+        Version: cloudWatchApiVersion,
+        Namespace: metricNamespace
+      }
+    })
+
+    return
+  } catch {
+    // Keep polling until the LocalStack CloudWatch query API is reachable.
+  }
+
+  if (attempt >= 40) {
+    throw new Error(`Timed out waiting for LocalStack CloudWatch endpoint: ${endpoint}`)
+  }
+
+  await sleep(250)
+  await waitForCloudWatch({
+    endpoint,
+    attempt: attempt + 1
+  })
+}
+
+/**
+ * Reads all datapoints for one metric in the smoke's measurement window.
+ *
+ * @param {object} params Metric query parameters.
+ * @param {string} params.endpoint LocalStack CloudWatch endpoint.
+ * @param {string} params.metricName CloudWatch metric name.
+ * @param {string} params.startTime ISO start time for the smoke window.
+ * @param {string} params.endTime ISO end time for the smoke window.
+ * @param {object} params.parser XML parser instance.
+ * @returns {Promise<Array<{timestamp: string, value: number}>>} Parsed metric datapoints.
+ */
+const getMetricDatapoints = async ({
+  endpoint,
+  metricName,
+  startTime,
+  endTime,
+  parser
+}) => {
+  const responseXml = await postCloudWatchQuery({
+    endpoint,
+    queryParams: {
+      Action: 'GetMetricStatistics',
+      Version: cloudWatchApiVersion,
+      Namespace: metricNamespace,
+      MetricName: metricName,
+      StartTime: startTime,
+      EndTime: endTime,
+      Period: String(metricPeriodSeconds),
+      'Statistics.member.1': 'Sum'
+    }
+  })
+
+  const result = parser.parse(responseXml)
+  const datapoints = toArray(
+    result?.GetMetricStatisticsResponse?.GetMetricStatisticsResult?.Datapoints?.member
+  )
+
+  return datapoints
+    .map((datapoint) => ({
+      timestamp: datapoint?.Timestamp,
+      value: Number(datapoint?.Sum || 0)
+    }))
+    .filter((datapoint) => datapoint.timestamp && Number.isFinite(datapoint.value))
+}
+
+/**
+ * Computes the total observed Sum statistic for one metric across the smoke window.
+ *
+ * @param {object} params Metric total query parameters.
+ * @param {string} params.endpoint LocalStack CloudWatch endpoint.
+ * @param {string} params.metricName CloudWatch metric name.
+ * @param {string} params.startTime ISO start time for the smoke window.
+ * @param {string} params.endTime ISO end time for the smoke window.
+ * @param {object} params.parser XML parser instance.
+ * @returns {Promise<number>} Total metric sum across all datapoints in the window.
+ */
+const getMetricTotal = async ({
+  endpoint,
+  metricName,
+  startTime,
+  endTime,
+  parser
+}) => {
+  const datapoints = await getMetricDatapoints({
+    endpoint,
+    metricName,
+    startTime,
+    endTime,
+    parser
+  })
+
+  return datapoints.reduce((sum, datapoint) => sum + datapoint.value, 0)
+}
+
+/**
+ * Captures a baseline or post-run snapshot for the metrics relevant to the consumer smoke.
+ *
+ * @param {object} params Snapshot parameters.
+ * @param {string} params.endpoint LocalStack CloudWatch endpoint.
+ * @param {Array<string>} params.metricNames CloudWatch metric names to read.
+ * @param {string} params.startTime ISO start time for the smoke window.
+ * @param {string} params.endTime ISO end time for the smoke window.
+ * @param {object} params.parser XML parser instance.
+ * @returns {Promise<object>} Map of metric names to total observed sums.
+ */
+const captureMetricSnapshot = async ({
+  endpoint,
+  metricNames,
+  startTime,
+  endTime,
+  parser
+}) => {
+  const totals = await Promise.all(metricNames.map(async (metricName) => ([
+    metricName,
+    await getMetricTotal({
+      endpoint,
+      metricName,
+      startTime,
+      endTime,
+      parser
+    })
+  ])))
+
+  return Object.fromEntries(totals)
+}
+
+/**
+ * Computes per-metric deltas between two snapshots.
+ *
+ * @param {object} params Delta parameters.
+ * @param {object} params.before Baseline metric totals.
+ * @param {object} params.after Post-run metric totals.
+ * @returns {object} Map of metric names to delta values.
+ */
+const buildMetricDeltas = ({
+  before,
+  after
+}) => Object.fromEntries(
+  Object.keys(after).map((metricName) => [
+    metricName,
+    (after[metricName] || 0) - (before[metricName] || 0)
+  ])
+)
+
+/**
+ * Polls LocalStack until the expected metric deltas appear or times out.
+ *
+ * @param {object} params Polling parameters.
+ * @param {string} params.endpoint LocalStack CloudWatch endpoint.
+ * @param {Array<string>} params.metricNames CloudWatch metric names to read.
+ * @param {string} params.startTime ISO start time for the smoke window.
+ * @param {object} params.expectedDeltas Expected minimum delta by metric name.
+ * @param {object} params.parser XML parser instance.
+ * @param {number} [params.attempt=1] Current polling attempt.
+ * @returns {Promise<{afterSnapshot: object, deltas: object}>} Final snapshot and deltas.
+ */
+const waitForMetricDeltas = async ({
+  endpoint,
+  metricNames,
+  startTime,
+  expectedDeltas,
+  parser,
+  attempt = 1
+}) => {
+  const afterSnapshot = await captureMetricSnapshot({
+    endpoint,
+    metricNames,
+    startTime,
+    endTime: new Date().toISOString(),
+    parser
+  })
+  const deltas = buildMetricDeltas({
+    before: expectedDeltas.beforeSnapshot,
+    after: afterSnapshot
+  })
+
+  const allSatisfied = Object.entries(expectedDeltas.minimums).every(
+    ([metricName, expectedDelta]) => (deltas[metricName] || 0) >= expectedDelta
+  )
+
+  if (allSatisfied) {
+    return {
+      afterSnapshot,
+      deltas
+    }
+  }
+
+  if (attempt >= 20) {
+    throw new Error(
+      `Timed out waiting for expected consumer metric deltas. Observed deltas=${JSON.stringify(deltas)}`
+    )
+  }
+
+  await sleep(500)
+
+  return waitForMetricDeltas({
+    endpoint,
+    metricNames,
+    startTime,
+    expectedDeltas,
+    parser,
+    attempt: attempt + 1
+  })
+}
+
+let mockServerProcess
+let redisClient
+
+try {
+  if (startMockServer) {
+    mockServerProcess = spawn(
+      process.execPath,
+      [path.resolve(rootDir, 'scripts/local/mock_cmr_server.mjs'), fixturePath],
+      {
+        env: {
+          ...process.env,
+          FIXTURE_FILE: fixturePath,
+          MOCK_CMR_PORT: String(mockCmrPort)
+        },
+        stdio: 'inherit'
+      }
+    )
+
+    await waitForHealth(`${cmrBaseUrl}/health`)
+  }
+
+  await waitForCloudWatch({
+    endpoint: cloudWatchEndpoint
+  })
+
+  process.env.CMR_BASE_URL = cmrBaseUrl
+  process.env.CMR_WRITEBACK_PROVIDERS = process.env.CMR_WRITEBACK_PROVIDERS || providerId
+  process.env.CMR_WRITER_TOKEN = process.env.CMR_WRITER_TOKEN || 'local-writer-token'
+  process.env.AWS_ENDPOINT_URL = cloudWatchEndpoint
+
+  redisClient = await seedKeywordCaches()
+  await clearAuditRowsForCollection()
+
+  const { runMetadataCorrection } = await import('../../serverless/src/runMetadataCorrection/handler')
+  const { getCmrCollectionNativeMetadata } = await import('../../serverless/src/shared/getCmrCollectionNativeMetadata')
+  const parser = await createParser()
+
+  const metricNames = [
+    CONSUMER_METRIC_NAMES.EVENTS_CONSUMED,
+    CONSUMER_METRIC_NAMES.EVENTS_PROCESSED,
+    CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES,
+    CONSUMER_METRIC_NAMES.INVALID_KEYWORD_COUNT,
+    CONSUMER_METRIC_NAMES.KEYWORDS_RESOLVED,
+    CONSUMER_METRIC_NAMES.CORRECTIONS_APPLIED_TO_METADATA,
+    CONSUMER_METRIC_NAMES.CORRECTIONS_WRITTEN_TO_CMR,
+    CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_EVENT,
+    CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_MANUAL
+  ]
+
+  const beforeSnapshot = await captureMetricSnapshot({
+    endpoint: cloudWatchEndpoint,
+    metricNames,
+    startTime: measurementWindowStart,
+    endTime: new Date().toISOString(),
+    parser
+  })
+
+  const response = await runMetadataCorrection({
+    pathParameters: {
+      collectionConceptId
+    }
+  })
+
+  if (response.statusCode !== 200) {
+    throw new Error(`Expected 200 response from runMetadataCorrection, received ${response.statusCode}: ${response.body}`)
+  }
+
+  const responseBody = JSON.parse(response.body)
+
+  if (responseBody.outcome !== 'processed') {
+    throw new Error(`Expected processed outcome for ${collectionConceptId}, received ${responseBody.outcome}`)
+  }
+
+  if ((responseBody.correctionResult?.correctionCount || 0) < 1) {
+    throw new Error(`Expected at least one applied correction for ${collectionConceptId}`)
+  }
+
+  if (responseBody.writeResult?.ingestResult?.updated !== true) {
+    throw new Error(`Expected successful mock CMR writeback for ${collectionConceptId}`)
+  }
+
+  const updatedNativeMetadata = await getCmrCollectionNativeMetadata({
+    collectionConceptId
+  })
+  const updatedPlatform = updatedNativeMetadata?.Platforms?.[0]
+
+  if (!updatedPlatform) {
+    throw new Error(`Expected updated UMM Platforms[0] for ${collectionConceptId}`)
+  }
+
+  if (updatedPlatform.ShortName !== 'Aqua') {
+    throw new Error(`Expected corrected UMM Platforms[0].ShortName to be Aqua, received ${updatedPlatform.ShortName}`)
+  }
+
+  const {
+    afterSnapshot,
+    deltas
+  } = await waitForMetricDeltas({
+    endpoint: cloudWatchEndpoint,
+    metricNames,
+    startTime: measurementWindowStart,
+    expectedDeltas: {
+      beforeSnapshot,
+      minimums: {
+        [CONSUMER_METRIC_NAMES.INVALID_KEYWORD_COUNT]: 1,
+        [CONSUMER_METRIC_NAMES.KEYWORDS_RESOLVED]: 1,
+        [CONSUMER_METRIC_NAMES.CORRECTIONS_APPLIED_TO_METADATA]: 1,
+        [CONSUMER_METRIC_NAMES.CORRECTIONS_WRITTEN_TO_CMR]: 1,
+        [CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_MANUAL]: 1
+      }
+    },
+    parser
+  })
+
+  if ((deltas[CONSUMER_METRIC_NAMES.EVENTS_CONSUMED] || 0) !== 0) {
+    throw new Error(
+      'Expected EventsConsumed delta to remain 0 for the manual sync flow, '
+      + `received ${deltas[CONSUMER_METRIC_NAMES.EVENTS_CONSUMED]}`
+    )
+  }
+
+  if ((deltas[CONSUMER_METRIC_NAMES.EVENTS_PROCESSED] || 0) !== 0) {
+    throw new Error(
+      'Expected EventsProcessed delta to remain 0 for the manual sync flow, '
+      + `received ${deltas[CONSUMER_METRIC_NAMES.EVENTS_PROCESSED]}`
+    )
+  }
+
+  if ((deltas[CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES] || 0) !== 0) {
+    throw new Error(
+      'Expected EventProcessingFailures delta to remain 0, '
+      + `received ${deltas[CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES]}`
+    )
+  }
+
+  if ((deltas[CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_EVENT] || 0) !== 0) {
+    throw new Error(
+      'Expected RecordsUpdatedFromEvent delta to remain 0 for the manual sync flow, '
+      + `received ${deltas[CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_EVENT]}`
+    )
+  }
+
+  await fs.mkdir(outputDir, { recursive: true })
+  await fs.writeFile(outputPath, JSON.stringify({
+    collectionConceptId,
+    providerId,
+    cmrBaseUrl,
+    cloudWatchEndpoint,
+    metricNamespace,
+    responseBody,
+    beforeSnapshot,
+    afterSnapshot,
+    deltas,
+    updatedPlatform
+  }, null, 2), 'utf8')
+
+  console.log('[metadata-correction-consumer-metrics-manual-sync-smoke] Completed successfully')
+  console.log(JSON.stringify({
+    collectionConceptId,
+    providerId,
+    cmrBaseUrl,
+    cloudWatchEndpoint,
+    metricNamespace,
+    outcome: responseBody.outcome,
+    deltas,
+    outputPath
+  }, null, 2))
+} finally {
+  if (redisClient) {
+    await redisClient.quit()
+  }
+
+  if (mockServerProcess) {
+    mockServerProcess.kill('SIGTERM')
+  }
+}

--- a/scripts/local/run_metadata_correction_consumer_metrics_manual_sync_smoke.mjs
+++ b/scripts/local/run_metadata_correction_consumer_metrics_manual_sync_smoke.mjs
@@ -19,7 +19,7 @@ import {
  * namespace for the manual single-collection flow.
  *
  * Prerequisites:
- * - LocalStack is running and reachable on `AWS_ENDPOINT_URL` or `http://localhost:4566`
+ * - LocalStack is running on `http://127.0.0.1:4566`
  * - local Redis is running
  * - local RDF4J is running
  *
@@ -34,9 +34,10 @@ const fixturePath = path.resolve(
 const outputDir = path.resolve(rootDir, 'tmp/metadata-correction-consumer-metrics-manual-sync-smoke')
 const outputPath = path.resolve(outputDir, 'result.json')
 const mockCmrPort = Number(process.env.MOCK_CMR_PORT || 3020)
-const cmrBaseUrl = process.env.CMR_BASE_URL || `http://127.0.0.1:${mockCmrPort}`
-const cloudWatchEndpoint = process.env.AWS_ENDPOINT_URL || 'http://127.0.0.1:4566'
 const startMockServer = String(process.env.START_MOCK_CMR || 'true').toLowerCase() !== 'false'
+const localMockCmrBaseUrl = `http://127.0.0.1:${mockCmrPort}`
+const cmrBaseUrl = localMockCmrBaseUrl
+const cloudWatchEndpoint = 'http://127.0.0.1:4566'
 const cloudWatchApiVersion = '2010-08-01'
 const metricNamespace = CONSUMER_METRIC_NAMESPACE
 const metricPeriodSeconds = 60

--- a/serverless/src/metadataCorrectionService/__tests__/handler.test.js
+++ b/serverless/src/metadataCorrectionService/__tests__/handler.test.js
@@ -6,6 +6,8 @@ import {
   vi
 } from 'vitest'
 
+import { CONSUMER_METRIC_NAMES } from '@/shared/emitConsumerMetrics'
+import { emitConsumerMetricsSafely } from '@/shared/emitConsumerMetricsSafely'
 import { extractKeywordValidationFailures } from '@/shared/extractKeywordValidationFailures'
 import { getCmrCollectionNativeMetadata } from '@/shared/getCmrCollectionNativeMetadata'
 import { getCmrCollectionUmmDetails } from '@/shared/getCmrCollectionUmmDetails'
@@ -36,6 +38,25 @@ vi.mock('@/shared/invokeMetadataCorrectionDelegate', () => ({
     nativeFormat === 'DIF10'
     || nativeFormat === 'UMM'
   ))
+}))
+
+vi.mock('@/shared/emitConsumerMetrics', () => ({
+  CONSUMER_METRIC_NAMES: {
+    EVENTS_CONSUMED: 'EventsConsumed',
+    EVENTS_PROCESSED: 'EventsProcessed',
+    EVENT_PROCESSING_FAILURES: 'EventProcessingFailures',
+    RECORDS_UPDATED_FROM_EVENT: 'RecordsUpdatedFromEvent',
+    RECORDS_UPDATED_FROM_MANUAL: 'RecordsUpdatedFromManual',
+    INVALID_KEYWORD_COUNT: 'InvalidKeywordCount',
+    CORRECTIONS_APPLIED_TO_METADATA: 'CorrectionsAppliedToMetadata',
+    CORRECTIONS_WRITTEN_TO_CMR: 'CorrectionsWrittenToCMR',
+    KEYWORDS_RESOLVED: 'KeywordsResolved'
+  },
+  emitConsumerMetrics: vi.fn()
+}))
+
+vi.mock('@/shared/emitConsumerMetricsSafely', () => ({
+  emitConsumerMetricsSafely: vi.fn()
 }))
 
 vi.mock('@/shared/logger', () => ({
@@ -96,6 +117,7 @@ const NEW_TRIGGER_SCIENCE_KEYWORD_OBJECT = {
 describe('when the metadata correction service is invoked', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(emitConsumerMetricsSafely).mockResolvedValue(undefined)
 
     vi.mocked(invokeMetadataCorrectionDelegate).mockResolvedValue({
       nativeFormat: 'DIF10',
@@ -1128,6 +1150,66 @@ describe('when the metadata correction service is invoked', () => {
         batchItemFailures: []
       })
     })
+
+    test('should emit consumed and processed metrics for a successful request', async () => {
+      vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
+        collectionConceptId: 'C1234567890-PROV',
+        providerId: 'PROV',
+        nativeId: 'native-123',
+        revisionId: 7,
+        format: 'application/dif10+xml',
+        umm: {}
+      })
+
+      vi.mocked(validateCmrCollectionUmm).mockResolvedValue({
+        status: 200,
+        errors: [],
+        warnings: [],
+        responseBody: {
+          errors: [],
+          warnings: []
+        }
+      })
+
+      vi.mocked(extractKeywordValidationFailures).mockReturnValue([])
+
+      await metadataCorrectionService({
+        Records: [
+          {
+            messageId: 'message-metrics-success',
+            body: JSON.stringify({
+              source: 'cmrKeywordEventsListener',
+              collectionConceptId: 'C1234567890-PROV',
+              keywordEvent: {
+                eventType: 'UPDATED',
+                scheme: 'sciencekeywords',
+                uuid: 'uuid-1'
+              }
+            })
+          }
+        ]
+      })
+
+      expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
+        metrics: [
+          {
+            metricName: CONSUMER_METRIC_NAMES.EVENTS_CONSUMED,
+            value: 1
+          }
+        ],
+        logMessage: '[metadata-correction] Failed to emit processing metrics'
+      }))
+
+      expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
+        metrics: [
+          {
+            metricName: CONSUMER_METRIC_NAMES.EVENTS_PROCESSED,
+            value: 1
+          }
+        ],
+        logMessage: '[metadata-correction] Failed to emit processing metrics'
+      }))
+    })
   })
 
   describe('when the invocation is unsuccessful', () => {
@@ -1234,6 +1316,82 @@ describe('when the metadata correction service is invoked', () => {
         '[metadata-correction] Failed to process metadata correction request',
         expect.anything()
       )
+    })
+
+    test('should emit a processing failure metric when a request fails', async () => {
+      await expect(metadataCorrectionService({
+        Records: [
+          {
+            messageId: 'message-processing-failure',
+            body: 'not-json'
+          }
+        ]
+      })).rejects.toThrow()
+
+      expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
+        metrics: [
+          {
+            metricName: CONSUMER_METRIC_NAMES.EVENTS_CONSUMED,
+            value: 1
+          }
+        ],
+        logMessage: '[metadata-correction] Failed to emit processing metrics'
+      }))
+
+      expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
+        metrics: [
+          {
+            metricName: CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES,
+            value: 1
+          }
+        ],
+        logMessage: '[metadata-correction] Failed to emit processing metrics'
+      }))
+    })
+
+    test('should log and continue when processing metric emission fails', async () => {
+      vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
+        collectionConceptId: 'C1234567890-PROV',
+        providerId: 'PROV',
+        nativeId: 'native-123',
+        revisionId: 7,
+        format: 'application/dif10+xml',
+        umm: {}
+      })
+
+      vi.mocked(validateCmrCollectionUmm).mockResolvedValue({
+        status: 200,
+        errors: [],
+        warnings: [],
+        responseBody: {
+          errors: [],
+          warnings: []
+        }
+      })
+
+      vi.mocked(extractKeywordValidationFailures).mockReturnValue([])
+      vi.mocked(emitConsumerMetricsSafely).mockResolvedValueOnce(undefined)
+
+      await expect(metadataCorrectionService({
+        Records: [
+          {
+            messageId: 'message-metric-failure',
+            body: JSON.stringify({
+              source: 'cmrKeywordEventsListener',
+              collectionConceptId: 'C1234567890-PROV'
+            })
+          }
+        ]
+      })).resolves.toEqual({
+        batchItemFailures: []
+      })
+
+      expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
+        logMessage: '[metadata-correction] Failed to emit processing metrics',
+        logContext: expect.objectContaining({
+          messageId: 'message-metric-failure'
+        })
+      }))
     })
   })
 })

--- a/serverless/src/metadataCorrectionService/__tests__/handler.test.js
+++ b/serverless/src/metadataCorrectionService/__tests__/handler.test.js
@@ -1202,7 +1202,7 @@ describe('when the metadata correction service is invoked', () => {
             value: 1
           }
         ],
-        logMessage: '[metadata-correction] Failed to emit async batch processing metrics',
+        errorLogMessage: '[metadata-correction] Failed to emit async batch processing metrics',
         logContext: expect.objectContaining({
           failureCount: 0,
           messageIds: ['message-metrics-success'],
@@ -1340,7 +1340,7 @@ describe('when the metadata correction service is invoked', () => {
             value: 1
           }
         ],
-        logMessage: '[metadata-correction] Failed to emit async batch processing metrics',
+        errorLogMessage: '[metadata-correction] Failed to emit async batch processing metrics',
         logContext: expect.objectContaining({
           failureCount: 1,
           messageIds: ['message-processing-failure'],
@@ -1388,7 +1388,7 @@ describe('when the metadata correction service is invoked', () => {
       })
 
       expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
-        logMessage: '[metadata-correction] Failed to emit async batch processing metrics',
+        errorLogMessage: '[metadata-correction] Failed to emit async batch processing metrics',
         logContext: expect.objectContaining({
           failureCount: 0,
           messageIds: ['message-metric-failure'],

--- a/serverless/src/metadataCorrectionService/__tests__/handler.test.js
+++ b/serverless/src/metadataCorrectionService/__tests__/handler.test.js
@@ -62,6 +62,7 @@ vi.mock('@/shared/emitConsumerMetricsSafely', () => ({
 vi.mock('@/shared/logger', () => ({
   logger: {
     info: vi.fn(),
+    debug: vi.fn(),
     error: vi.fn()
   }
 }))
@@ -1195,19 +1196,19 @@ describe('when the metadata correction service is invoked', () => {
           {
             metricName: CONSUMER_METRIC_NAMES.EVENTS_CONSUMED,
             value: 1
-          }
-        ],
-        logMessage: '[metadata-correction] Failed to emit processing metrics'
-      }))
-
-      expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
-        metrics: [
+          },
           {
             metricName: CONSUMER_METRIC_NAMES.EVENTS_PROCESSED,
             value: 1
           }
         ],
-        logMessage: '[metadata-correction] Failed to emit processing metrics'
+        logMessage: '[metadata-correction] Failed to emit async batch processing metrics',
+        logContext: expect.objectContaining({
+          failureCount: 0,
+          messageIds: ['message-metrics-success'],
+          processedCount: 1,
+          recordCount: 1
+        })
       }))
     })
   })
@@ -1333,19 +1334,19 @@ describe('when the metadata correction service is invoked', () => {
           {
             metricName: CONSUMER_METRIC_NAMES.EVENTS_CONSUMED,
             value: 1
-          }
-        ],
-        logMessage: '[metadata-correction] Failed to emit processing metrics'
-      }))
-
-      expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
-        metrics: [
+          },
           {
             metricName: CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES,
             value: 1
           }
         ],
-        logMessage: '[metadata-correction] Failed to emit processing metrics'
+        logMessage: '[metadata-correction] Failed to emit async batch processing metrics',
+        logContext: expect.objectContaining({
+          failureCount: 1,
+          messageIds: ['message-processing-failure'],
+          processedCount: 0,
+          recordCount: 1
+        })
       }))
     })
 
@@ -1387,9 +1388,12 @@ describe('when the metadata correction service is invoked', () => {
       })
 
       expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
-        logMessage: '[metadata-correction] Failed to emit processing metrics',
+        logMessage: '[metadata-correction] Failed to emit async batch processing metrics',
         logContext: expect.objectContaining({
-          messageId: 'message-metric-failure'
+          failureCount: 0,
+          messageIds: ['message-metric-failure'],
+          processedCount: 1,
+          recordCount: 1
         })
       }))
     })

--- a/serverless/src/metadataCorrectionService/handler.js
+++ b/serverless/src/metadataCorrectionService/handler.js
@@ -84,7 +84,7 @@ export const metadataCorrectionService = async (event) => {
         processedCount,
         failureCount
       }),
-      logMessage: '[metadata-correction] Failed to emit async batch processing metrics',
+      errorLogMessage: '[metadata-correction] Failed to emit async batch processing metrics',
       logContext: {
         failureCount,
         messageIds: records.map(({ messageId }) => messageId).filter(Boolean),

--- a/serverless/src/metadataCorrectionService/handler.js
+++ b/serverless/src/metadataCorrectionService/handler.js
@@ -1,3 +1,5 @@
+import { CONSUMER_METRIC_NAMES } from '@/shared/emitConsumerMetrics'
+import { emitConsumerMetricsSafely } from '@/shared/emitConsumerMetricsSafely'
 import { logger } from '@/shared/logger'
 import { runCollectionMetadataCorrection } from '@/shared/runCollectionMetadataCorrection'
 
@@ -15,6 +17,17 @@ export const metadataCorrectionService = async (event) => {
   const records = event?.Records || []
 
   await Promise.all(records.map(async (record) => {
+    await emitConsumerMetricsSafely({
+      metrics: [{
+        metricName: CONSUMER_METRIC_NAMES.EVENTS_CONSUMED,
+        value: 1
+      }],
+      logMessage: '[metadata-correction] Failed to emit processing metrics',
+      logContext: {
+        messageId: record?.messageId
+      }
+    })
+
     try {
       const metadataCorrectionRequest = JSON.parse(record.body || '{}')
 
@@ -30,7 +43,31 @@ export const metadataCorrectionService = async (event) => {
         messageId: record.messageId,
         source: metadataCorrectionRequest.source
       })
+
+      await emitConsumerMetricsSafely({
+        metrics: [{
+          metricName: CONSUMER_METRIC_NAMES.EVENTS_PROCESSED,
+          value: 1
+        }],
+        logMessage: '[metadata-correction] Failed to emit processing metrics',
+        logContext: {
+          collectionConceptId: metadataCorrectionRequest.collectionConceptId,
+          messageId: record.messageId,
+          source: metadataCorrectionRequest.source
+        }
+      })
     } catch (error) {
+      await emitConsumerMetricsSafely({
+        metrics: [{
+          metricName: CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES,
+          value: 1
+        }],
+        logMessage: '[metadata-correction] Failed to emit processing metrics',
+        logContext: {
+          messageId: record?.messageId
+        }
+      })
+
       logger.error('[metadata-correction] Failed to process metadata correction request', error)
       throw error
     }

--- a/serverless/src/metadataCorrectionService/handler.js
+++ b/serverless/src/metadataCorrectionService/handler.js
@@ -4,6 +4,42 @@ import { logger } from '@/shared/logger'
 import { runCollectionMetadataCorrection } from '@/shared/runCollectionMetadataCorrection'
 
 /**
+ * Builds the batch-level processing metrics emitted by the async correction consumer.
+ *
+ * @param {Object} params Batch processing counts.
+ * @param {number} params.consumedCount Number of SQS records received in the batch.
+ * @param {number} params.processedCount Number of records that completed successfully.
+ * @param {number} params.failureCount Number of records that failed during processing.
+ * @returns {Array<{metricName: string, value: number}>} Metrics to emit for the batch.
+ */
+const buildBatchProcessingMetrics = ({
+  consumedCount,
+  processedCount,
+  failureCount
+}) => {
+  const metrics = [{
+    metricName: CONSUMER_METRIC_NAMES.EVENTS_CONSUMED,
+    value: consumedCount
+  }]
+
+  if (processedCount > 0) {
+    metrics.push({
+      metricName: CONSUMER_METRIC_NAMES.EVENTS_PROCESSED,
+      value: processedCount
+    })
+  }
+
+  if (failureCount > 0) {
+    metrics.push({
+      metricName: CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES,
+      value: failureCount
+    })
+  }
+
+  return metrics
+}
+
+/**
  * Metadata correction service that consumes collection-scoped correction requests from SQS.
  *
  * The worker remains asynchronous for keyword-event-driven correction requests, but the actual
@@ -16,18 +52,7 @@ import { runCollectionMetadataCorrection } from '@/shared/runCollectionMetadataC
 export const metadataCorrectionService = async (event) => {
   const records = event?.Records || []
 
-  await Promise.all(records.map(async (record) => {
-    await emitConsumerMetricsSafely({
-      metrics: [{
-        metricName: CONSUMER_METRIC_NAMES.EVENTS_CONSUMED,
-        value: 1
-      }],
-      logMessage: '[metadata-correction] Failed to emit processing metrics',
-      logContext: {
-        messageId: record?.messageId
-      }
-    })
-
+  const settledResults = await Promise.allSettled(records.map(async (record) => {
     try {
       const metadataCorrectionRequest = JSON.parse(record.body || '{}')
 
@@ -43,35 +68,37 @@ export const metadataCorrectionService = async (event) => {
         messageId: record.messageId,
         source: metadataCorrectionRequest.source
       })
-
-      await emitConsumerMetricsSafely({
-        metrics: [{
-          metricName: CONSUMER_METRIC_NAMES.EVENTS_PROCESSED,
-          value: 1
-        }],
-        logMessage: '[metadata-correction] Failed to emit processing metrics',
-        logContext: {
-          collectionConceptId: metadataCorrectionRequest.collectionConceptId,
-          messageId: record.messageId,
-          source: metadataCorrectionRequest.source
-        }
-      })
     } catch (error) {
-      await emitConsumerMetricsSafely({
-        metrics: [{
-          metricName: CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES,
-          value: 1
-        }],
-        logMessage: '[metadata-correction] Failed to emit processing metrics',
-        logContext: {
-          messageId: record?.messageId
-        }
-      })
-
       logger.error('[metadata-correction] Failed to process metadata correction request', error)
       throw error
     }
   }))
+
+  if (records.length > 0) {
+    const processedCount = settledResults.filter(({ status }) => status === 'fulfilled').length
+    const failureCount = settledResults.length - processedCount
+
+    await emitConsumerMetricsSafely({
+      metrics: buildBatchProcessingMetrics({
+        consumedCount: records.length,
+        processedCount,
+        failureCount
+      }),
+      logMessage: '[metadata-correction] Failed to emit async batch processing metrics',
+      logContext: {
+        failureCount,
+        messageIds: records.map(({ messageId }) => messageId).filter(Boolean),
+        processedCount,
+        recordCount: records.length
+      }
+    })
+
+    const firstRejectedResult = settledResults.find(({ status }) => status === 'rejected')
+
+    if (firstRejectedResult) {
+      throw firstRejectedResult.reason
+    }
+  }
 
   return {
     batchItemFailures: []

--- a/serverless/src/shared/__tests__/emitConsumerMetrics.test.js
+++ b/serverless/src/shared/__tests__/emitConsumerMetrics.test.js
@@ -1,0 +1,205 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi
+} from 'vitest'
+
+import { logger } from '@/shared/logger'
+
+import {
+  CONSUMER_METRIC_NAMES,
+  CONSUMER_METRIC_NAMESPACE,
+  emitConsumerMetrics
+} from '../emitConsumerMetrics'
+import { emitConsumerMetricsSafely } from '../emitConsumerMetricsSafely'
+
+const {
+  CloudWatchClientMock,
+  fetchMock,
+  sendCloudWatchMock,
+  PutMetricDataCommandMock
+} = vi.hoisted(() => ({
+  CloudWatchClientMock: vi.fn(() => ({
+    send: sendCloudWatchMock
+  })),
+  fetchMock: vi.fn(),
+  sendCloudWatchMock: vi.fn(),
+  PutMetricDataCommandMock: vi.fn((input) => input)
+}))
+
+vi.mock('@aws-sdk/client-cloudwatch', () => ({
+  CloudWatchClient: CloudWatchClientMock,
+  PutMetricDataCommand: PutMetricDataCommandMock
+}))
+
+describe('emitConsumerMetrics', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    CloudWatchClientMock.mockImplementation(() => ({
+      send: sendCloudWatchMock
+    }))
+
+    vi.spyOn(logger, 'info').mockImplementation(() => {})
+    vi.stubGlobal('fetch', fetchMock)
+    delete process.env.AWS_ENDPOINT_URL
+    sendCloudWatchMock.mockResolvedValue({})
+  })
+
+  test('publishes the provided consumer metrics to CloudWatch', async () => {
+    await emitConsumerMetrics({
+      metrics: [
+        {
+          metricName: CONSUMER_METRIC_NAMES.EVENTS_CONSUMED,
+          value: 3
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.EVENTS_PROCESSED,
+          value: 2
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES,
+          value: 1
+        }
+      ]
+    })
+
+    expect(PutMetricDataCommandMock).toHaveBeenCalledWith({
+      Namespace: CONSUMER_METRIC_NAMESPACE,
+      MetricData: [
+        {
+          MetricName: CONSUMER_METRIC_NAMES.EVENTS_CONSUMED,
+          Unit: 'Count',
+          Value: 3
+        },
+        {
+          MetricName: CONSUMER_METRIC_NAMES.EVENTS_PROCESSED,
+          Unit: 'Count',
+          Value: 2
+        },
+        {
+          MetricName: CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES,
+          Unit: 'Count',
+          Value: 1
+        }
+      ]
+    })
+
+    expect(sendCloudWatchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('EventsConsumed:3')
+    )
+  })
+
+  test('publishes zero-valued metrics without dimensions', async () => {
+    await emitConsumerMetrics({
+      metrics: [
+        {
+          metricName: CONSUMER_METRIC_NAMES.CORRECTIONS_APPLIED_TO_METADATA,
+          value: 0
+        }
+      ]
+    })
+
+    expect(PutMetricDataCommandMock).toHaveBeenCalledWith({
+      Namespace: CONSUMER_METRIC_NAMESPACE,
+      MetricData: [
+        {
+          MetricName: CONSUMER_METRIC_NAMES.CORRECTIONS_APPLIED_TO_METADATA,
+          Unit: 'Count',
+          Value: 0
+        }
+      ]
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test('emits metrics to LocalStack CloudWatch with the query api when AWS_ENDPOINT_URL is set', async () => {
+    process.env.AWS_ENDPOINT_URL = 'http://localhost:4566'
+    fetchMock.mockResolvedValue({
+      ok: true
+    })
+
+    await emitConsumerMetrics({
+      metrics: [
+        {
+          metricName: CONSUMER_METRIC_NAMES.KEYWORDS_RESOLVED,
+          value: 1
+        }
+      ]
+    })
+
+    expect(sendCloudWatchMock).not.toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:4566', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
+      },
+      body: expect.any(String)
+    })
+
+    const requestBody = new URLSearchParams(fetchMock.mock.calls[0][1].body)
+
+    expect(requestBody.get('Action')).toBe('PutMetricData')
+    expect(requestBody.get('Version')).toBe('2010-08-01')
+    expect(requestBody.get('Namespace')).toBe(CONSUMER_METRIC_NAMESPACE)
+    expect(requestBody.get('MetricData.member.1.MetricName')).toBe(
+      CONSUMER_METRIC_NAMES.KEYWORDS_RESOLVED
+    )
+
+    expect(requestBody.get('MetricData.member.1.Value')).toBe('1')
+  })
+
+  test('throws when the LocalStack CloudWatch query request fails', async () => {
+    process.env.AWS_ENDPOINT_URL = 'http://localhost:4566'
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: vi.fn().mockResolvedValue('<?xml version="1.0"?><ErrorResponse />')
+    })
+
+    await expect(emitConsumerMetrics({
+      metrics: [
+        {
+          metricName: CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES,
+          value: 1
+        }
+      ]
+    })).rejects.toThrow('Failed to emit consumer keyword sync metrics to LocalStack')
+  })
+
+  test('logs and swallows metric emission failures when using the safe helper', async () => {
+    sendCloudWatchMock.mockRejectedValueOnce(new Error('cloudwatch unavailable'))
+    vi.spyOn(logger, 'error').mockImplementation(() => {})
+
+    await expect(emitConsumerMetricsSafely({
+      metrics: [
+        {
+          metricName: CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES,
+          value: 1
+        }
+      ],
+      logMessage: '[metadata-correction] Failed to emit processing metrics',
+      logContext: {
+        messageId: 'message-1'
+      }
+    })).resolves.toBeUndefined()
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[metadata-correction] Failed to emit processing metrics',
+      expect.objectContaining({
+        messageId: 'message-1',
+        error: 'cloudwatch unavailable',
+        metrics: [
+          {
+            metricName: CONSUMER_METRIC_NAMES.EVENT_PROCESSING_FAILURES,
+            value: 1
+          }
+        ]
+      })
+    )
+  })
+})

--- a/serverless/src/shared/__tests__/emitConsumerMetrics.test.js
+++ b/serverless/src/shared/__tests__/emitConsumerMetrics.test.js
@@ -41,7 +41,7 @@ describe('emitConsumerMetrics', () => {
       send: sendCloudWatchMock
     }))
 
-    vi.spyOn(logger, 'info').mockImplementation(() => {})
+    vi.spyOn(logger, 'debug').mockImplementation(() => {})
     vi.stubGlobal('fetch', fetchMock)
     delete process.env.AWS_ENDPOINT_URL
     sendCloudWatchMock.mockResolvedValue({})
@@ -88,7 +88,7 @@ describe('emitConsumerMetrics', () => {
 
     expect(sendCloudWatchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).not.toHaveBeenCalled()
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.debug).toHaveBeenCalledWith(
       expect.stringContaining('EventsConsumed:3')
     )
   })
@@ -168,7 +168,7 @@ describe('emitConsumerMetrics', () => {
           value: 1
         }
       ]
-    })).rejects.toThrow('Failed to emit consumer keyword sync metrics to LocalStack')
+    })).rejects.toThrow('Failed to emit consumer keyword sync metrics')
   })
 
   test('logs and swallows metric emission failures when using the safe helper', async () => {

--- a/serverless/src/shared/__tests__/emitConsumerMetrics.test.js
+++ b/serverless/src/shared/__tests__/emitConsumerMetrics.test.js
@@ -182,7 +182,7 @@ describe('emitConsumerMetrics', () => {
           value: 1
         }
       ],
-      logMessage: '[metadata-correction] Failed to emit processing metrics',
+      errorLogMessage: '[metadata-correction] Failed to emit processing metrics',
       logContext: {
         messageId: 'message-1'
       }
@@ -214,7 +214,7 @@ describe('emitConsumerMetrics', () => {
           value: 1
         }
       ],
-      logMessage: '[metadata-correction] Failed to emit processing metrics'
+      errorLogMessage: '[metadata-correction] Failed to emit processing metrics'
     })).resolves.toBeUndefined()
 
     expect(logger.error).toHaveBeenCalledWith(

--- a/serverless/src/shared/__tests__/emitConsumerMetrics.test.js
+++ b/serverless/src/shared/__tests__/emitConsumerMetrics.test.js
@@ -202,4 +202,32 @@ describe('emitConsumerMetrics', () => {
       })
     )
   })
+
+  test('logs metric emission failures when safe helper uses the default empty log context', async () => {
+    sendCloudWatchMock.mockRejectedValueOnce(new Error('cloudwatch unavailable'))
+    vi.spyOn(logger, 'error').mockImplementation(() => {})
+
+    await expect(emitConsumerMetricsSafely({
+      metrics: [
+        {
+          metricName: CONSUMER_METRIC_NAMES.EVENTS_CONSUMED,
+          value: 1
+        }
+      ],
+      logMessage: '[metadata-correction] Failed to emit processing metrics'
+    })).resolves.toBeUndefined()
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[metadata-correction] Failed to emit processing metrics',
+      {
+        metrics: [
+          {
+            metricName: CONSUMER_METRIC_NAMES.EVENTS_CONSUMED,
+            value: 1
+          }
+        ],
+        error: 'cloudwatch unavailable'
+      }
+    )
+  })
 })

--- a/serverless/src/shared/__tests__/runCollectionMetadataCorrection.test.js
+++ b/serverless/src/shared/__tests__/runCollectionMetadataCorrection.test.js
@@ -67,6 +67,7 @@ vi.mock('@/shared/emitConsumerMetricsSafely', () => ({
 vi.mock('@/shared/logger', () => ({
   logger: {
     info: vi.fn(),
+    debug: vi.fn(),
     error: vi.fn()
   }
 }))

--- a/serverless/src/shared/__tests__/runCollectionMetadataCorrection.test.js
+++ b/serverless/src/shared/__tests__/runCollectionMetadataCorrection.test.js
@@ -7,6 +7,8 @@ import {
 } from 'vitest'
 
 import { detectNativeMetadataFormat } from '@/shared/detectNativeMetadataFormat'
+import { CONSUMER_METRIC_NAMES } from '@/shared/emitConsumerMetrics'
+import { emitConsumerMetricsSafely } from '@/shared/emitConsumerMetricsSafely'
 import { extractKeywordValidationFailures } from '@/shared/extractKeywordValidationFailures'
 import { getCmrCollectionNativeMetadata } from '@/shared/getCmrCollectionNativeMetadata'
 import { getCmrCollectionUmmDetails } from '@/shared/getCmrCollectionUmmDetails'
@@ -43,9 +45,29 @@ vi.mock('@/shared/invokeMetadataCorrectionDelegate', () => ({
   ))
 }))
 
+vi.mock('@/shared/emitConsumerMetrics', () => ({
+  CONSUMER_METRIC_NAMES: {
+    EVENTS_CONSUMED: 'EventsConsumed',
+    EVENTS_PROCESSED: 'EventsProcessed',
+    EVENT_PROCESSING_FAILURES: 'EventProcessingFailures',
+    RECORDS_UPDATED_FROM_EVENT: 'RecordsUpdatedFromEvent',
+    RECORDS_UPDATED_FROM_MANUAL: 'RecordsUpdatedFromManual',
+    INVALID_KEYWORD_COUNT: 'InvalidKeywordCount',
+    CORRECTIONS_APPLIED_TO_METADATA: 'CorrectionsAppliedToMetadata',
+    CORRECTIONS_WRITTEN_TO_CMR: 'CorrectionsWrittenToCMR',
+    KEYWORDS_RESOLVED: 'KeywordsResolved'
+  },
+  emitConsumerMetrics: vi.fn()
+}))
+
+vi.mock('@/shared/emitConsumerMetricsSafely', () => ({
+  emitConsumerMetricsSafely: vi.fn()
+}))
+
 vi.mock('@/shared/logger', () => ({
   logger: {
-    info: vi.fn()
+    info: vi.fn(),
+    error: vi.fn()
   }
 }))
 
@@ -119,6 +141,24 @@ describe('runCollectionMetadataCorrection', () => {
       writeResult: null,
       source: 'metadataCorrectionService'
     })
+
+    expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
+      metrics: [
+        {
+          metricName: CONSUMER_METRIC_NAMES.INVALID_KEYWORD_COUNT,
+          value: 0
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.KEYWORDS_RESOLVED,
+          value: 0
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.CORRECTIONS_APPLIED_TO_METADATA,
+          value: 0
+        }
+      ],
+      logMessage: '[metadata-correction] Failed to emit correction-run metrics'
+    }))
 
     expect(logger.info).toHaveBeenCalledWith(
       '[metadata-correction] No resolvable keyword corrections found',
@@ -233,6 +273,7 @@ describe('runCollectionMetadataCorrection', () => {
 
     vi.mocked(writeCorrectedMetadataToCmr).mockResolvedValue({
       ingestResult: {
+        enabled: true,
         updated: true
       }
     })
@@ -241,6 +282,32 @@ describe('runCollectionMetadataCorrection', () => {
       collectionConceptId: 'C1234567890-PROV',
       source: 'metadataCorrectionApi'
     })
+
+    expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
+      metrics: [
+        {
+          metricName: CONSUMER_METRIC_NAMES.INVALID_KEYWORD_COUNT,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.KEYWORDS_RESOLVED,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.CORRECTIONS_APPLIED_TO_METADATA,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.CORRECTIONS_WRITTEN_TO_CMR,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_MANUAL,
+          value: 1
+        }
+      ],
+      logMessage: '[metadata-correction] Failed to emit correction-run metrics'
+    }))
 
     expect(persistMetadataCorrectionAuditLog).toHaveBeenNthCalledWith(
       1,
@@ -261,6 +328,54 @@ describe('runCollectionMetadataCorrection', () => {
         status: 'applied'
       })
     )
+  })
+
+  test('emits no-op run metrics for the synchronous concept-id correction flow', async () => {
+    vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
+      collectionConceptId: 'C1234567890-PROV',
+      providerId: 'PROV',
+      nativeId: 'native-123',
+      revisionId: 7,
+      format: 'application/dif10+xml',
+      umm: {}
+    })
+
+    vi.mocked(validateCmrCollectionUmm).mockResolvedValue({
+      status: 200,
+      errors: [],
+      warnings: [],
+      responseBody: {
+        errors: [],
+        warnings: []
+      }
+    })
+
+    vi.mocked(extractKeywordValidationFailures).mockReturnValue([])
+
+    await expect(runCollectionMetadataCorrection({
+      collectionConceptId: 'C1234567890-PROV',
+      source: 'metadataCorrectionApi'
+    })).resolves.toEqual(expect.objectContaining({
+      outcome: 'no-keyword-issues'
+    }))
+
+    expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
+      metrics: [
+        {
+          metricName: CONSUMER_METRIC_NAMES.INVALID_KEYWORD_COUNT,
+          value: 0
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.KEYWORDS_RESOLVED,
+          value: 0
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.CORRECTIONS_APPLIED_TO_METADATA,
+          value: 0
+        }
+      ],
+      logMessage: '[metadata-correction] Failed to emit correction-run metrics'
+    }))
   })
 
   test('passes the exact fetched UMM content type through to writeback', async () => {
@@ -343,12 +458,14 @@ describe('runCollectionMetadataCorrection', () => {
 
     vi.mocked(writeCorrectedMetadataToCmr).mockResolvedValue({
       ingestResult: {
+        enabled: true,
         updated: true
       }
     })
 
     await runCollectionMetadataCorrection({
-      collectionConceptId: 'C1234567890-PROV'
+      collectionConceptId: 'C1234567890-PROV',
+      source: 'metadataCorrectionApi'
     })
 
     expect(getCmrCollectionNativeMetadata).toHaveBeenCalledWith({
@@ -367,6 +484,32 @@ describe('runCollectionMetadataCorrection', () => {
     expect(writeCorrectedMetadataToCmr).toHaveBeenCalledWith(expect.objectContaining({
       nativeFormat: 'UMM',
       nativeMetadataContentType: 'application/vnd.nasa.cmr.umm+json;version=1.16.2; charset=utf-8'
+    }))
+
+    expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
+      metrics: [
+        {
+          metricName: CONSUMER_METRIC_NAMES.INVALID_KEYWORD_COUNT,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.KEYWORDS_RESOLVED,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.CORRECTIONS_APPLIED_TO_METADATA,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.CORRECTIONS_WRITTEN_TO_CMR,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_MANUAL,
+          value: 1
+        }
+      ],
+      logMessage: '[metadata-correction] Failed to emit correction-run metrics'
     }))
   })
 
@@ -452,6 +595,253 @@ describe('runCollectionMetadataCorrection', () => {
     expect(writeCorrectedMetadataToCmr).toHaveBeenCalledWith(expect.objectContaining({
       nativeFormat: 'DIF10',
       nativeMetadataContentType: ''
+    }))
+  })
+
+  test('does not emit record-update metrics when corrections are applied but writeback is disabled', async () => {
+    vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
+      collectionConceptId: 'C1234567890-PROV',
+      providerId: 'PROV',
+      nativeId: 'native-123',
+      revisionId: 7,
+      format: 'application/dif10+xml',
+      umm: {}
+    })
+
+    vi.mocked(validateCmrCollectionUmm).mockResolvedValue({
+      status: 200,
+      errors: ['invalid keyword'],
+      warnings: [],
+      responseBody: {
+        errors: ['invalid keyword'],
+        warnings: []
+      }
+    })
+
+    vi.mocked(extractKeywordValidationFailures).mockReturnValue([
+      {
+        scheme: 'sciencekeywords',
+        path: ['ScienceKeywords', 0],
+        keywordValue: {
+          Category: 'EARTH SCIENCE'
+        }
+      }
+    ])
+
+    vi.mocked(resolveOldKeywordConceptUuid).mockResolvedValue({
+      keywordConceptUuid: 'uuid-1',
+      oldKeywordObject: {
+        Category: 'EARTH SCIENCE'
+      },
+      newKeywordObject: {
+        Category: 'EARTH SCIENCE - UPDATED'
+      },
+      action: 'replace'
+    })
+
+    vi.mocked(getCmrCollectionNativeMetadata).mockResolvedValue('<DIF/>')
+
+    vi.mocked(invokeMetadataCorrectionDelegate).mockResolvedValue({
+      delegateName: 'dif10',
+      nativeFormat: 'DIF10',
+      correctionCount: 1,
+      correctionsApplied: [
+        {
+          scheme: 'sciencekeywords',
+          keywordConceptUuid: 'uuid-1'
+        }
+      ],
+      correctedMetadata: '<DIF>corrected</DIF>'
+    })
+
+    vi.mocked(persistMetadataCorrectionAuditLog).mockResolvedValue({
+      insertedCount: 1,
+      publishedVersionName: 'published',
+      status: 'pending'
+    })
+
+    vi.mocked(writeCorrectedMetadataToCmr).mockResolvedValue({
+      ingestResult: {
+        enabled: false,
+        ingested: false,
+        updated: false
+      }
+    })
+
+    await runCollectionMetadataCorrection({
+      collectionConceptId: 'C1234567890-PROV',
+      keywordEvent: {
+        eventType: 'UPDATED',
+        scheme: 'sciencekeywords',
+        uuid: 'uuid-1'
+      }
+    })
+
+    expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
+      metrics: [
+        {
+          metricName: CONSUMER_METRIC_NAMES.INVALID_KEYWORD_COUNT,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.KEYWORDS_RESOLVED,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.CORRECTIONS_APPLIED_TO_METADATA,
+          value: 1
+        }
+      ],
+      logMessage: '[metadata-correction] Failed to emit correction-run metrics'
+    }))
+  })
+
+  test('emits direct update metrics for keyword-event-driven corrections', async () => {
+    vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
+      collectionConceptId: 'C1234567890-PROV',
+      providerId: 'PROV',
+      nativeId: 'native-123',
+      revisionId: 7,
+      format: 'application/dif10+xml',
+      umm: {}
+    })
+
+    vi.mocked(validateCmrCollectionUmm).mockResolvedValue({
+      status: 200,
+      errors: ['invalid keyword'],
+      warnings: [],
+      responseBody: {
+        errors: ['invalid keyword'],
+        warnings: []
+      }
+    })
+
+    vi.mocked(extractKeywordValidationFailures).mockReturnValue([
+      {
+        scheme: 'sciencekeywords',
+        path: ['ScienceKeywords', 0],
+        keywordValue: {
+          Category: 'EARTH SCIENCE'
+        }
+      }
+    ])
+
+    vi.mocked(resolveOldKeywordConceptUuid).mockResolvedValue({
+      keywordConceptUuid: 'uuid-1',
+      oldKeywordObject: {
+        Category: 'EARTH SCIENCE'
+      },
+      newKeywordObject: {
+        Category: 'EARTH SCIENCE - UPDATED'
+      },
+      action: 'replace'
+    })
+
+    vi.mocked(getCmrCollectionNativeMetadata).mockResolvedValue('<DIF/>')
+
+    vi.mocked(invokeMetadataCorrectionDelegate).mockResolvedValue({
+      delegateName: 'dif10',
+      nativeFormat: 'DIF10',
+      correctionCount: 1,
+      correctionsApplied: [
+        {
+          scheme: 'sciencekeywords',
+          keywordConceptUuid: 'uuid-1'
+        }
+      ],
+      correctedMetadata: '<DIF>corrected</DIF>'
+    })
+
+    vi.mocked(persistMetadataCorrectionAuditLog)
+      .mockResolvedValueOnce({
+        insertedCount: 1,
+        publishedVersionName: 'published',
+        status: 'pending'
+      })
+      .mockResolvedValueOnce({
+        insertedCount: 1,
+        publishedVersionName: 'published',
+        status: 'applied'
+      })
+
+    vi.mocked(writeCorrectedMetadataToCmr).mockResolvedValue({
+      ingestResult: {
+        enabled: true,
+        updated: true
+      }
+    })
+
+    await runCollectionMetadataCorrection({
+      collectionConceptId: 'C1234567890-PROV',
+      keywordEvent: {
+        eventType: 'UPDATED',
+        scheme: 'sciencekeywords',
+        uuid: 'uuid-1'
+      }
+    })
+
+    expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
+      metrics: [
+        {
+          metricName: CONSUMER_METRIC_NAMES.INVALID_KEYWORD_COUNT,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.KEYWORDS_RESOLVED,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.CORRECTIONS_APPLIED_TO_METADATA,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.CORRECTIONS_WRITTEN_TO_CMR,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_EVENT,
+          value: 1
+        }
+      ],
+      logMessage: '[metadata-correction] Failed to emit correction-run metrics'
+    }))
+  })
+
+  test('logs and continues when correction-run metric emission fails', async () => {
+    vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
+      collectionConceptId: 'C1234567890-PROV',
+      providerId: 'PROV',
+      nativeId: 'native-123',
+      revisionId: 7,
+      format: 'application/dif10+xml',
+      umm: {}
+    })
+
+    vi.mocked(validateCmrCollectionUmm).mockResolvedValue({
+      status: 200,
+      errors: [],
+      warnings: [],
+      responseBody: {
+        errors: [],
+        warnings: []
+      }
+    })
+
+    vi.mocked(extractKeywordValidationFailures).mockReturnValue([])
+    vi.mocked(emitConsumerMetricsSafely).mockResolvedValueOnce(undefined)
+
+    await expect(runCollectionMetadataCorrection({
+      collectionConceptId: 'C1234567890-PROV'
+    })).resolves.toEqual(expect.objectContaining({
+      outcome: 'no-keyword-issues'
+    }))
+
+    expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
+      logMessage: '[metadata-correction] Failed to emit correction-run metrics',
+      logContext: expect.objectContaining({
+        collectionConceptId: 'C1234567890-PROV',
+        source: 'metadataCorrectionService'
+      })
     }))
   })
 

--- a/serverless/src/shared/__tests__/runCollectionMetadataCorrection.test.js
+++ b/serverless/src/shared/__tests__/runCollectionMetadataCorrection.test.js
@@ -158,7 +158,7 @@ describe('runCollectionMetadataCorrection', () => {
           value: 0
         }
       ],
-      logMessage: '[metadata-correction] Failed to emit correction-run metrics'
+      errorLogMessage: '[metadata-correction] Failed to emit correction-run metrics'
     }))
 
     expect(logger.info).toHaveBeenCalledWith(
@@ -307,7 +307,7 @@ describe('runCollectionMetadataCorrection', () => {
           value: 1
         }
       ],
-      logMessage: '[metadata-correction] Failed to emit correction-run metrics'
+      errorLogMessage: '[metadata-correction] Failed to emit correction-run metrics'
     }))
 
     expect(persistMetadataCorrectionAuditLog).toHaveBeenNthCalledWith(
@@ -375,7 +375,7 @@ describe('runCollectionMetadataCorrection', () => {
           value: 0
         }
       ],
-      logMessage: '[metadata-correction] Failed to emit correction-run metrics'
+      errorLogMessage: '[metadata-correction] Failed to emit correction-run metrics'
     }))
   })
 
@@ -510,7 +510,7 @@ describe('runCollectionMetadataCorrection', () => {
           value: 1
         }
       ],
-      logMessage: '[metadata-correction] Failed to emit correction-run metrics'
+      errorLogMessage: '[metadata-correction] Failed to emit correction-run metrics'
     }))
   })
 
@@ -693,7 +693,7 @@ describe('runCollectionMetadataCorrection', () => {
           value: 1
         }
       ],
-      logMessage: '[metadata-correction] Failed to emit correction-run metrics'
+      errorLogMessage: '[metadata-correction] Failed to emit correction-run metrics'
     }))
   })
 
@@ -804,7 +804,116 @@ describe('runCollectionMetadataCorrection', () => {
           value: 1
         }
       ],
-      logMessage: '[metadata-correction] Failed to emit correction-run metrics'
+      errorLogMessage: '[metadata-correction] Failed to emit correction-run metrics'
+    }))
+  })
+
+  test('emits deleted-action record update metrics when a deleted keyword event writes successfully', async () => {
+    vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
+      collectionConceptId: 'C1234567890-PROV',
+      providerId: 'PROV',
+      nativeId: 'native-123',
+      revisionId: 7,
+      format: 'application/dif10+xml',
+      umm: {}
+    })
+
+    vi.mocked(validateCmrCollectionUmm).mockResolvedValue({
+      status: 200,
+      errors: ['invalid keyword'],
+      warnings: [],
+      responseBody: {
+        errors: ['invalid keyword'],
+        warnings: []
+      }
+    })
+
+    vi.mocked(extractKeywordValidationFailures).mockReturnValue([
+      {
+        scheme: 'sciencekeywords',
+        path: ['ScienceKeywords', 0],
+        keywordValue: {
+          Category: 'EARTH SCIENCE'
+        }
+      }
+    ])
+
+    vi.mocked(resolveOldKeywordConceptUuid).mockResolvedValue({
+      keywordConceptUuid: 'uuid-1',
+      oldKeywordObject: {
+        Category: 'EARTH SCIENCE'
+      },
+      newKeywordObject: {},
+      action: 'delete'
+    })
+
+    vi.mocked(getCmrCollectionNativeMetadata).mockResolvedValue('<DIF/>')
+
+    vi.mocked(invokeMetadataCorrectionDelegate).mockResolvedValue({
+      delegateName: 'dif10',
+      nativeFormat: 'DIF10',
+      correctionCount: 1,
+      correctionsApplied: [
+        {
+          scheme: 'sciencekeywords',
+          keywordConceptUuid: 'uuid-1'
+        }
+      ],
+      correctedMetadata: '<DIF>corrected</DIF>'
+    })
+
+    vi.mocked(persistMetadataCorrectionAuditLog)
+      .mockResolvedValueOnce({
+        insertedCount: 1,
+        publishedVersionName: 'published',
+        status: 'pending'
+      })
+      .mockResolvedValueOnce({
+        insertedCount: 1,
+        publishedVersionName: 'published',
+        status: 'applied'
+      })
+
+    vi.mocked(writeCorrectedMetadataToCmr).mockResolvedValue({
+      ingestResult: {
+        enabled: true,
+        updated: true
+      }
+    })
+
+    await runCollectionMetadataCorrection({
+      collectionConceptId: 'C1234567890-PROV',
+      keywordEvent: {
+        eventType: 'DELETED',
+        scheme: 'sciencekeywords',
+        uuid: 'uuid-1'
+      }
+    })
+
+    expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
+      metrics: [
+        {
+          metricName: CONSUMER_METRIC_NAMES.INVALID_KEYWORD_COUNT,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.KEYWORDS_RESOLVED,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.CORRECTIONS_APPLIED_TO_METADATA,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.CORRECTIONS_WRITTEN_TO_CMR,
+          value: 1
+        },
+        {
+          metricName: CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_EVENT,
+          value: 1
+        }
+      ],
+      errorLogMessage: '[metadata-correction] Failed to emit correction-run metrics'
     }))
   })
 
@@ -838,7 +947,7 @@ describe('runCollectionMetadataCorrection', () => {
     }))
 
     expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
-      logMessage: '[metadata-correction] Failed to emit correction-run metrics',
+      errorLogMessage: '[metadata-correction] Failed to emit correction-run metrics',
       logContext: expect.objectContaining({
         collectionConceptId: 'C1234567890-PROV',
         source: 'metadataCorrectionService'

--- a/serverless/src/shared/emitConsumerMetrics.js
+++ b/serverless/src/shared/emitConsumerMetrics.js
@@ -112,7 +112,7 @@ const emitConsumerMetricsWithQueryApi = async ({ endpoint, metrics }) => {
     const responseBody = await response.text()
 
     throw new Error(
-      'Failed to emit consumer keyword sync metrics to LocalStack. '
+      'Failed to emit consumer keyword sync metrics. '
       + `Status: ${response.status}. Response: ${responseBody}`
     )
   }
@@ -143,7 +143,7 @@ export const emitConsumerMetrics = async ({ metrics }) => {
     }))
   }
 
-  logger.info(
+  logger.debug(
     '[consumer-metrics] Emitted consumer metrics '
     + `namespace=${CONSUMER_METRIC_NAMESPACE} `
     + `metrics=${metrics.map(({ metricName, value }) => `${metricName}:${value}`).join(',')}`

--- a/serverless/src/shared/emitConsumerMetrics.js
+++ b/serverless/src/shared/emitConsumerMetrics.js
@@ -1,0 +1,153 @@
+import { CloudWatchClient, PutMetricDataCommand } from '@aws-sdk/client-cloudwatch'
+
+import { logger } from './logger'
+
+/**
+ * Shared metric namespace used for CMR-side keyword sync monitoring.
+ * @type {string}
+ */
+export const CONSUMER_METRIC_NAMESPACE = 'CMR/KeywordSync'
+
+/**
+ * Consumer and reconciliation metric names emitted during metadata correction processing.
+ * @type {{[key: string]: string}}
+ */
+export const CONSUMER_METRIC_NAMES = {
+  // Count of metadata-correction SQS records the async consumer starts processing.
+  EVENTS_CONSUMED: 'EventsConsumed',
+
+  // Count of metadata-correction SQS records that complete without throwing.
+  EVENTS_PROCESSED: 'EventsProcessed',
+
+  // Count of metadata-correction SQS records that fail during processing.
+  EVENT_PROCESSING_FAILURES: 'EventProcessingFailures',
+
+  // Count of collections successfully updated in CMR by the async keyword-event flow.
+  RECORDS_UPDATED_FROM_EVENT: 'RecordsUpdatedFromEvent',
+
+  // Count of collections successfully updated in CMR by the manual single-collection sync endpoint.
+  RECORDS_UPDATED_FROM_MANUAL: 'RecordsUpdatedFromManual',
+
+  // Resolver-stage count: how many invalid keyword values were found for the collection.
+  INVALID_KEYWORD_COUNT: 'InvalidKeywordCount',
+
+  // How many invalid keyword findings were turned into concrete
+  // replace/delete correction plans.
+  KEYWORDS_RESOLVED: 'KeywordsResolved',
+
+  // Count of concrete corrections applied to the native metadata payload by the format-specific editor.
+  CORRECTIONS_APPLIED_TO_METADATA: 'CorrectionsAppliedToMetadata',
+
+  // Count of applied corrections successfully written to CMR.
+  CORRECTIONS_WRITTEN_TO_CMR: 'CorrectionsWrittenToCMR'
+}
+
+/**
+ * Creates a CloudWatch client for standard AWS metric emission.
+ *
+ * @returns {CloudWatchClient} Configured CloudWatch client instance.
+ */
+const createCloudWatchClient = () => new CloudWatchClient({})
+
+const cloudWatchClient = createCloudWatchClient()
+
+/**
+ * Converts consumer metric name/value pairs into CloudWatch MetricData entries.
+ *
+ * @param {Object} params Metric serialization details.
+ * @param {Array<{metricName: string, value: number}>} params.metrics Metrics to emit.
+ * @returns {Array<Object>} CloudWatch MetricData payload.
+ */
+const buildMetricData = ({ metrics }) => metrics.map(({ metricName, value }) => ({
+  MetricName: metricName,
+  Unit: 'Count',
+  Value: value
+}))
+
+/**
+ * Builds a CloudWatch Query API request body for local metric emission.
+ *
+ * @param {Object} params Query serialization details.
+ * @param {Array<{metricName: string, value: number}>} params.metrics Metrics to emit.
+ * @returns {string} URL-encoded request body for PutMetricData.
+ */
+const buildCloudWatchQueryRequestBody = ({ metrics }) => {
+  const params = new URLSearchParams({
+    Action: 'PutMetricData',
+    Version: '2010-08-01',
+    Namespace: CONSUMER_METRIC_NAMESPACE
+  })
+
+  metrics.forEach(({ metricName, value }, index) => {
+    const metricIndex = index + 1
+
+    params.set(`MetricData.member.${metricIndex}.MetricName`, metricName)
+    params.set(`MetricData.member.${metricIndex}.Unit`, 'Count')
+    params.set(`MetricData.member.${metricIndex}.Value`, String(value))
+  })
+
+  return params.toString()
+}
+
+/**
+ * Emits consumer metrics through the CloudWatch Query API.
+ *
+ * @param {Object} params Query API emission details.
+ * @param {string} params.endpoint Local CloudWatch-compatible endpoint.
+ * @param {Array<{metricName: string, value: number}>} params.metrics Metrics to emit.
+ * @returns {Promise<void>}
+ */
+const emitConsumerMetricsWithQueryApi = async ({ endpoint, metrics }) => {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
+    },
+    body: buildCloudWatchQueryRequestBody({
+      metrics
+    })
+  })
+
+  if (!response.ok) {
+    const responseBody = await response.text()
+
+    throw new Error(
+      'Failed to emit consumer keyword sync metrics to LocalStack. '
+      + `Status: ${response.status}. Response: ${responseBody}`
+    )
+  }
+}
+
+/**
+ * Emits one or more consumer metrics to CloudWatch.
+ *
+ * @param {Object} params Metric emission details.
+ * @param {Array<{metricName: string, value: number}>} params.metrics Metrics to emit.
+ * @returns {Promise<void>}
+ */
+export const emitConsumerMetrics = async ({ metrics }) => {
+  const endpoint = process.env.AWS_ENDPOINT_URL
+  const metricData = buildMetricData({
+    metrics
+  })
+
+  if (endpoint) {
+    await emitConsumerMetricsWithQueryApi({
+      endpoint,
+      metrics
+    })
+  } else {
+    await cloudWatchClient.send(new PutMetricDataCommand({
+      Namespace: CONSUMER_METRIC_NAMESPACE,
+      MetricData: metricData
+    }))
+  }
+
+  logger.info(
+    '[consumer-metrics] Emitted consumer metrics '
+    + `namespace=${CONSUMER_METRIC_NAMESPACE} `
+    + `metrics=${metrics.map(({ metricName, value }) => `${metricName}:${value}`).join(',')}`
+  )
+}
+
+export default emitConsumerMetrics

--- a/serverless/src/shared/emitConsumerMetrics.js
+++ b/serverless/src/shared/emitConsumerMetrics.js
@@ -22,10 +22,10 @@ export const CONSUMER_METRIC_NAMES = {
   // Count of metadata-correction SQS records that fail during processing.
   EVENT_PROCESSING_FAILURES: 'EventProcessingFailures',
 
-  // Count of collections successfully updated in CMR by the async keyword-event flow.
+  // Count of collections successfully updated in CMR for event-driven runs.
   RECORDS_UPDATED_FROM_EVENT: 'RecordsUpdatedFromEvent',
 
-  // Count of collections successfully updated in CMR by the manual single-collection sync endpoint.
+  // Count of collections successfully updated in CMR for manual sync runs.
   RECORDS_UPDATED_FROM_MANUAL: 'RecordsUpdatedFromManual',
 
   // Resolver-stage count: how many invalid keyword values were found for the collection.

--- a/serverless/src/shared/emitConsumerMetricsSafely.js
+++ b/serverless/src/shared/emitConsumerMetricsSafely.js
@@ -1,0 +1,31 @@
+import { emitConsumerMetrics } from '@/shared/emitConsumerMetrics'
+import { logger } from '@/shared/logger'
+
+/**
+ * Emits consumer metrics without failing the caller when CloudWatch is unavailable.
+ *
+ * @param {Object} params Safe emission details.
+ * @param {Array<{metricName: string, value: number}>} params.metrics Metrics to emit.
+ * @param {string} params.logMessage Error log message to use when metric emission fails.
+ * @param {Object} [params.logContext={}] Structured log context for failed emission.
+ * @returns {Promise<void>}
+ */
+export const emitConsumerMetricsSafely = async ({
+  metrics,
+  logMessage,
+  logContext = {}
+}) => {
+  try {
+    await emitConsumerMetrics({
+      metrics
+    })
+  } catch (metricError) {
+    logger.error(logMessage, {
+      ...logContext,
+      metrics,
+      error: metricError.message
+    })
+  }
+}
+
+export default emitConsumerMetricsSafely

--- a/serverless/src/shared/emitConsumerMetricsSafely.js
+++ b/serverless/src/shared/emitConsumerMetricsSafely.js
@@ -11,13 +11,13 @@ import { logger } from '@/shared/logger'
  *
  * @param {Object} params Safe emission details.
  * @param {Array<{metricName: string, value: number}>} params.metrics Metrics to emit.
- * @param {string} params.logMessage Error log message to use when metric emission fails.
+ * @param {string} params.errorLogMessage Error log message to use when metric emission fails.
  * @param {Object} [params.logContext={}] Structured log context for failed emission.
  * @returns {Promise<void>}
  */
 export const emitConsumerMetricsSafely = async ({
   metrics,
-  logMessage,
+  errorLogMessage,
   logContext = {}
 }) => {
   try {
@@ -25,7 +25,7 @@ export const emitConsumerMetricsSafely = async ({
       metrics
     })
   } catch (metricError) {
-    logger.error(logMessage, {
+    logger.error(errorLogMessage, {
       ...logContext,
       metrics,
       error: metricError.message

--- a/serverless/src/shared/emitConsumerMetricsSafely.js
+++ b/serverless/src/shared/emitConsumerMetricsSafely.js
@@ -2,7 +2,12 @@ import { emitConsumerMetrics } from '@/shared/emitConsumerMetrics'
 import { logger } from '@/shared/logger'
 
 /**
- * Emits consumer metrics without failing the caller when CloudWatch is unavailable.
+ * Best-effort wrapper around consumer metric emission.
+ *
+ * The correction worker and the shared collection runner both emit CloudWatch metrics, but
+ * metric delivery should never break the actual metadata-correction flow. This helper keeps that
+ * behavior in one place: try to emit, log enough context on failure, and then let processing
+ * continue.
  *
  * @param {Object} params Safe emission details.
  * @param {Array<{metricName: string, value: number}>} params.metrics Metrics to emit.

--- a/serverless/src/shared/runCollectionMetadataCorrection.js
+++ b/serverless/src/shared/runCollectionMetadataCorrection.js
@@ -159,36 +159,26 @@ const determineNoOpOutcome = (keywordValidationFailures) => (
  * Determines which record-update metric applies to the current correction run.
  *
  * @param {Object} params Classification inputs.
- * @param {Object} params.keywordEvent Optional triggering keyword event context.
- * @param {string} params.source Source label for the current correction request.
- * @returns {string|undefined} Metric name for the update source, if one applies.
+ * @param {Object} params.keywordEvent Normalized triggering keyword event context.
+ * @returns {string} Metric name for the run source bucket.
  */
 const getRecordUpdateMetricName = ({
-  keywordEvent,
-  source
+  keywordEvent
 }) => {
-  if (source === 'metadataCorrectionApi') {
+  const normalizedEventType = String(keywordEvent?.eventType || '').trim().toUpperCase()
+
+  if (normalizedEventType === 'MANUAL') {
     return CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_MANUAL
   }
 
-  if (typeof keywordEvent?.uuid === 'string' && keywordEvent.uuid.trim().length > 0) {
-    return CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_EVENT
-  }
-
-  logger.debug('[metadata-correction] No source-specific record update metric applied', {
-    source,
-    keywordEventUuid: keywordEvent?.uuid
-  })
-
-  return undefined
+  return CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_EVENT
 }
 
 /**
  * Builds the reconciliation/update metrics for a completed correction run.
  *
  * @param {Object} params Metric inputs.
- * @param {Object} params.keywordEvent Optional triggering keyword event context.
- * @param {string} params.source Source label for the current correction request.
+ * @param {Object} params.keywordEvent Normalized triggering keyword event context.
  * @param {Array} params.keywordValidationFailures Extracted invalid keyword failures.
  * @param {Array} params.resolvedCorrections Resolved corrections derived from the failures.
  * @param {Array} params.correctionsApplied Delegate-applied corrections.
@@ -197,7 +187,6 @@ const getRecordUpdateMetricName = ({
  */
 const buildRunMetrics = ({
   keywordEvent,
-  source,
   keywordValidationFailures,
   resolvedCorrections,
   correctionsApplied,
@@ -219,8 +208,7 @@ const buildRunMetrics = ({
   ]
   const writebackUpdated = writeResult?.ingestResult?.updated === true
   const recordUpdateMetricName = getRecordUpdateMetricName({
-    keywordEvent,
-    source
+    keywordEvent
   })
 
   if (correctionsApplied.length > 0 && writebackUpdated) {
@@ -229,12 +217,10 @@ const buildRunMetrics = ({
       value: correctionsApplied.length
     })
 
-    if (recordUpdateMetricName) {
-      metrics.push({
-        metricName: recordUpdateMetricName,
-        value: 1
-      })
-    }
+    metrics.push({
+      metricName: recordUpdateMetricName,
+      value: 1
+    })
   }
 
   return metrics
@@ -307,14 +293,13 @@ export const runCollectionMetadataCorrection = async ({
 
     await emitConsumerMetricsSafely({
       metrics: buildRunMetrics({
-        keywordEvent,
-        source,
+        keywordEvent: auditKeywordEvent,
         keywordValidationFailures,
         resolvedCorrections,
         correctionsApplied: [],
         writeResult: null
       }),
-      logMessage: '[metadata-correction] Failed to emit correction-run metrics',
+      errorLogMessage: '[metadata-correction] Failed to emit correction-run metrics',
       logContext: {
         collectionConceptId: collectionDetails.collectionConceptId,
         messageId,
@@ -447,14 +432,13 @@ export const runCollectionMetadataCorrection = async ({
 
   await emitConsumerMetricsSafely({
     metrics: buildRunMetrics({
-      keywordEvent,
-      source,
+      keywordEvent: auditKeywordEvent,
       keywordValidationFailures,
       resolvedCorrections,
       correctionsApplied,
       writeResult
     }),
-    logMessage: '[metadata-correction] Failed to emit correction-run metrics',
+    errorLogMessage: '[metadata-correction] Failed to emit correction-run metrics',
     logContext: {
       collectionConceptId: collectionDetails.collectionConceptId,
       messageId,

--- a/serverless/src/shared/runCollectionMetadataCorrection.js
+++ b/serverless/src/shared/runCollectionMetadataCorrection.js
@@ -1,4 +1,6 @@
 import { detectNativeMetadataFormat } from '@/shared/detectNativeMetadataFormat'
+import { CONSUMER_METRIC_NAMES } from '@/shared/emitConsumerMetrics'
+import { emitConsumerMetricsSafely } from '@/shared/emitConsumerMetricsSafely'
 import { extractKeywordValidationFailures } from '@/shared/extractKeywordValidationFailures'
 import { getCmrCollectionNativeMetadata } from '@/shared/getCmrCollectionNativeMetadata'
 import { getCmrCollectionUmmDetails } from '@/shared/getCmrCollectionUmmDetails'
@@ -154,6 +156,86 @@ const determineNoOpOutcome = (keywordValidationFailures) => (
 )
 
 /**
+ * Determines which record-update metric applies to the current correction run.
+ *
+ * @param {Object} params Classification inputs.
+ * @param {Object} params.keywordEvent Optional triggering keyword event context.
+ * @param {string} params.source Source label for the current correction request.
+ * @returns {string|undefined} Metric name for the update source, if one applies.
+ */
+const getRecordUpdateMetricName = ({
+  keywordEvent,
+  source
+}) => {
+  if (source === 'metadataCorrectionApi') {
+    return CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_MANUAL
+  }
+
+  if (typeof keywordEvent?.uuid === 'string' && keywordEvent.uuid.trim().length > 0) {
+    return CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_EVENT
+  }
+
+  return undefined
+}
+
+/**
+ * Builds the reconciliation/update metrics for a completed correction run.
+ *
+ * @param {Object} params Metric inputs.
+ * @param {Object} params.keywordEvent Optional triggering keyword event context.
+ * @param {string} params.source Source label for the current correction request.
+ * @param {Array} params.keywordValidationFailures Extracted invalid keyword failures.
+ * @param {Array} params.resolvedCorrections Resolved corrections derived from the failures.
+ * @param {Array} params.correctionsApplied Delegate-applied corrections.
+ * @param {Object|null} params.writeResult Writeback summary returned by CMR writeback.
+ * @returns {Array<{metricName: string, value: number}>} Metric payload for the run.
+ */
+const buildRunMetrics = ({
+  keywordEvent,
+  source,
+  keywordValidationFailures,
+  resolvedCorrections,
+  correctionsApplied,
+  writeResult
+}) => {
+  const metrics = [
+    {
+      metricName: CONSUMER_METRIC_NAMES.INVALID_KEYWORD_COUNT,
+      value: keywordValidationFailures.length
+    },
+    {
+      metricName: CONSUMER_METRIC_NAMES.KEYWORDS_RESOLVED,
+      value: resolvedCorrections.length
+    },
+    {
+      metricName: CONSUMER_METRIC_NAMES.CORRECTIONS_APPLIED_TO_METADATA,
+      value: correctionsApplied.length
+    }
+  ]
+  const writebackUpdated = writeResult?.ingestResult?.updated === true
+  const recordUpdateMetricName = getRecordUpdateMetricName({
+    keywordEvent,
+    source
+  })
+
+  if (correctionsApplied.length > 0 && writebackUpdated) {
+    metrics.push({
+      metricName: CONSUMER_METRIC_NAMES.CORRECTIONS_WRITTEN_TO_CMR,
+      value: correctionsApplied.length
+    })
+
+    if (recordUpdateMetricName) {
+      metrics.push({
+        metricName: recordUpdateMetricName,
+        value: 1
+      })
+    }
+  }
+
+  return metrics
+}
+
+/**
  * Runs the full metadata-correction flow for one collection and returns a rich summary.
  *
  * This is the shared execution seam used by both the asynchronous SQS consumer and the
@@ -216,6 +298,24 @@ export const runCollectionMetadataCorrection = async ({
       messageId,
       nativeFormat,
       keywordValidationFailureCount: keywordValidationFailures.length
+    })
+
+    await emitConsumerMetricsSafely({
+      metrics: buildRunMetrics({
+        keywordEvent,
+        source,
+        keywordValidationFailures,
+        resolvedCorrections,
+        correctionsApplied: [],
+        writeResult: null
+      }),
+      logMessage: '[metadata-correction] Failed to emit correction-run metrics',
+      logContext: {
+        collectionConceptId: collectionDetails.collectionConceptId,
+        messageId,
+        nativeFormat,
+        source
+      }
     })
 
     return {
@@ -338,6 +438,24 @@ export const runCollectionMetadataCorrection = async ({
     nativeFormat,
     correctionCount: normalizedCorrectionCount,
     writeResult
+  })
+
+  await emitConsumerMetricsSafely({
+    metrics: buildRunMetrics({
+      keywordEvent,
+      source,
+      keywordValidationFailures,
+      resolvedCorrections,
+      correctionsApplied,
+      writeResult
+    }),
+    logMessage: '[metadata-correction] Failed to emit correction-run metrics',
+    logContext: {
+      collectionConceptId: collectionDetails.collectionConceptId,
+      messageId,
+      nativeFormat,
+      source
+    }
   })
 
   return {

--- a/serverless/src/shared/runCollectionMetadataCorrection.js
+++ b/serverless/src/shared/runCollectionMetadataCorrection.js
@@ -175,6 +175,11 @@ const getRecordUpdateMetricName = ({
     return CONSUMER_METRIC_NAMES.RECORDS_UPDATED_FROM_EVENT
   }
 
+  logger.debug('[metadata-correction] No source-specific record update metric applied', {
+    source,
+    keywordEventUuid: keywordEvent?.uuid
+  })
+
   return undefined
 }
 


### PR DESCRIPTION
# Overview

### What is the feature?

This PR adds CloudWatch monitoring for metadata-correction consumer processing.

This gives us visibility into:
- how many async correction events are consumed
- how many finish successfully or fail
- how many invalid keywords are found and resolved
- how many corrections are applied to metadata
- how many corrected records are actually written back to CMR

It also adds equivalent metrics for the manual single-collection sync path so both flows report into the same `CMR/KeywordSync` namespace.

### What is the Solution?

This branch adds shared consumer metric emission and wires it into both metadata-correction execution paths.

Key changes:
- Adds shared metric definitions and emission logic in:
  - `serverless/src/shared/emitConsumerMetrics.js`
  - `serverless/src/shared/emitConsumerMetricsSafely.js`
- Emits consumer lifecycle metrics from the async metadata-correction consumer:
  - `EventsConsumed`
  - `EventsProcessed`
  - `EventProcessingFailures`
- Emits correction-stage and writeback-stage metrics from the shared collection runner:
  - `InvalidKeywordCount`
  - `KeywordsResolved`
  - `CorrectionsAppliedToMetadata`
  - `CorrectionsWrittenToCMR`
  - `RecordsUpdatedFromEvent`
  - `RecordsUpdatedFromManual`
- Adds CloudWatch `PutMetricData` permissions for the metadata correction setup in CDK.

### What areas of the application does this impact?

- Metadata correction consumer
- Shared correction runner
- Shared metrics helpers
- CDK IAM setup for metadata correction

# Testing

# KMS-669 AWS Test Session

Script used:
- `scripts/local/find_collection_with_positive_manual_sync_result.mjs`

```bash
# Set the KMS token used by the manual correction endpoint.
export KMS_AUTHORIZATION='Bearer <kms token>'

# Run the manual correction finder until one AMD_KOPRI DIF10 collection returns a positive result.
ALLOW_MUTATING_CORRECTION_ENDPOINT=true MAX_CONCEPTS=10 \
node scripts/local/find_collection_with_positive_manual_sync_result.mjs sit dif10 AMD_KOPRI \
  | tee /tmp/kms-669-correction-response.json

# Inspect the key response fields from the matching correction run.
jq '{ collectionConceptId, matchedField, matchedValue, outcome: .response.outcome, keywordValidationFailureCount: .response.keywordValidationFailureCount, resolvedCorrectionCount: .response.resolvedCorrectionCount, correctionsAppliedCount: .response.correctionResult.correctionsAppliedCount, writeUpdated: .response.writeResult.ingestResult.updated }' \
  /tmp/kms-669-correction-response.json
```

In AWS, open `CloudWatch` -> `Metrics` -> `All metrics` -> `Custom namespaces` -> `CMR/KeywordSync`. Use `Sum`, set the period to `1 minute`, and check the last few minutes right after running the script. For a good manual test run, look for movement on `InvalidKeywordCount`, `KeywordsResolved`, and `CorrectionsAppliedToMetadata`. If writeback was enabled and succeeded, you should also see `CorrectionsWrittenToCMR` and `RecordsUpdatedFromManual`.

### Attachments

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added consumer keyword-sync metric reporting for metadata correction runs, including consumed/processed and processing-failure metrics.
  * Updated local fixtures and mock server to support native metadata content type overrides.
  * Added local smoke tests for async and manual sync flows, plus a helper script to find collections with positive manual-sync results.
* **Bug Fixes**
  * Improved batch handling so all records are attempted; metric emission failures are logged but no longer block processing.
* **Tests**
  * Expanded unit and integration coverage for metric emission and correction scenarios, including error and no-op paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->