### PR TITLE
KMS-686: Update Keywords in ISO19115 native records

### DIFF
--- a/scripts/local/fixtures/metadata_correction_service.iso-19115.corrections.json
+++ b/scripts/local/fixtures/metadata_correction_service.iso-19115.corrections.json
@@ -1,0 +1,126 @@
+{
+  "collectionConceptId": "C1234567222-LOCAL",
+  "nativeFormat": "ISO19115",
+  "source": "local-smoke",
+  "corrections": [
+    {
+      "scheme": "sciencekeywords",
+      "action": "replace",
+      "oldKeywordObject": {
+        "Category": "EARTH SCIENCE",
+        "Topic": "ATMOSPHERE",
+        "Term": "AEROSOLS",
+        "VariableLevel1": "",
+        "VariableLevel2": "",
+        "VariableLevel3": "",
+        "DetailedVariable": ""
+      },
+      "newKeywordObject": {
+        "Category": "EARTH SCIENCE",
+        "Topic": "OCEANS",
+        "Term": "MARINE SEDIMENTS",
+        "VariableLevel1": "PARTICLE SIZE",
+        "VariableLevel2": "",
+        "VariableLevel3": "",
+        "DetailedVariable": ""
+      }
+    },
+    {
+      "scheme": "locations",
+      "action": "replace",
+      "oldKeywordObject": {
+        "Category": "CONTINENT",
+        "Type": "NORTH AMERICA",
+        "Subregion1": "CANADA",
+        "Subregion2": "ALBERTA",
+        "Subregion3": "",
+        "DetailedLocation": ""
+      },
+      "newKeywordObject": {
+        "Category": "CONTINENT",
+        "Type": "NORTH AMERICA",
+        "Subregion1": "MEXICO",
+        "Subregion2": "",
+        "Subregion3": "",
+        "DetailedLocation": ""
+      }
+    },
+    {                                     
+      "scheme": "platforms",
+      "action": "replace",
+      "newLongName": "New Platform Long Name",
+      "oldKeywordObject": {
+        "Class": "Air-based Platforms",
+        "Type": "Rotorcraft/Helicopter",
+        "ShortName": "AQUA"
+      },
+      "newKeywordObject": {
+        "Class": "Air-based Platforms",
+        "Type": "Rotorcraft/Helicopter",
+        "ShortName": "AQUA"
+      }
+    },
+    {
+      "scheme": "instruments",
+      "action": "delete",
+      "oldKeywordObject": {
+        "Category": "Imaging Spectrometers/Radiometers",
+        "Class": "",
+        "Subclass": "",
+        "ShortName": "ATLAS"
+      }
+    },
+    {
+      "scheme": "projects",
+      "action": "replace",
+      "newLongName": "New Project Long Name",
+      "oldKeywordObject": {
+        "Category": "M - N",
+        "ShortName": "MEASURES"
+      },
+      "newKeywordObject": {
+        "Category": "M - N",
+        "ShortName": "MEASURES-UPDATED"
+      }
+    },
+    {
+      "scheme": "providers",
+      "action": "replace",
+      "newLongName": "New Provider Long Name",
+      "oldKeywordObject": {
+        "BucketLevel0": "ARCHIVER",
+        "BucketLevel1": "",
+        "BucketLevel2": "",
+        "BucketLevel3": "",
+        "ShortName": "DOC/NOAA/NESDIS/NCEI"
+      },
+      "newKeywordObject": {
+        "BucketLevel0": "ARCHIVER",
+        "BucketLevel1": "",
+        "BucketLevel2": "",
+        "BucketLevel3": "",
+        "ShortName": "DOC/NOAA/NESDIS/NCEI-1"
+      }
+    },                                    
+    {
+      "scheme": "isotopiccategory",
+      "action": "replace",
+      "oldKeywordObject": {
+        "Value": "FARMING"
+      },
+      "newKeywordObject": {
+        "Value": "BIOTA"
+      }
+    },
+    {
+      "scheme": "productlevelid",
+      "action": "replace",
+      "oldKeywordObject": {
+        "Value": "3"
+      },
+      "newKeywordObject": {
+        "Value": "5"
+      }
+    }
+  ]
+}

--- a/scripts/local/fixtures/metadata_correction_service.iso-19115.corrections.json
+++ b/scripts/local/fixtures/metadata_correction_service.iso-19115.corrections.json
@@ -48,26 +48,45 @@
     {                                     
       "scheme": "platforms",
       "action": "replace",
-      "newLongName": "New Platform Long Name",
+      "newLongName": "Earth Observing System AQUA Updated",
       "oldKeywordObject": {
-        "Class": "Air-based Platforms",
-        "Type": "Rotorcraft/Helicopter",
         "ShortName": "AQUA"
       },
       "newKeywordObject": {
-        "Class": "Air-based Platforms",
-        "Type": "Rotorcraft/Helicopter",
-        "ShortName": "AQUA"
+        "ShortName": "AQUA-2"
+      }
+    },
+    {
+      "scheme": "platforms",
+      "action": "replace",
+      "newLongName": "Earth Observing System TERRA Updated",
+      "oldKeywordObject": {
+        "ShortName": "TERRA"
+      },
+      "newKeywordObject": {
+        "ShortName": "TERRA-2"
       }
     },
     {
       "scheme": "instruments",
-      "action": "delete",
+      "action": "replace",
+      "newLongName": "Moderate-Resolution Imaging Spectroradiometer Updated",
       "oldKeywordObject": {
-        "Category": "Imaging Spectrometers/Radiometers",
-        "Class": "",
-        "Subclass": "",
+        "ShortName": "MODIS"
+      },
+      "newKeywordObject": {
+        "ShortName": "MODIS-2"
+      }
+    },
+    {
+      "scheme": "instruments",
+      "action": "replace",
+      "newLongName": "Advanced Topographic Laser Altimeter System Updated",
+      "oldKeywordObject": {
         "ShortName": "ATLAS"
+      },
+      "newKeywordObject": {
+        "ShortName": "ATLAS-2"
       }
     },
     {

--- a/scripts/local/fixtures/metadata_correction_service.iso-19115.example.xml
+++ b/scripts/local/fixtures/metadata_correction_service.iso-19115.example.xml
@@ -1,0 +1,279 @@
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode codeListValue="LOCATION">LOCATION</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode codeListValue="FARMING">FARMING</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode codeListValue="ELEVATION">ELEVATION</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:processingLevel>
+        <gmd:MD_Identifier>
+          <gmd:code>
+            <gco:CharacterString>3</gco:CharacterString>
+          </gmd:code>
+          <gmd:codeSpace>
+            <gco:CharacterString>gov.nasa.esdis.umm.processinglevelid</gco:CharacterString>
+          </gmd:codeSpace>
+        </gmd:MD_Identifier>
+      </gmd:processingLevel>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gmx:Anchor xlink:href="https://gcmdservices.gsfc.nasa.gov/kms/concept/086c68e5-1c94-4f2f-89d5-0453443ff249" xlink:actuate="onRequest">DOC/NOAA/NESDIS/NODC &gt; National Oceanographic Data Center, NESDIS, NOAA, U.S. Department of Commerce</gmx:Anchor>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gmx:Anchor xlink:href="https://gcmdservices.gsfc.nasa.gov/kms/concept/e59896e0-3b4d-43ea-9348-f1f456305d05" xlink:actuate="onRequest">DOC/NOAA/NESDIS/NCEI &gt; National Centers for Environmental Information, NESDIS, NOAA, U.S. Department of Commerce</gmx:Anchor>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="https://data.noaa.gov/resources/iso19139/schema/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="dataCentre">dataCentre</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>Global Change Master Directory (GCMD) Data Center Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2019-11-12</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="https://data.noaa.gov/resources/iso19139/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:edition>
+                <gco:CharacterString>9</gco:CharacterString>
+              </gmd:edition>
+              <gmd:citedResponsibleParty>
+                <gmd:CI_ResponsibleParty>
+                  <gmd:organisationName>
+                    <gco:CharacterString>Global Change Data Center, Science and Exploration Directorate, Goddard Space Flight Center (GSFC) National Aeronautics and Space Administration (NASA)</gco:CharacterString>
+                  </gmd:organisationName>
+                  <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                      <gmd:address>
+                        <gmd:CI_Address>
+                          <gmd:city>
+                            <gco:CharacterString>Greenbelt</gco:CharacterString>
+                          </gmd:city>
+                          <gmd:administrativeArea>
+                            <gco:CharacterString>MD</gco:CharacterString>
+                          </gmd:administrativeArea>
+                        </gmd:CI_Address>
+                      </gmd:address>
+                      <gmd:onlineResource>
+                        <gmd:CI_OnlineResource>
+                          <gmd:linkage>
+                            <gmd:URL>https://wiki.earthdata.nasa.gov/display/gcmdkey</gmd:URL>
+                          </gmd:linkage>
+                          <gmd:protocol>
+                            <gco:CharacterString>HTTPS</gco:CharacterString>
+                          </gmd:protocol>
+                          <gmd:name>
+                            <gco:CharacterString>GCMD Keyword Forum Page</gco:CharacterString>
+                          </gmd:name>
+                          <gmd:description>
+                            <gco:CharacterString>The information provided on this page seeks to define how the GCMD Keywords are structured, used and accessed. It also provides information on how users can participate in the further development of the keywords.</gco:CharacterString>
+                          </gmd:description>
+                          <gmd:function>
+                            <gmd:CI_OnLineFunctionCode codeList="https://data.noaa.gov/resources/iso19139/schema/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
+                          </gmd:function>
+                        </gmd:CI_OnlineResource>
+                      </gmd:onlineResource>
+                    </gmd:CI_Contact>
+                  </gmd:contactInfo>
+                  <gmd:role>
+                    <gmd:CI_RoleCode codeList="https://data.noaa.gov/resources/iso19139/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="custodian">custodian</gmd:CI_RoleCode>
+                  </gmd:role>
+                </gmd:CI_ResponsibleParty>
+              </gmd:citedResponsibleParty>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>   
+          <gmd:keyword>
+            <gco:CharacterString>EARTH SCIENCE &gt; Cryosphere &gt; Glaciers/Ice Sheets &gt; Firn &gt; Snow Grain Size</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>EARTH SCIENCE &gt; ATMOSPHERE &gt; AEROSOLS</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>EARTH SCIENCE &gt; Cryosphere &gt; Glaciers/Ice Sheets &gt; Glacier Topography/Ice Sheet Topography &gt; Surface Morphology</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>EARTH SCIENCE &gt; Cryosphere &gt; Glaciers/Ice Sheets &gt; Glacier Topography/Ice Sheet Topography &gt; Surface Morphology</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Science Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-02-05</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>TERRA &gt; Earth Observing System, TERRA (AM-1)</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>AQUA &gt; Earth Observing System</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Platform Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2016-06-10</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+            <gmd:keyword>
+            <gco:CharacterString>ATLAS &gt; Advanced Topographic Laser Altimeter System</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>MODIS &gt; Moderate-Resolution Imaging Spectroradiometer</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="instrument">instrument</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Instrument Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2016-06-01</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>MEASURES &gt; Making Earth System Data Records for Use in Research Environments</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>MAGIA &gt; Structure, Stratigraphy, and Sedimentology North of the Antarctic Peninsula</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="project">project</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Project Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-01-24</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>Continent &gt; North America &gt; Greenland</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>Continent &gt; North America &gt; Canada &gt; Alberta</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="place">place</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Location Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-02-05</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:contentInfo>
+    <gmd:MD_ImageDescription>
+      <gmd:processingLevelCode>
+        <gmd:MD_Identifier>
+          <gmd:code>
+            <gco:CharacterString>3</gco:CharacterString>
+          </gmd:code>
+          <gmd:codeSpace>
+            <gco:CharacterString>gov.nasa.esdis.umm.processinglevelid</gco:CharacterString>
+          </gmd:codeSpace>
+        </gmd:MD_Identifier>
+      </gmd:processingLevelCode>
+    </gmd:MD_ImageDescription>
+  </gmd:contentInfo>
+</gmi:MI_Metadata>

--- a/scripts/local/fixtures/metadata_correction_service.iso-19115.example.xml
+++ b/scripts/local/fixtures/metadata_correction_service.iso-19115.example.xml
@@ -276,4 +276,60 @@
       </gmd:processingLevelCode>
     </gmd:MD_ImageDescription>
   </gmd:contentInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <!-- CWIC-style platform (combined ShortName > LongName in code) -->
+      <gmi:platform>
+        <eos:EOS_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>AQUA > Earth Observing System</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:instrument>
+            <eos:EOS_Instrument>
+              <gmi:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gco:CharacterString>MODIS > Moderate-Resolution Imaging Spectroradiometer</gco:CharacterString>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmi:identifier>
+            </eos:EOS_Instrument>
+          </gmi:instrument>
+        </eos:EOS_Platform>
+      </gmi:platform>
+      <!-- NSIDC/NOAA-style platform (split format: ShortName in code, LongName in description) -->
+      <gmi:platform>
+        <gmi:MI_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>TERRA</gco:CharacterString>
+              </gmd:code>
+              <gmd:description>
+                <gco:CharacterString>Earth Observing System, TERRA (AM-1)</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:instrument>
+            <gmi:MI_Instrument>
+              <gmi:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gco:CharacterString>ATLAS</gco:CharacterString>
+                  </gmd:code>
+                  <gmd:description>
+                    <gco:CharacterString>Advanced Topographic Laser Altimeter System</gco:CharacterString>
+                  </gmd:description>
+                </gmd:MD_Identifier>
+              </gmi:identifier>
+            </gmi:MI_Instrument>
+          </gmi:instrument>
+        </gmi:MI_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
 </gmi:MI_Metadata>

--- a/scripts/local/list_collection_concept_ids_by_native_format.mjs
+++ b/scripts/local/list_collection_concept_ids_by_native_format.mjs
@@ -31,7 +31,9 @@ const ENVIRONMENT_BASE_URLS = {
 const FORMAT_ALIASES = {
   dif10: 'application/dif10+xml',
   echo10: 'application/echo10+xml',
-  umm: 'application/vnd.nasa.cmr.umm+json'
+  umm: 'application/vnd.nasa.cmr.umm+json',
+  iso19115: 'application/iso19115+xml',
+  isosmap: 'application/iso:smap+xml'
 }
 
 /**

--- a/scripts/local/run_metadata_correction_iso-19115_smoke.mjs
+++ b/scripts/local/run_metadata_correction_iso-19115_smoke.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+const rootDir = path.resolve(import.meta.dirname, '../..')
+const fixturePath = path.resolve(
+  rootDir,
+  'scripts/local/fixtures/metadata_correction_service.iso-19115.corrections.json'
+)
+const metadataPayloadPath = path.resolve(
+  rootDir,
+  'scripts/local/fixtures/metadata_correction_service.iso-19115.example.xml'
+)
+const outputPath = path.resolve(
+  rootDir,
+  'tmp/metadata_correction_service_iso-19115_smoke_output.xml'
+)
+
+const fixture = JSON.parse(await fs.readFile(fixturePath, 'utf8'))
+const metadataPayload = await fs.readFile(metadataPayloadPath, 'utf8')
+
+const { applyIso19115MetadataCorrections } = await import('../../serverless/src/shared/applyIso19115MetadataCorrections')
+const { writeCorrectedMetadataToCmr } = await import('../../serverless/src/shared/writeCorrectedMetadataToCmr')
+
+const request = {
+  ...fixture,
+  metadataPayload
+}
+
+const correctionResult = await applyIso19115MetadataCorrections(request)
+
+await fs.mkdir(path.dirname(outputPath), { recursive: true })
+await fs.writeFile(outputPath, correctionResult.correctedMetadata || '', 'utf8')
+
+const writeResult = await writeCorrectedMetadataToCmr({
+  collectionConceptId: request.collectionConceptId,
+  nativeFormat: request.nativeFormat,
+  correctedMetadata: correctionResult.correctedMetadata || '',
+  correctionCount: correctionResult.correctionCount || 0,
+  correctionsApplied: correctionResult.correctionsApplied || [],
+  source: request.source || 'local-smoke'
+})
+
+console.log('[metadata-correction-smoke] Applied corrections locally')
+console.log(JSON.stringify({
+  fixturePath,
+  collectionConceptId: request.collectionConceptId,
+  nativeFormat: request.nativeFormat,
+  requestedCorrections: request.corrections.length,
+  appliedCorrections: correctionResult.correctionCount || 0,
+  outputPath,
+  writeResult
+}, null, 2))

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -4,14 +4,22 @@ import { FULL_PATH_VALUE_FIELDS } from './redis-path-store/helpers/constants'
 /**
  * Helper factory function to create a block editor configuration.
  * Maps a correction to an update operation within the editor instance.
+ * @param {Object} config - Configuration object defining XPath and transformation logic.
+ * @returns {Function} Function to apply the update.
  */
 const blockScheme = (config) => (editor, correction) => editor.updateBlockNode(correction, config)
-
+/**
+ * Helper factory function to create a leaf editor configuration.
+ * @param {Object} config - Configuration object for updating single nodes.
+ * @returns {Function} Function to apply the update.
+ */
 const leafScheme = (config) => (editor, correction) => editor.updateLeafNode(correction, config)
-
 /**
  * Factory to generate standardized keyword block editors for structures
  * like Platforms and Instruments.
+ * * @param {string} type - The 'codeListValue' for the MD_KeywordTypeCode.
+ * @param {Object} options - Configuration for field parsing and value generation.
+ * @returns {Function} Configured block editor function.
  */
 const createKeywordBlock = (type, { fieldKeys, matchKeys, getValue }) => blockScheme({
   nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords[gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${type}']`,
@@ -19,6 +27,10 @@ const createKeywordBlock = (type, { fieldKeys, matchKeys, getValue }) => blockSc
     fieldPaths: ['gmx:Anchor', 'gco:CharacterString'],
     valueKeys: fieldKeys,
     matchKeys,
+    /**
+     * Extracts values from the XML node and maps them to field keys.
+     * Handles hierarchical strings (l1 > l2).
+     */
     getNodeValueObject: ({ node, editor }) => {
       const anchorNode = editor.selectNodes('./gmx:Anchor', node)[0]
       const charStringNode = editor.selectNodes('./gco:CharacterString', node)[0]
@@ -36,16 +48,20 @@ const createKeywordBlock = (type, { fieldKeys, matchKeys, getValue }) => blockSc
   },
   replace: [
     {
+      // Dynamically select target element (Anchor vs CharacterString) based on existing content
       fieldPath: ({ node, editor }) => (editor.selectNodes('./gmx:Anchor', node).length > 0 ? 'gmx:Anchor' : 'gco:CharacterString'),
       source: {
         type: 'computed',
-        // Use the custom getValue if provided, else fall back to default
+        // Allows custom formatting for keyword strings; defaults to joining keys with ' > '
         getValue: getValue || (({ correction }) => fieldKeys.map((k) => correction.newKeywordObject[k]).filter(Boolean).join(' > '))
       }
     }
   ]
 })
-
+/**
+ * Creates an editor for ISO Topic Category nodes.
+ * Updates both the text content and the @codeListValue attribute.
+ */
 const createIsoTopicCategoryEditor = () => leafScheme({
   nodeXPath: '//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory',
   find: {
@@ -70,7 +86,10 @@ const createIsoTopicCategoryEditor = () => leafScheme({
     }
   ]
 })
-
+/**
+ * Creates an editor for Processing Level Identifiers.
+ * Manages deletion of old paths and insertion/updates into specific XML locations.
+ */
 const createProductLevelIdEditor = () => leafScheme({
   nodeXPath: '//gmd:processingLevel/gmd:MD_Identifier[gmd:codeSpace/gco:CharacterString="gov.nasa.esdis.umm.processinglevelid"]',
   find: {
@@ -85,7 +104,6 @@ const createProductLevelIdEditor = () => leafScheme({
   ],
   replace: [
     {
-      // Since matchingNode is now MD_Identifier, this path correctly selects the child
       fieldPath: 'gmd:code/gco:CharacterString',
       source: {
         type: 'computed',
@@ -93,6 +111,7 @@ const createProductLevelIdEditor = () => leafScheme({
       }
     },
     {
+      // Target specific secondary locations for synchronization
       fieldPath: '//gmd:contentInfo/gmd:MD_ImageDescription/gmd:processingLevelCode/gmd:MD_Identifier[gmd:codeSpace/gco:CharacterString="gov.nasa.esdis.umm.processinglevelid"]/gmd:code/gco:CharacterString',
       source: {
         type: 'computed',
@@ -157,10 +176,6 @@ export const ISO_19115_SCHEME_EDITORS = {
     }
   }),
 
-  isotopiccategory: createIsoTopicCategoryEditor(),
-
-  productlevelid: createProductLevelIdEditor(),
-
   providers: createKeywordBlock('dataCentre', {
     fieldKeys: ['ShortName', 'LongName'],
     matchKeys: ['ShortName'],
@@ -170,16 +185,11 @@ export const ISO_19115_SCHEME_EDITORS = {
 
       return LongName ? `${ShortName} > ${LongName}` : ShortName
     }
-  })
+  }),
 
-  /*
-  Providers: short name not in examples
-              <gmd:organisationName>
-                <gco:CharacterString>National Snow and Ice Data Center</gco:CharacterString>
-              </gmd:organisationName>
-  rucontenttype: TBD
-  idnnode: no mapping
-  */
+  isotopiccategory: createIsoTopicCategoryEditor(),
+
+  productlevelid: createProductLevelIdEditor()
 }
 
 /**

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -2,6 +2,17 @@ import Iso19115MetadataPathEditor from './Iso19115MetadataPathEditor'
 import { FULL_PATH_VALUE_FIELDS } from './redis-path-store/helpers/constants'
 
 /**
+ * A list of authorized domains used to validate the 'codeList' attribute
+ * within MD_KeywordTypeCode elements. This ensures only keywords originating
+ * from trusted metadata authorities are processed by the editor.
+ */
+const KEYWORD_DOMAINS = [
+  'cdn.earthdata.nasa.gov', // NASA Earthdata Resource Codelists
+  'www.isotc211.org', // ISO TC 211 Standard Codelists
+  'data.noaa.gov' // NOAA Metadata Authority Codelists
+]
+
+/**
  * Helper factory function to create a block editor configuration.
  * Maps a correction to an update operation within the editor instance.
  * @param {Object} config - Configuration object defining XPath and transformation logic.
@@ -15,49 +26,56 @@ const blockScheme = (config) => (editor, correction) => editor.updateBlockNode(c
  */
 const leafScheme = (config) => (editor, correction) => editor.updateLeafNode(correction, config)
 /**
- * Factory to generate standardized keyword block editors for structures
- * like Platforms and Instruments.
- * * @param {string} type - The 'codeListValue' for the MD_KeywordTypeCode.
- * @param {Object} options - Configuration for field parsing and value generation.
- * @returns {Function} Configured block editor function.
+ * Factory to generate standardized keyword block editors.
+ * @param {string} type - The 'codeListValue' for the MD_KeywordTypeCode.
+ * @param {Object} options - Configuration options.
+ * @param {string[]} options.allowedCodelistDomains - List of domains (e.g., ['cdn.earthdata.nasa.gov', 'noaa.gov']).
  */
-const createKeywordBlock = (type, { fieldKeys, matchKeys, getValue }) => blockScheme({
-  nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords[gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${type}']`,
-  find: {
-    fieldPaths: ['gmx:Anchor', 'gco:CharacterString'],
-    valueKeys: fieldKeys,
-    matchKeys,
-    /**
-     * Extracts values from the XML node and maps them to field keys.
-     * Handles hierarchical strings (l1 > l2).
-     */
-    getNodeValueObject: ({ node, editor }) => {
-      const anchorNode = editor.selectNodes('./gmx:Anchor', node)[0]
-      const charStringNode = editor.selectNodes('./gco:CharacterString', node)[0]
+const createKeywordBlock = (type, {
+  fieldKeys, matchKeys, getValue, allowedCodelistDomains = []
+}) => {
+  // Construct the XPath predicate to check if the codeList contains any of the allowed domains
+  const domainConditions = allowedCodelistDomains
+    .map((domain) => `contains(gmd:type/gmd:MD_KeywordTypeCode/@codeList, '${domain}')`)
+    .join(' or ')
 
-      const fullString = (anchorNode || charStringNode)?.textContent || ''
-      // Parsing logic: Hierarchical (l1 > l2) or Simple (short > long)
-      const parts = fullString.split(' > ').map((s) => s.trim())
+  const predicate = domainConditions ? `and (${domainConditions})` : ''
 
-      return fieldKeys.reduce((acc, key, index) => {
-        acc[key] = parts[index] || ''
+  return blockScheme({
+    nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords[
+      gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${type}' 
+      ${predicate}
+    ]`.replace(/\s+/g, ' '),
 
-        return acc
-      }, { Value: fullString.trim() })
-    }
-  },
-  replace: [
-    {
-      // Dynamically select target element (Anchor vs CharacterString) based on existing content
-      fieldPath: ({ node, editor }) => (editor.selectNodes('./gmx:Anchor', node).length > 0 ? 'gmx:Anchor' : 'gco:CharacterString'),
-      source: {
-        type: 'computed',
-        // Allows custom formatting for keyword strings; defaults to joining keys with ' > '
-        getValue: getValue || (({ correction }) => fieldKeys.map((k) => correction.newKeywordObject[k]).filter(Boolean).join(' > '))
+    find: {
+      fieldPaths: ['gmx:Anchor', 'gco:CharacterString'],
+      valueKeys: fieldKeys,
+      matchKeys,
+      getNodeValueObject: ({ node, editor }) => {
+        const anchorNode = editor.selectNodes('./gmx:Anchor', node)[0]
+        const charStringNode = editor.selectNodes('./gco:CharacterString', node)[0]
+        const fullString = (anchorNode || charStringNode)?.textContent || ''
+        const parts = fullString.split(' > ').map((s) => s.trim())
+
+        return fieldKeys.reduce((acc, key, index) => {
+          acc[key] = parts[index] || ''
+
+          return acc
+        }, { Value: fullString.trim() })
       }
-    }
-  ]
-})
+    },
+    replace: [
+      {
+        fieldPath: ({ node, editor }) => (editor.selectNodes('./gmx:Anchor', node).length > 0 ? 'gmx:Anchor' : 'gco:CharacterString'),
+        source: {
+          type: 'computed',
+          getValue: getValue || (({ correction }) => fieldKeys.map((k) => correction.newKeywordObject[k]).filter(Boolean).join(' > '))
+        }
+      }
+    ]
+  })
+}
+
 /**
  * Creates an editor for ISO Topic Category nodes.
  * Updates both the text content and the @codeListValue attribute.
@@ -131,7 +149,8 @@ export const ISO_19115_SCHEME_EDITORS = {
     'theme',
     {
       fieldKeys: FULL_PATH_VALUE_FIELDS.sciencekeywords,
-      matchKeys: ['Value']
+      matchKeys: ['Value'],
+      allowedCodelistDomains: KEYWORD_DOMAINS
     }
   ),
 
@@ -139,13 +158,15 @@ export const ISO_19115_SCHEME_EDITORS = {
     'place',
     {
       fieldKeys: FULL_PATH_VALUE_FIELDS.locations,
-      matchKeys: ['Value']
+      matchKeys: ['Value'],
+      allowedCodelistDomains: KEYWORD_DOMAINS
     }
   ),
 
   platforms: createKeywordBlock('platform', {
     fieldKeys: ['ShortName', 'LongName'],
     matchKeys: ['ShortName'],
+    allowedCodelistDomains: KEYWORD_DOMAINS,
     getValue: ({ correction }) => {
       const { ShortName } = correction.newKeywordObject
       const LongName = correction.newLongName || ''
@@ -157,6 +178,7 @@ export const ISO_19115_SCHEME_EDITORS = {
   instruments: createKeywordBlock('instrument', {
     fieldKeys: ['ShortName', 'LongName'],
     matchKeys: ['ShortName'],
+    allowedCodelistDomains: KEYWORD_DOMAINS,
     getValue: ({ correction }) => {
       const { ShortName } = correction.newKeywordObject
       const LongName = correction.newLongName || ''
@@ -168,6 +190,7 @@ export const ISO_19115_SCHEME_EDITORS = {
   projects: createKeywordBlock('project', {
     fieldKeys: ['ShortName', 'LongName'],
     matchKeys: ['ShortName'],
+    allowedCodelistDomains: KEYWORD_DOMAINS,
     getValue: ({ correction }) => {
       const { ShortName } = correction.newKeywordObject
       const LongName = correction.newLongName || ''
@@ -179,6 +202,7 @@ export const ISO_19115_SCHEME_EDITORS = {
   providers: createKeywordBlock('dataCentre', {
     fieldKeys: ['ShortName', 'LongName'],
     matchKeys: ['ShortName'],
+    allowedCodelistDomains: KEYWORD_DOMAINS,
     getValue: ({ correction }) => {
       const { ShortName } = correction.newKeywordObject
       const LongName = correction.newLongName || ''

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -92,7 +92,8 @@ export const ISO_19115_SCHEME_EDITORS = {
         source: {
           type: 'computed',
           getValue: ({ correction }) => {
-            const { ShortName, LongName } = correction.newKeywordObject
+            const { ShortName } = correction.newKeywordObject
+            const LongName = correction.newLongName
 
             return `${ShortName} > ${LongName}`
           }
@@ -130,7 +131,8 @@ export const ISO_19115_SCHEME_EDITORS = {
         source: {
           type: 'computed',
           getValue: ({ correction }) => {
-            const { ShortName, LongName } = correction.newKeywordObject
+            const { ShortName } = correction.newKeywordObject
+            const LongName = correction.newLongName
 
             return `${ShortName} > ${LongName}`
           }

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -2,17 +2,6 @@ import Iso19115MetadataPathEditor from './Iso19115MetadataPathEditor'
 import { FULL_PATH_VALUE_FIELDS } from './redis-path-store/helpers/constants'
 
 /**
- * A list of authorized domains used to validate the 'codeList' attribute
- * within MD_KeywordTypeCode elements. This ensures only keywords originating
- * from trusted metadata authorities are processed by the editor.
- */
-const KEYWORD_DOMAINS = [
-  'cdn.earthdata.nasa.gov', // NASA Earthdata Resource Codelists
-  'www.isotc211.org', // ISO TC 211 Standard Codelists
-  'data.noaa.gov' // NOAA Metadata Authority Codelists
-]
-
-/**
  * Helper factory function to create a block editor configuration.
  * Maps a correction to an update operation within the editor instance.
  * @param {Object} config - Configuration object defining XPath and transformation logic.
@@ -29,52 +18,41 @@ const leafScheme = (config) => (editor, correction) => editor.updateLeafNode(cor
  * Factory to generate standardized keyword block editors.
  * @param {string} type - The 'codeListValue' for the MD_KeywordTypeCode.
  * @param {Object} options - Configuration options.
- * @param {string[]} options.allowedCodelistDomains - List of domains (e.g., ['cdn.earthdata.nasa.gov', 'noaa.gov']).
  */
 const createKeywordBlock = (type, {
-  fieldKeys, matchKeys, getValue, allowedCodelistDomains = []
-}) => {
-  // Construct the XPath predicate to check if the codeList contains any of the allowed domains
-  const domainConditions = allowedCodelistDomains
-    .map((domain) => `contains(gmd:type/gmd:MD_KeywordTypeCode/@codeList, '${domain}')`)
-    .join(' or ')
-
-  const predicate = domainConditions ? `and (${domainConditions})` : ''
-
-  return blockScheme({
-    nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords[
+  fieldKeys, matchKeys, getValue
+}) => blockScheme({
+  nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords[
       gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${type}' 
-      ${predicate}
     ]`.replace(/\s+/g, ' '),
 
-    find: {
-      fieldPaths: ['gmx:Anchor', 'gco:CharacterString'],
-      valueKeys: fieldKeys,
-      matchKeys,
-      getNodeValueObject: ({ node, editor }) => {
-        const anchorNode = editor.selectNodes('./gmx:Anchor', node)[0]
-        const charStringNode = editor.selectNodes('./gco:CharacterString', node)[0]
-        const fullString = (anchorNode || charStringNode)?.textContent || ''
-        const parts = fullString.split(' > ').map((s) => s.trim())
+  find: {
+    fieldPaths: ['gmx:Anchor', 'gco:CharacterString'],
+    valueKeys: fieldKeys,
+    matchKeys,
+    getNodeValueObject: ({ node, editor }) => {
+      const anchorNode = editor.selectNodes('./gmx:Anchor', node)[0]
+      const charStringNode = editor.selectNodes('./gco:CharacterString', node)[0]
+      const fullString = (anchorNode || charStringNode)?.textContent || ''
+      const parts = fullString.split(' > ').map((s) => s.trim())
 
-        return fieldKeys.reduce((acc, key, index) => {
-          acc[key] = parts[index] || ''
+      return fieldKeys.reduce((acc, key, index) => {
+        acc[key] = parts[index] || ''
 
-          return acc
-        }, { Value: fullString.trim() })
+        return acc
+      }, { Value: fullString.trim() })
+    }
+  },
+  replace: [
+    {
+      fieldPath: ({ node, editor }) => (editor.selectNodes('./gmx:Anchor', node).length > 0 ? 'gmx:Anchor' : 'gco:CharacterString'),
+      source: {
+        type: 'computed',
+        getValue: getValue || (({ correction }) => fieldKeys.map((k) => correction.newKeywordObject[k]).filter(Boolean).join(' > '))
       }
-    },
-    replace: [
-      {
-        fieldPath: ({ node, editor }) => (editor.selectNodes('./gmx:Anchor', node).length > 0 ? 'gmx:Anchor' : 'gco:CharacterString'),
-        source: {
-          type: 'computed',
-          getValue: getValue || (({ correction }) => fieldKeys.map((k) => correction.newKeywordObject[k]).filter(Boolean).join(' > '))
-        }
-      }
-    ]
-  })
-}
+    }
+  ]
+})
 
 /**
  * Creates an editor for ISO Topic Category nodes.
@@ -149,8 +127,7 @@ export const ISO_19115_SCHEME_EDITORS = {
     'theme',
     {
       fieldKeys: FULL_PATH_VALUE_FIELDS.sciencekeywords,
-      matchKeys: FULL_PATH_VALUE_FIELDS.sciencekeywords,
-      allowedCodelistDomains: KEYWORD_DOMAINS
+      matchKeys: FULL_PATH_VALUE_FIELDS.sciencekeywords
     }
   ),
 
@@ -158,15 +135,13 @@ export const ISO_19115_SCHEME_EDITORS = {
     'place',
     {
       fieldKeys: FULL_PATH_VALUE_FIELDS.locations,
-      matchKeys: FULL_PATH_VALUE_FIELDS.locations,
-      allowedCodelistDomains: KEYWORD_DOMAINS
+      matchKeys: FULL_PATH_VALUE_FIELDS.locations
     }
   ),
 
   platforms: createKeywordBlock('platform', {
     fieldKeys: ['ShortName', 'LongName'],
     matchKeys: ['ShortName'],
-    allowedCodelistDomains: KEYWORD_DOMAINS,
     getValue: ({ correction }) => {
       const { ShortName } = correction.newKeywordObject
       const LongName = correction.newLongName || ''
@@ -178,7 +153,6 @@ export const ISO_19115_SCHEME_EDITORS = {
   instruments: createKeywordBlock('instrument', {
     fieldKeys: ['ShortName', 'LongName'],
     matchKeys: ['ShortName'],
-    allowedCodelistDomains: KEYWORD_DOMAINS,
     getValue: ({ correction }) => {
       const { ShortName } = correction.newKeywordObject
       const LongName = correction.newLongName || ''
@@ -190,7 +164,6 @@ export const ISO_19115_SCHEME_EDITORS = {
   projects: createKeywordBlock('project', {
     fieldKeys: ['ShortName', 'LongName'],
     matchKeys: ['ShortName'],
-    allowedCodelistDomains: KEYWORD_DOMAINS,
     getValue: ({ correction }) => {
       const { ShortName } = correction.newKeywordObject
       const LongName = correction.newLongName || ''
@@ -202,7 +175,6 @@ export const ISO_19115_SCHEME_EDITORS = {
   providers: createKeywordBlock('dataCentre', {
     fieldKeys: ['ShortName', 'LongName'],
     matchKeys: ['ShortName'],
-    allowedCodelistDomains: KEYWORD_DOMAINS,
     getValue: ({ correction }) => {
       const { ShortName } = correction.newKeywordObject
       const LongName = correction.newLongName || ''

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -2,6 +2,17 @@ import Iso19115MetadataPathEditor from './Iso19115MetadataPathEditor'
 import { FULL_PATH_VALUE_FIELDS } from './redis-path-store/helpers/constants'
 
 /**
+ * A list of authorized domains used to validate the 'codeList' attribute
+ * within MD_KeywordTypeCode elements. This ensures only keywords originating
+ * from trusted metadata authorities are processed by the editor.
+ */
+const KEYWORD_DOMAINS = [
+  'cdn.earthdata.nasa.gov', // NASA Earthdata Resource Codelists
+  'www.isotc211.org', // ISO TC 211 Standard Codelists
+  'data.noaa.gov' // NOAA Metadata Authority Codelists
+]
+
+/**
  * Helper factory function to create a block editor configuration.
  * Maps a correction to an update operation within the editor instance.
  * @param {Object} config - Configuration object defining XPath and transformation logic.
@@ -15,49 +26,56 @@ const blockScheme = (config) => (editor, correction) => editor.updateBlockNode(c
  */
 const leafScheme = (config) => (editor, correction) => editor.updateLeafNode(correction, config)
 /**
- * Factory to generate standardized keyword block editors for structures
- * like Platforms and Instruments.
- * * @param {string} type - The 'codeListValue' for the MD_KeywordTypeCode.
- * @param {Object} options - Configuration for field parsing and value generation.
- * @returns {Function} Configured block editor function.
+ * Factory to generate standardized keyword block editors.
+ * @param {string} type - The 'codeListValue' for the MD_KeywordTypeCode.
+ * @param {Object} options - Configuration options.
+ * @param {string[]} options.allowedCodelistDomains - List of domains (e.g., ['cdn.earthdata.nasa.gov', 'noaa.gov']).
  */
-const createKeywordBlock = (type, { fieldKeys, matchKeys, getValue }) => blockScheme({
-  nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords[gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${type}']`,
-  find: {
-    fieldPaths: ['gmx:Anchor', 'gco:CharacterString'],
-    valueKeys: fieldKeys,
-    matchKeys,
-    /**
-     * Extracts values from the XML node and maps them to field keys.
-     * Handles hierarchical strings (l1 > l2).
-     */
-    getNodeValueObject: ({ node, editor }) => {
-      const anchorNode = editor.selectNodes('./gmx:Anchor', node)[0]
-      const charStringNode = editor.selectNodes('./gco:CharacterString', node)[0]
+const createKeywordBlock = (type, {
+  fieldKeys, matchKeys, getValue, allowedCodelistDomains = []
+}) => {
+  // Construct the XPath predicate to check if the codeList contains any of the allowed domains
+  const domainConditions = allowedCodelistDomains
+    .map((domain) => `contains(gmd:type/gmd:MD_KeywordTypeCode/@codeList, '${domain}')`)
+    .join(' or ')
 
-      const fullString = (anchorNode || charStringNode)?.textContent || ''
-      // Parsing logic: Hierarchical (l1 > l2) or Simple (short > long)
-      const parts = fullString.split(' > ').map((s) => s.trim())
+  const predicate = domainConditions ? `and (${domainConditions})` : ''
 
-      return fieldKeys.reduce((acc, key, index) => {
-        acc[key] = parts[index] || ''
+  return blockScheme({
+    nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords[
+      gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${type}' 
+      ${predicate}
+    ]`.replace(/\s+/g, ' '),
 
-        return acc
-      }, { Value: fullString.trim() })
-    }
-  },
-  replace: [
-    {
-      // Dynamically select target element (Anchor vs CharacterString) based on existing content
-      fieldPath: ({ node, editor }) => (editor.selectNodes('./gmx:Anchor', node).length > 0 ? 'gmx:Anchor' : 'gco:CharacterString'),
-      source: {
-        type: 'computed',
-        // Allows custom formatting for keyword strings; defaults to joining keys with ' > '
-        getValue: getValue || (({ correction }) => fieldKeys.map((k) => correction.newKeywordObject[k]).filter(Boolean).join(' > '))
+    find: {
+      fieldPaths: ['gmx:Anchor', 'gco:CharacterString'],
+      valueKeys: fieldKeys,
+      matchKeys,
+      getNodeValueObject: ({ node, editor }) => {
+        const anchorNode = editor.selectNodes('./gmx:Anchor', node)[0]
+        const charStringNode = editor.selectNodes('./gco:CharacterString', node)[0]
+        const fullString = (anchorNode || charStringNode)?.textContent || ''
+        const parts = fullString.split(' > ').map((s) => s.trim())
+
+        return fieldKeys.reduce((acc, key, index) => {
+          acc[key] = parts[index] || ''
+
+          return acc
+        }, { Value: fullString.trim() })
       }
-    }
-  ]
-})
+    },
+    replace: [
+      {
+        fieldPath: ({ node, editor }) => (editor.selectNodes('./gmx:Anchor', node).length > 0 ? 'gmx:Anchor' : 'gco:CharacterString'),
+        source: {
+          type: 'computed',
+          getValue: getValue || (({ correction }) => fieldKeys.map((k) => correction.newKeywordObject[k]).filter(Boolean).join(' > '))
+        }
+      }
+    ]
+  })
+}
+
 /**
  * Creates an editor for ISO Topic Category nodes.
  * Updates both the text content and the @codeListValue attribute.
@@ -131,7 +149,8 @@ export const ISO_19115_SCHEME_EDITORS = {
     'theme',
     {
       fieldKeys: FULL_PATH_VALUE_FIELDS.sciencekeywords,
-      matchKeys: ['Value']
+      matchKeys: FULL_PATH_VALUE_FIELDS.sciencekeywords,
+      allowedCodelistDomains: KEYWORD_DOMAINS
     }
   ),
 
@@ -139,13 +158,15 @@ export const ISO_19115_SCHEME_EDITORS = {
     'place',
     {
       fieldKeys: FULL_PATH_VALUE_FIELDS.locations,
-      matchKeys: ['Value']
+      matchKeys: FULL_PATH_VALUE_FIELDS.locations,
+      allowedCodelistDomains: KEYWORD_DOMAINS
     }
   ),
 
   platforms: createKeywordBlock('platform', {
     fieldKeys: ['ShortName', 'LongName'],
     matchKeys: ['ShortName'],
+    allowedCodelistDomains: KEYWORD_DOMAINS,
     getValue: ({ correction }) => {
       const { ShortName } = correction.newKeywordObject
       const LongName = correction.newLongName || ''
@@ -157,6 +178,7 @@ export const ISO_19115_SCHEME_EDITORS = {
   instruments: createKeywordBlock('instrument', {
     fieldKeys: ['ShortName', 'LongName'],
     matchKeys: ['ShortName'],
+    allowedCodelistDomains: KEYWORD_DOMAINS,
     getValue: ({ correction }) => {
       const { ShortName } = correction.newKeywordObject
       const LongName = correction.newLongName || ''
@@ -168,6 +190,7 @@ export const ISO_19115_SCHEME_EDITORS = {
   projects: createKeywordBlock('project', {
     fieldKeys: ['ShortName', 'LongName'],
     matchKeys: ['ShortName'],
+    allowedCodelistDomains: KEYWORD_DOMAINS,
     getValue: ({ correction }) => {
       const { ShortName } = correction.newKeywordObject
       const LongName = correction.newLongName || ''
@@ -179,6 +202,7 @@ export const ISO_19115_SCHEME_EDITORS = {
   providers: createKeywordBlock('dataCentre', {
     fieldKeys: ['ShortName', 'LongName'],
     matchKeys: ['ShortName'],
+    allowedCodelistDomains: KEYWORD_DOMAINS,
     getValue: ({ correction }) => {
       const { ShortName } = correction.newKeywordObject
       const LongName = correction.newLongName || ''

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -1,0 +1,151 @@
+import Iso19115MetadataPathEditor from './Iso19115MetadataPathEditor'
+import { FULL_PATH_VALUE_FIELDS } from './redis-path-store/helpers/constants'
+
+/**
+ * Helper factory function to create a block editor configuration.
+ * Maps a correction to an update operation within the editor instance.
+ */
+const blockScheme = (config) => (editor, correction) => editor.updateBlockNode(correction, config)
+
+/**
+ * ISO 19115 scheme configuration.
+ * Defines how to identify, parse, and update specific keyword blocks (e.g., science keywords, platforms)
+ * within an ISO 19115 XML structure using XPath selectors and transformation logic.
+ */
+export const ISO_19115_SCHEME_EDITORS = {
+  sciencekeywords: blockScheme({
+    // XPath to locate MD_Keywords nodes based on specific thesaurus title or type
+    nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords
+  [
+    gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString = 'NASA / GCMD Science Keywords'
+    or
+    gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = 'theme'
+  ]`,
+    find: {
+      fieldPaths: ['gco:CharacterString'],
+      valueKeys: FULL_PATH_VALUE_FIELDS.sciencekeywords,
+      // Parses the XML node into a structured object
+      getNodeValueObject: ({ node, editor, fieldPaths }) => {
+        const fullString = editor.getNestedText(node, fieldPaths[0]) || ''
+        // Splits hierarchical keywords (e.g., "Level 1 > Level 2") into array components
+        const parts = fullString.split(' > ').map((s) => s.trim())
+        const fields = FULL_PATH_VALUE_FIELDS.sciencekeywords
+        // Map split parts to defined schema fields
+        const obj = fields.reduce((acc, field, index) => {
+          acc[field] = parts[index] || ''
+
+          return acc
+        }, {})
+
+        obj.Value = fullString.trim()// Keep original full string as 'Value'
+
+        return obj
+      }
+    },
+    // Defines how to serialize the updated object back into the XML structure
+    replace: [
+      {
+        fieldPath: 'gmd:keyword/gco:CharacterString',
+        source: {
+          type: 'computed',
+          getValue: ({ correction }) => {
+            const k = correction.newKeywordObject
+            const fields = FULL_PATH_VALUE_FIELDS.sciencekeywords
+
+            // Reconstructs the hierarchical string from object fields, ignoring empty ones
+            return fields
+              .map((field) => k[field] || '')
+              .filter((v) => v.trim().length > 0)
+              .join(' > ')
+          }
+        }
+      }
+    ]
+  }),
+
+  platforms: blockScheme({
+    // XPath to locate MD_Keywords specific to platforms
+    nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords
+  [
+    gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString = 'NASA / GCMD Platform Keywords'
+    or
+    gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = 'platform'
+  ]`,
+    find: {
+      fieldPaths: ['gco:CharacterString'],
+      valueKeys: ['ShortName', 'LongName'],
+      // Parses platform string: "ShortName > LongName"
+      getNodeValueObject: ({ node, editor, fieldPaths }) => {
+        const fullString = editor.getNestedText(node, fieldPaths[0]) || ''
+        const [ShortName, ...longNameParts] = fullString.split(' > ')
+
+        return {
+          ShortName: ShortName?.trim() || '',
+          LongName: longNameParts.join(' > ').trim() || ''
+        }
+      }
+    },
+    // Reconstructs platform string for XML update
+    replace: [
+      {
+        fieldPath: 'gmd:keyword/gco:CharacterString',
+        source: {
+          type: 'computed',
+          getValue: ({ correction }) => {
+            const { ShortName, LongName } = correction.newKeywordObject
+
+            return `${ShortName} > ${LongName}`
+          }
+        }
+      }
+    ]
+  }),
+
+  instruments: blockScheme({
+    // XPath to locate MD_Keywords specific to instruments
+    nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords
+  [
+    gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString = 'NASA / GCMD Instrument Keywords'
+    or
+    gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = 'instrument'
+  ]`,
+    find: {
+      fieldPaths: ['gco:CharacterString'],
+      valueKeys: ['ShortName', 'LongName'],
+      // Parses instrument string: "ShortName > LongName"
+      getNodeValueObject: ({ node, editor, fieldPaths }) => {
+        const fullString = editor.getNestedText(node, fieldPaths[0]) || ''
+        const [ShortName, ...longNameParts] = fullString.split(' > ')
+
+        return {
+          ShortName: ShortName?.trim() || '',
+          LongName: longNameParts.join(' > ').trim() || ''
+        }
+      }
+    },
+    // Reconstructs instrument string for XML update
+    replace: [
+      {
+        fieldPath: 'gmd:keyword/gco:CharacterString',
+        source: {
+          type: 'computed',
+          getValue: ({ correction }) => {
+            const { ShortName, LongName } = correction.newKeywordObject
+
+            return `${ShortName} > ${LongName}`
+          }
+        }
+      }
+    ]
+  })
+}
+
+/**
+ * Creates a DOM-backed editor for a raw ISO 19115 XML payload.
+ *
+ * @param {string} payload Raw ISO 19115 XML string.
+ * @returns {Iso19115Editor} Specialized ISO 19115 XML path editor instance.
+ */
+export const createIso19115Editor = (payload) => new Iso19115MetadataPathEditor(payload)
+
+export default ISO_19115_SCHEME_EDITORS

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -7,24 +7,24 @@ import { FULL_PATH_VALUE_FIELDS } from './redis-path-store/helpers/constants'
  */
 const blockScheme = (config) => (editor, correction) => editor.updateBlockNode(correction, config)
 
+const leafScheme = (config) => (editor, correction) => editor.updateLeafNode(correction, config)
+
 /**
  * Factory to generate hierarchical keyword block editors
  * (like Science Keywords and Locations).
  */
-const createHierarchicalKeywordBlock = (thesaurusTitle, keywordTypeCode, fieldKey) => blockScheme({
+const createHierarchicalKeywordBlock = (keywordTypeCode, fieldKeys) => blockScheme({
   nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords
   [
-    gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString = '${thesaurusTitle}'
-    or
     gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${keywordTypeCode}'
   ]`,
   find: {
     fieldPaths: ['gco:CharacterString'],
-    valueKeys: FULL_PATH_VALUE_FIELDS[fieldKey],
+    valueKeys: fieldKeys,
     getNodeValueObject: ({ node, editor, fieldPaths }) => {
       const fullString = editor.getNestedText(node, fieldPaths[0]) || ''
       const parts = fullString.split(' > ').map((s) => s.trim())
-      const fields = FULL_PATH_VALUE_FIELDS[fieldKey]
+      const fields = fieldKeys
 
       const obj = fields.reduce((acc, field, index) => {
         acc[field] = parts[index] || ''
@@ -44,7 +44,7 @@ const createHierarchicalKeywordBlock = (thesaurusTitle, keywordTypeCode, fieldKe
         type: 'computed',
         getValue: ({ correction }) => {
           const k = correction.newKeywordObject
-          const fields = FULL_PATH_VALUE_FIELDS[fieldKey]
+          const fields = fieldKeys
 
           return fields
             .map((field) => k[field] || '')
@@ -60,11 +60,9 @@ const createHierarchicalKeywordBlock = (thesaurusTitle, keywordTypeCode, fieldKe
  * Factory to generate standardized keyword block editors for structures
  * like Platforms and Instruments.
  */
-const createKeywordBlock = (thesaurusTitle, keywordTypeCode) => blockScheme({
+const createKeywordBlock = (keywordTypeCode) => blockScheme({
   nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords
   [
-    gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString = '${thesaurusTitle}'
-    or
     gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${keywordTypeCode}'
   ]`,
   find: {
@@ -96,6 +94,30 @@ const createKeywordBlock = (thesaurusTitle, keywordTypeCode) => blockScheme({
   ]
 })
 
+const createIsoTopicCategoryEditor = () => leafScheme({
+  // Targets the specific category element directly
+  nodeXPath: '//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory',
+  find: {
+    getNodeValueObject: ({ node }) => ({ Value: node.textContent?.trim() || '' })
+  },
+  replace: [
+    {
+      fieldPath: 'gmd:MD_TopicCategoryCode',
+      source: {
+        type: 'computed',
+        getValue: ({ correction }) => correction.newKeywordObject.Value
+      }
+    },
+    {
+      fieldPath: 'gmd:MD_TopicCategoryCode/@codeListValue',
+      source: {
+        type: 'computed',
+        getValue: ({ correction }) => correction.newKeywordObject.Value
+      }
+    }
+  ]
+})
+
 /**
  * ISO 19115 scheme configuration.
  * Defines how to identify, parse, and update specific keyword blocks (e.g., science keywords, platforms)
@@ -103,22 +125,31 @@ const createKeywordBlock = (thesaurusTitle, keywordTypeCode) => blockScheme({
  */
 export const ISO_19115_SCHEME_EDITORS = {
   sciencekeywords: createHierarchicalKeywordBlock(
-    'NASA / GCMD Science Keywords',
     'theme',
-    'sciencekeywords'
+    FULL_PATH_VALUE_FIELDS.sciencekeywords
   ),
 
   locations: createHierarchicalKeywordBlock(
-    'NASA / GCMD Location Keywords',
     'place',
-    'locations'
+    FULL_PATH_VALUE_FIELDS.locations
   ),
 
-  platforms: createKeywordBlock('NASA / GCMD Platform Keywords', 'platform'),
+  platforms: createKeywordBlock('platform'),
 
-  instruments: createKeywordBlock('NASA / GCMD Instrument Keywords', 'instrument'),
+  instruments: createKeywordBlock('instrument'),
 
-  projects: createKeywordBlock('NASA / GCMD Project Keywords', 'project')
+  projects: createKeywordBlock('project'),
+
+  isotopiccategory: createIsoTopicCategoryEditor()
+
+  /*
+  Providers: short name not in examples
+              <gmd:organisationName>
+                <gco:CharacterString>National Snow and Ice Data Center</gco:CharacterString>
+              </gmd:organisationName>
+  rucontenttype: TBD
+  idnnode: no mapping
+  */
 }
 
 /**

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -14,13 +14,15 @@ const blockScheme = (config) => (editor, correction) => editor.updateBlockNode(c
  * @returns {Function} Function to apply the update.
  */
 const leafScheme = (config) => (editor, correction) => editor.updateLeafNode(correction, config)
+
 /**
  * Factory to generate standardized keyword block editors.
  * @param {string} type - The 'codeListValue' for the MD_KeywordTypeCode.
  * @param {Object} options - Configuration options.
+ * @param {Array} [options.additionalPaths] - Optional array of XPath strings for secondary sync.
  */
 const createKeywordBlock = (type, {
-  fieldKeys, matchKeys, getValue
+  fieldKeys, matchKeys, getValue, additionalPaths = []
 }) => blockScheme({
   nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords[
       gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${type}' 
@@ -48,9 +50,23 @@ const createKeywordBlock = (type, {
       fieldPath: ({ node, editor }) => (editor.selectNodes('./gmx:Anchor', node).length > 0 ? 'gmx:Anchor' : 'gco:CharacterString'),
       source: {
         type: 'computed',
-        getValue: getValue || (({ correction }) => fieldKeys.map((k) => correction.newKeywordObject[k]).filter(Boolean).join(' > '))
+        getValue: getValue || (({ correction }) => fieldKeys
+          .map((k) => correction.newKeywordObject[k] || 'NONE')
+          .join(' > ')
+        )
       }
-    }
+    },
+    // Dynamically add secondary paths for synchronization
+    ...additionalPaths.map((path) => ({
+      fieldPath: path,
+      source: {
+        type: 'computed',
+        // Ensure the secondary sync paths also use the 'NONE' padding logic
+        getValue: getValue || (({ correction }) => fieldKeys
+          .map((k) => correction.newKeywordObject[k] || 'NONE')
+          .join(' > '))
+      }
+    }))
   ]
 })
 
@@ -180,7 +196,11 @@ export const ISO_19115_SCHEME_EDITORS = {
       const LongName = correction.newLongName || ''
 
       return LongName ? `${ShortName} > ${LongName}` : ShortName
-    }
+    },
+    // Additional paths
+    additionalPaths: [
+      '//gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString'
+    ]
   }),
 
   isotopiccategory: createIsoTopicCategoryEditor(),

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -10,88 +10,37 @@ const blockScheme = (config) => (editor, correction) => editor.updateBlockNode(c
 const leafScheme = (config) => (editor, correction) => editor.updateLeafNode(correction, config)
 
 /**
- * Factory to generate hierarchical keyword block editors
- * (like Science Keywords and Locations).
- */
-const createHierarchicalKeywordBlock = (keywordTypeCode, fieldKeys) => blockScheme({
-  nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords
-  [
-    gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${keywordTypeCode}'
-  ]`,
-  find: {
-    fieldPaths: ['gco:CharacterString'],
-    valueKeys: fieldKeys,
-    getNodeValueObject: ({ node, editor, fieldPaths }) => {
-      const fullString = editor.getNestedText(node, fieldPaths[0]) || ''
-      const parts = fullString.split(' > ').map((s) => s.trim())
-      const fields = fieldKeys
-
-      const obj = fields.reduce((acc, field, index) => {
-        acc[field] = parts[index] || ''
-
-        return acc
-      }, {})
-
-      obj.Value = fullString.trim()
-
-      return obj
-    }
-  },
-  replace: [
-    {
-      fieldPath: 'gmd:keyword/gco:CharacterString',
-      source: {
-        type: 'computed',
-        getValue: ({ correction }) => {
-          const k = correction.newKeywordObject
-          const fields = fieldKeys
-
-          return fields
-            .map((field) => k[field] || '')
-            .filter((v) => v.trim().length > 0)
-            .join(' > ')
-        }
-      }
-    }
-  ]
-})
-
-/**
  * Factory to generate standardized keyword block editors for structures
  * like Platforms and Instruments.
  */
-const createKeywordBlock = (type) => blockScheme({
+const createKeywordBlock = (type, { fieldKeys, matchKeys, getValue }) => blockScheme({
   nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords[gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${type}']`,
   find: {
-    // Look for both, factory will handle the specific logic
     fieldPaths: ['gmx:Anchor', 'gco:CharacterString'],
-    valueKeys: ['ShortName', 'LongName'],
+    valueKeys: fieldKeys,
+    matchKeys,
     getNodeValueObject: ({ node, editor }) => {
-      // Use helper to grab content regardless of tag type
       const anchorNode = editor.selectNodes('./gmx:Anchor', node)[0]
       const charStringNode = editor.selectNodes('./gco:CharacterString', node)[0]
 
       const fullString = (anchorNode || charStringNode)?.textContent || ''
-      const [ShortName, ...longNameParts] = fullString.split(' > ')
+      // Parsing logic: Hierarchical (l1 > l2) or Simple (short > long)
+      const parts = fullString.split(' > ').map((s) => s.trim())
 
-      return {
-        ShortName: ShortName?.trim() || '',
-        LongName: longNameParts.join(' > ').trim() || ''
-      }
+      return fieldKeys.reduce((acc, key, index) => {
+        acc[key] = parts[index] || ''
+
+        return acc
+      }, { Value: fullString.trim() })
     }
   },
   replace: [
     {
-      // Dynamic path resolver used by the editor class
       fieldPath: ({ node, editor }) => (editor.selectNodes('./gmx:Anchor', node).length > 0 ? 'gmx:Anchor' : 'gco:CharacterString'),
       source: {
         type: 'computed',
-        getValue: ({ correction }) => {
-          const { ShortName } = correction.newKeywordObject
-          const LongName = correction.newLongName || ''
-
-          return LongName ? `${ShortName} > ${LongName}` : ShortName
-        }
+        // Use the custom getValue if provided, else fall back to default
+        getValue: getValue || (({ correction }) => fieldKeys.map((k) => correction.newKeywordObject[k]).filter(Boolean).join(' > '))
       }
     }
   ]
@@ -159,27 +108,69 @@ const createProductLevelIdEditor = () => leafScheme({
  * within an ISO 19115 XML structure using XPath selectors and transformation logic.
  */
 export const ISO_19115_SCHEME_EDITORS = {
-  sciencekeywords: createHierarchicalKeywordBlock(
+  sciencekeywords: createKeywordBlock(
     'theme',
-    FULL_PATH_VALUE_FIELDS.sciencekeywords
+    {
+      fieldKeys: FULL_PATH_VALUE_FIELDS.sciencekeywords,
+      matchKeys: ['Value']
+    }
   ),
 
-  locations: createHierarchicalKeywordBlock(
+  locations: createKeywordBlock(
     'place',
-    FULL_PATH_VALUE_FIELDS.locations
+    {
+      fieldKeys: FULL_PATH_VALUE_FIELDS.locations,
+      matchKeys: ['Value']
+    }
   ),
 
-  platforms: createKeywordBlock('platform'),
+  platforms: createKeywordBlock('platform', {
+    fieldKeys: ['ShortName', 'LongName'],
+    matchKeys: ['ShortName'],
+    getValue: ({ correction }) => {
+      const { ShortName } = correction.newKeywordObject
+      const LongName = correction.newLongName || ''
 
-  instruments: createKeywordBlock('instrument'),
+      return LongName ? `${ShortName} > ${LongName}` : ShortName
+    }
+  }),
 
-  projects: createKeywordBlock('project'),
+  instruments: createKeywordBlock('instrument', {
+    fieldKeys: ['ShortName', 'LongName'],
+    matchKeys: ['ShortName'],
+    getValue: ({ correction }) => {
+      const { ShortName } = correction.newKeywordObject
+      const LongName = correction.newLongName || ''
+
+      return LongName ? `${ShortName} > ${LongName}` : ShortName
+    }
+  }),
+
+  projects: createKeywordBlock('project', {
+    fieldKeys: ['ShortName', 'LongName'],
+    matchKeys: ['ShortName'],
+    getValue: ({ correction }) => {
+      const { ShortName } = correction.newKeywordObject
+      const LongName = correction.newLongName || ''
+
+      return LongName ? `${ShortName} > ${LongName}` : ShortName
+    }
+  }),
 
   isotopiccategory: createIsoTopicCategoryEditor(),
 
   productlevelid: createProductLevelIdEditor(),
 
-  providers: createKeywordBlock('dataCentre')
+  providers: createKeywordBlock('dataCentre', {
+    fieldKeys: ['ShortName', 'LongName'],
+    matchKeys: ['ShortName'],
+    getValue: ({ correction }) => {
+      const { ShortName } = correction.newKeywordObject
+      const LongName = correction.newLongName || ''
+
+      return LongName ? `${ShortName} > ${LongName}` : ShortName
+    }
+  })
 
   /*
   Providers: short name not in examples

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -95,13 +95,13 @@ const createKeywordBlock = (keywordTypeCode) => blockScheme({
 })
 
 const createIsoTopicCategoryEditor = () => leafScheme({
-  // Targets the specific category element directly
   nodeXPath: '//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory',
   find: {
     getNodeValueObject: ({ node }) => ({ Value: node.textContent?.trim() || '' })
   },
   replace: [
     {
+      // 1. Update the visible text content
       fieldPath: 'gmd:MD_TopicCategoryCode',
       source: {
         type: 'computed',
@@ -109,7 +109,39 @@ const createIsoTopicCategoryEditor = () => leafScheme({
       }
     },
     {
+      // 2. Update the codeListValue attribute
       fieldPath: 'gmd:MD_TopicCategoryCode/@codeListValue',
+      source: {
+        type: 'computed',
+        getValue: ({ correction }) => correction.newKeywordObject.Value
+      }
+    }
+  ]
+})
+
+const createProductLevelIdEditor = () => leafScheme({
+  nodeXPath: '//gmd:processingLevel/gmd:MD_Identifier[gmd:codeSpace/gco:CharacterString="gov.nasa.esdis.umm.processinglevelid"]',
+  find: {
+    getNodeValueObject: ({ node, editor }) => ({
+      Value: editor.getNestedText(node, 'gmd:code/gco:CharacterString')?.trim() || ''
+    })
+  },
+  delete: [
+    // Define the paths to remove both occurrences
+    { path: '//gmd:processingLevel/gmd:MD_Identifier[gmd:codeSpace/gco:CharacterString="gov.nasa.esdis.umm.processinglevelid"]' },
+    { path: '//gmd:processingLevelCode/gmd:MD_Identifier[gmd:codeSpace/gco:CharacterString="gov.nasa.esdis.umm.processinglevelid"]' }
+  ],
+  replace: [
+    {
+      // Since matchingNode is now MD_Identifier, this path correctly selects the child
+      fieldPath: 'gmd:code/gco:CharacterString',
+      source: {
+        type: 'computed',
+        getValue: ({ correction }) => correction.newKeywordObject.Value
+      }
+    },
+    {
+      fieldPath: '//gmd:contentInfo/gmd:MD_ImageDescription/gmd:processingLevelCode/gmd:MD_Identifier[gmd:codeSpace/gco:CharacterString="gov.nasa.esdis.umm.processinglevelid"]/gmd:code/gco:CharacterString',
       source: {
         type: 'computed',
         getValue: ({ correction }) => correction.newKeywordObject.Value
@@ -140,7 +172,9 @@ export const ISO_19115_SCHEME_EDITORS = {
 
   projects: createKeywordBlock('project'),
 
-  isotopiccategory: createIsoTopicCategoryEditor()
+  isotopiccategory: createIsoTopicCategoryEditor(),
+
+  productlevelid: createProductLevelIdEditor()
 
   /*
   Providers: short name not in examples

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -60,60 +60,18 @@ const createHierarchicalKeywordBlock = (keywordTypeCode, fieldKeys) => blockSche
  * Factory to generate standardized keyword block editors for structures
  * like Platforms and Instruments.
  */
-const createKeywordBlock = (keywordTypeCode) => blockScheme({
-  nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords
-  [
-    gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${keywordTypeCode}'
-  ]`,
+const createKeywordBlock = (type) => blockScheme({
+  nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords[gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${type}']`,
   find: {
-    fieldPaths: ['gco:CharacterString'],
-    valueKeys: ['ShortName', 'LongName'],
-    getNodeValueObject: ({ node, editor, fieldPaths }) => {
-      const fullString = editor.getNestedText(node, fieldPaths[0]) || ''
-      const [ShortName, ...longNameParts] = fullString.split(' > ')
-
-      return {
-        ShortName: ShortName?.trim() || '',
-        LongName: longNameParts.join(' > ').trim() || ''
-      }
-    }
-  },
-  replace: [
-    {
-      fieldPath: 'gmd:keyword/gco:CharacterString',
-      source: {
-        type: 'computed',
-        getValue: ({ correction }) => {
-          const { ShortName } = correction.newKeywordObject
-          const LongName = correction.newLongName
-
-          return `${ShortName} > ${LongName}`
-        }
-      }
-    }
-  ]
-})
-
-/**
- * Factory to generate standardized keyword block editors for structures
- * like Platforms and Instruments.
- */
-const createProviderEditor = () => blockScheme({
-  nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords
-  [
-    gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = 'dataCentre'
-  ]`,
-  find: {
-    fieldPaths: ['gmx:Anchor', 'gco:CharacterString'], // Changed paths to be relative to <gmd:keyword>
+    // Look for both, factory will handle the specific logic
+    fieldPaths: ['gmx:Anchor', 'gco:CharacterString'],
     valueKeys: ['ShortName', 'LongName'],
     getNodeValueObject: ({ node, editor }) => {
-      // Directly extract the text from the child elements
+      // Use helper to grab content regardless of tag type
       const anchorNode = editor.selectNodes('./gmx:Anchor', node)[0]
       const charStringNode = editor.selectNodes('./gco:CharacterString', node)[0]
 
-      const fullString = (anchorNode ? anchorNode.textContent : '')
-                     || (charStringNode ? charStringNode.textContent : '') || ''
-
+      const fullString = (anchorNode || charStringNode)?.textContent || ''
       const [ShortName, ...longNameParts] = fullString.split(' > ')
 
       return {
@@ -124,9 +82,8 @@ const createProviderEditor = () => blockScheme({
   },
   replace: [
     {
-      fieldPath: ({ node, editor }) => (editor.selectNodes('./gmx:Anchor', node).length > 0
-        ? 'gmx:Anchor'
-        : 'gco:CharacterString'),
+      // Dynamic path resolver used by the editor class
+      fieldPath: ({ node, editor }) => (editor.selectNodes('./gmx:Anchor', node).length > 0 ? 'gmx:Anchor' : 'gco:CharacterString'),
       source: {
         type: 'computed',
         getValue: ({ correction }) => {
@@ -222,7 +179,7 @@ export const ISO_19115_SCHEME_EDITORS = {
 
   productlevelid: createProductLevelIdEditor(),
 
-  providers: createProviderEditor()
+  providers: createKeywordBlock('dataCentre')
 
   /*
   Providers: short name not in examples

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -8,138 +8,117 @@ import { FULL_PATH_VALUE_FIELDS } from './redis-path-store/helpers/constants'
 const blockScheme = (config) => (editor, correction) => editor.updateBlockNode(correction, config)
 
 /**
+ * Factory to generate hierarchical keyword block editors
+ * (like Science Keywords and Locations).
+ */
+const createHierarchicalKeywordBlock = (thesaurusTitle, keywordTypeCode, fieldKey) => blockScheme({
+  nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords
+  [
+    gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString = '${thesaurusTitle}'
+    or
+    gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${keywordTypeCode}'
+  ]`,
+  find: {
+    fieldPaths: ['gco:CharacterString'],
+    valueKeys: FULL_PATH_VALUE_FIELDS[fieldKey],
+    getNodeValueObject: ({ node, editor, fieldPaths }) => {
+      const fullString = editor.getNestedText(node, fieldPaths[0]) || ''
+      const parts = fullString.split(' > ').map((s) => s.trim())
+      const fields = FULL_PATH_VALUE_FIELDS[fieldKey]
+
+      const obj = fields.reduce((acc, field, index) => {
+        acc[field] = parts[index] || ''
+
+        return acc
+      }, {})
+
+      obj.Value = fullString.trim()
+
+      return obj
+    }
+  },
+  replace: [
+    {
+      fieldPath: 'gmd:keyword/gco:CharacterString',
+      source: {
+        type: 'computed',
+        getValue: ({ correction }) => {
+          const k = correction.newKeywordObject
+          const fields = FULL_PATH_VALUE_FIELDS[fieldKey]
+
+          return fields
+            .map((field) => k[field] || '')
+            .filter((v) => v.trim().length > 0)
+            .join(' > ')
+        }
+      }
+    }
+  ]
+})
+
+/**
+ * Factory to generate standardized keyword block editors for structures
+ * like Platforms and Instruments.
+ */
+const createKeywordBlock = (thesaurusTitle, keywordTypeCode) => blockScheme({
+  nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords
+  [
+    gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString = '${thesaurusTitle}'
+    or
+    gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = '${keywordTypeCode}'
+  ]`,
+  find: {
+    fieldPaths: ['gco:CharacterString'],
+    valueKeys: ['ShortName', 'LongName'],
+    getNodeValueObject: ({ node, editor, fieldPaths }) => {
+      const fullString = editor.getNestedText(node, fieldPaths[0]) || ''
+      const [ShortName, ...longNameParts] = fullString.split(' > ')
+
+      return {
+        ShortName: ShortName?.trim() || '',
+        LongName: longNameParts.join(' > ').trim() || ''
+      }
+    }
+  },
+  replace: [
+    {
+      fieldPath: 'gmd:keyword/gco:CharacterString',
+      source: {
+        type: 'computed',
+        getValue: ({ correction }) => {
+          const { ShortName } = correction.newKeywordObject
+          const LongName = correction.newLongName
+
+          return `${ShortName} > ${LongName}`
+        }
+      }
+    }
+  ]
+})
+
+/**
  * ISO 19115 scheme configuration.
  * Defines how to identify, parse, and update specific keyword blocks (e.g., science keywords, platforms)
  * within an ISO 19115 XML structure using XPath selectors and transformation logic.
  */
 export const ISO_19115_SCHEME_EDITORS = {
-  sciencekeywords: blockScheme({
-    // XPath to locate MD_Keywords nodes based on specific thesaurus title or type
-    nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords
-  [
-    gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString = 'NASA / GCMD Science Keywords'
-    or
-    gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = 'theme'
-  ]`,
-    find: {
-      fieldPaths: ['gco:CharacterString'],
-      valueKeys: FULL_PATH_VALUE_FIELDS.sciencekeywords,
-      // Parses the XML node into a structured object
-      getNodeValueObject: ({ node, editor, fieldPaths }) => {
-        const fullString = editor.getNestedText(node, fieldPaths[0]) || ''
-        // Splits hierarchical keywords (e.g., "Level 1 > Level 2") into array components
-        const parts = fullString.split(' > ').map((s) => s.trim())
-        const fields = FULL_PATH_VALUE_FIELDS.sciencekeywords
-        // Map split parts to defined schema fields
-        const obj = fields.reduce((acc, field, index) => {
-          acc[field] = parts[index] || ''
+  sciencekeywords: createHierarchicalKeywordBlock(
+    'NASA / GCMD Science Keywords',
+    'theme',
+    'sciencekeywords'
+  ),
 
-          return acc
-        }, {})
+  locations: createHierarchicalKeywordBlock(
+    'NASA / GCMD Location Keywords',
+    'place',
+    'locations'
+  ),
 
-        obj.Value = fullString.trim()// Keep original full string as 'Value'
+  platforms: createKeywordBlock('NASA / GCMD Platform Keywords', 'platform'),
 
-        return obj
-      }
-    },
-    // Defines how to serialize the updated object back into the XML structure
-    replace: [
-      {
-        fieldPath: 'gmd:keyword/gco:CharacterString',
-        source: {
-          type: 'computed',
-          getValue: ({ correction }) => {
-            const k = correction.newKeywordObject
-            const fields = FULL_PATH_VALUE_FIELDS.sciencekeywords
+  instruments: createKeywordBlock('NASA / GCMD Instrument Keywords', 'instrument'),
 
-            // Reconstructs the hierarchical string from object fields, ignoring empty ones
-            return fields
-              .map((field) => k[field] || '')
-              .filter((v) => v.trim().length > 0)
-              .join(' > ')
-          }
-        }
-      }
-    ]
-  }),
-
-  platforms: blockScheme({
-    // XPath to locate MD_Keywords specific to platforms
-    nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords
-  [
-    gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString = 'NASA / GCMD Platform Keywords'
-    or
-    gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = 'platform'
-  ]`,
-    find: {
-      fieldPaths: ['gco:CharacterString'],
-      valueKeys: ['ShortName', 'LongName'],
-      // Parses platform string: "ShortName > LongName"
-      getNodeValueObject: ({ node, editor, fieldPaths }) => {
-        const fullString = editor.getNestedText(node, fieldPaths[0]) || ''
-        const [ShortName, ...longNameParts] = fullString.split(' > ')
-
-        return {
-          ShortName: ShortName?.trim() || '',
-          LongName: longNameParts.join(' > ').trim() || ''
-        }
-      }
-    },
-    // Reconstructs platform string for XML update
-    replace: [
-      {
-        fieldPath: 'gmd:keyword/gco:CharacterString',
-        source: {
-          type: 'computed',
-          getValue: ({ correction }) => {
-            const { ShortName } = correction.newKeywordObject
-            const LongName = correction.newLongName
-
-            return `${ShortName} > ${LongName}`
-          }
-        }
-      }
-    ]
-  }),
-
-  instruments: blockScheme({
-    // XPath to locate MD_Keywords specific to instruments
-    nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords
-  [
-    gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString = 'NASA / GCMD Instrument Keywords'
-    or
-    gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = 'instrument'
-  ]`,
-    find: {
-      fieldPaths: ['gco:CharacterString'],
-      valueKeys: ['ShortName', 'LongName'],
-      // Parses instrument string: "ShortName > LongName"
-      getNodeValueObject: ({ node, editor, fieldPaths }) => {
-        const fullString = editor.getNestedText(node, fieldPaths[0]) || ''
-        const [ShortName, ...longNameParts] = fullString.split(' > ')
-
-        return {
-          ShortName: ShortName?.trim() || '',
-          LongName: longNameParts.join(' > ').trim() || ''
-        }
-      }
-    },
-    // Reconstructs instrument string for XML update
-    replace: [
-      {
-        fieldPath: 'gmd:keyword/gco:CharacterString',
-        source: {
-          type: 'computed',
-          getValue: ({ correction }) => {
-            const { ShortName } = correction.newKeywordObject
-            const LongName = correction.newLongName
-
-            return `${ShortName} > ${LongName}`
-          }
-        }
-      }
-    ]
-  })
+  projects: createKeywordBlock('NASA / GCMD Project Keywords', 'project')
 }
 
 /**

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -94,6 +94,52 @@ const createKeywordBlock = (keywordTypeCode) => blockScheme({
   ]
 })
 
+/**
+ * Factory to generate standardized keyword block editors for structures
+ * like Platforms and Instruments.
+ */
+const createProviderEditor = () => blockScheme({
+  nodeXPath: `//gmd:descriptiveKeywords/gmd:MD_Keywords
+  [
+    gmd:type/gmd:MD_KeywordTypeCode/@codeListValue = 'dataCentre'
+  ]`,
+  find: {
+    fieldPaths: ['gmx:Anchor', 'gco:CharacterString'], // Changed paths to be relative to <gmd:keyword>
+    valueKeys: ['ShortName', 'LongName'],
+    getNodeValueObject: ({ node, editor }) => {
+      // Directly extract the text from the child elements
+      const anchorNode = editor.selectNodes('./gmx:Anchor', node)[0]
+      const charStringNode = editor.selectNodes('./gco:CharacterString', node)[0]
+
+      const fullString = (anchorNode ? anchorNode.textContent : '')
+                     || (charStringNode ? charStringNode.textContent : '') || ''
+
+      const [ShortName, ...longNameParts] = fullString.split(' > ')
+
+      return {
+        ShortName: ShortName?.trim() || '',
+        LongName: longNameParts.join(' > ').trim() || ''
+      }
+    }
+  },
+  replace: [
+    {
+      fieldPath: ({ node, editor }) => (editor.selectNodes('./gmx:Anchor', node).length > 0
+        ? 'gmx:Anchor'
+        : 'gco:CharacterString'),
+      source: {
+        type: 'computed',
+        getValue: ({ correction }) => {
+          const { ShortName } = correction.newKeywordObject
+          const LongName = correction.newLongName || ''
+
+          return LongName ? `${ShortName} > ${LongName}` : ShortName
+        }
+      }
+    }
+  ]
+})
+
 const createIsoTopicCategoryEditor = () => leafScheme({
   nodeXPath: '//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory',
   find: {
@@ -174,7 +220,9 @@ export const ISO_19115_SCHEME_EDITORS = {
 
   isotopiccategory: createIsoTopicCategoryEditor(),
 
-  productlevelid: createProductLevelIdEditor()
+  productlevelid: createProductLevelIdEditor(),
+
+  providers: createProviderEditor()
 
   /*
   Providers: short name not in examples

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -310,7 +310,23 @@ export const ISO_19115_SCHEME_EDITORS = {
       const LongName = correction.newLongName || ''
 
       return LongName ? `${ShortName} > ${LongName}` : ShortName
-    }
+    },
+    // Sync with acquisition information section (gmi:MI_Operation)
+    additionalPaths: [
+      {
+        path: '//gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:operation/gmi:MI_Operation/gmi:identifier/gmd:MD_Identifier[gmd:codeSpace/gco:CharacterString="gov.nasa.esdis.umm.projectshortname"]/gmd:code/gco:CharacterString',
+        getValue: ({ correction }) => {
+          const { ShortName } = correction.newKeywordObject
+          const LongName = correction.newLongName || ''
+
+          return LongName ? `${ShortName} > ${LongName}` : ShortName
+        }
+      },
+      {
+        path: '//gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:operation/gmi:MI_Operation/gmi:identifier/gmd:MD_Identifier[gmd:codeSpace/gco:CharacterString="gov.nasa.esdis.umm.projectshortname"]/gmd:description/gco:CharacterString',
+        getValue: ({ correction }) => correction.newLongName || ''
+      }
+    ]
   }),
 
   providers: createKeywordBlock('dataCentre', {

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -321,11 +321,11 @@ export const ISO_19115_SCHEME_EDITORS = {
       const LongName = correction.newLongName || ''
 
       return LongName ? `${ShortName} > ${LongName}` : ShortName
-    },
-    // Additional paths
-    additionalPaths: [
-      '//gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString'
-    ]
+    }
+    // // Additional paths
+    // additionalPaths: [
+    //   '//gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString'
+    // ]
   }),
 
   isotopiccategory: createIsoTopicCategoryEditor(),

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -338,7 +338,7 @@ export const ISO_19115_SCHEME_EDITORS = {
 
       return LongName ? `${ShortName} > ${LongName}` : ShortName
     }
-    // // Additional paths
+    // Additional paths
     // additionalPaths: [
     //   '//gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString'
     // ]

--- a/serverless/src/shared/Iso19115DomEditor.js
+++ b/serverless/src/shared/Iso19115DomEditor.js
@@ -57,16 +57,22 @@ const createKeywordBlock = (type, {
       }
     },
     // Dynamically add secondary paths for synchronization
-    ...additionalPaths.map((path) => ({
-      fieldPath: path,
-      source: {
-        type: 'computed',
-        // Ensure the secondary sync paths also use the 'NONE' padding logic
-        getValue: getValue || (({ correction }) => fieldKeys
-          .map((k) => correction.newKeywordObject[k] || 'NONE')
-          .join(' > '))
+    // Each path can be a string or an object with { path, getValue }
+    ...additionalPaths.map((pathConfig) => {
+      const isObject = typeof pathConfig === 'object' && pathConfig.path
+      const path = isObject ? pathConfig.path : pathConfig
+      const pathGetValue = isObject ? pathConfig.getValue : null
+
+      return {
+        fieldPath: path,
+        source: {
+          type: 'computed',
+          getValue: pathGetValue || getValue || (({ correction }) => fieldKeys
+            .map((k) => correction.newKeywordObject[k] || 'NONE')
+            .join(' > '))
+        }
       }
-    }))
+    })
   ]
 })
 
@@ -110,9 +116,10 @@ const createProductLevelIdEditor = () => leafScheme({
     })
   },
   delete: [
-    // Define the paths to remove both occurrences
-    { path: '//gmd:processingLevel/gmd:MD_Identifier[gmd:codeSpace/gco:CharacterString="gov.nasa.esdis.umm.processinglevelid"]' },
-    { path: '//gmd:processingLevelCode/gmd:MD_Identifier[gmd:codeSpace/gco:CharacterString="gov.nasa.esdis.umm.processinglevelid"]' }
+    // Remove the entire processingLevel parent wrapper (in identificationInfo)
+    { path: '//gmd:identificationInfo//gmd:processingLevel[gmd:MD_Identifier/gmd:codeSpace/gco:CharacterString="gov.nasa.esdis.umm.processinglevelid"]' },
+    // Remove the entire processingLevelCode parent wrapper (in contentInfo)
+    { path: '//gmd:contentInfo//gmd:processingLevelCode[gmd:MD_Identifier/gmd:codeSpace/gco:CharacterString="gov.nasa.esdis.umm.processinglevelid"]' }
   ],
   replace: [
     {
@@ -163,7 +170,68 @@ export const ISO_19115_SCHEME_EDITORS = {
       const LongName = correction.newLongName || ''
 
       return LongName ? `${ShortName} > ${LongName}` : ShortName
-    }
+    },
+    // Sync with acquisition information section
+    // Smart detection: if gmd:code contains ' > ', use combined format (CWIC style)
+    // Otherwise use split format (NSIDC/NOAA style)
+    additionalPaths: [
+      {
+        path: '//gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:platform/eos:EOS_Platform/gmi:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString',
+        getValue: ({ correction, node }) => {
+          const existingValue = node?.textContent || ''
+          // If existing value contains ' > ', keep combined format
+          if (existingValue.includes(' > ')) {
+            const { ShortName } = correction.newKeywordObject
+            const LongName = correction.newLongName || ''
+
+            return LongName ? `${ShortName} > ${LongName}` : ShortName
+          }
+
+          // Otherwise use ShortName only (NSIDC/NOAA format)
+          return correction.newKeywordObject.ShortName
+        }
+      },
+      {
+        path: '//gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:platform/gmi:MI_Platform/gmi:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString',
+        getValue: ({ correction, node }) => {
+          const existingValue = node?.textContent || ''
+          if (existingValue.includes(' > ')) {
+            const { ShortName } = correction.newKeywordObject
+            const LongName = correction.newLongName || ''
+
+            return LongName ? `${ShortName} > ${LongName}` : ShortName
+          }
+
+          return correction.newKeywordObject.ShortName
+        }
+      },
+      {
+        path: '//gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:platform/eos:EOS_Platform/gmi:identifier/gmd:MD_Identifier/gmd:description/gco:CharacterString',
+        getValue: ({ correction, node, editor }) => {
+          const codeNode = editor.selectNodes('../gmd:code/gco:CharacterString', node.parentNode)[0]
+          const codeValue = codeNode?.textContent || ''
+          // Only update description if code uses split format (doesn't contain ' > ')
+          if (!codeValue.includes(' > ')) {
+            return correction.newLongName || ''
+          }
+
+          // For CWIC format, preserve existing free-text description
+          return node?.textContent || ''
+        }
+      },
+      {
+        path: '//gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:platform/gmi:MI_Platform/gmi:identifier/gmd:MD_Identifier/gmd:description/gco:CharacterString',
+        getValue: ({ correction, node, editor }) => {
+          const codeNode = editor.selectNodes('../gmd:code/gco:CharacterString', node.parentNode)[0]
+          const codeValue = codeNode?.textContent || ''
+          if (!codeValue.includes(' > ')) {
+            return correction.newLongName || ''
+          }
+
+          return node?.textContent || ''
+        }
+      }
+    ]
   }),
 
   instruments: createKeywordBlock('instrument', {
@@ -174,7 +242,64 @@ export const ISO_19115_SCHEME_EDITORS = {
       const LongName = correction.newLongName || ''
 
       return LongName ? `${ShortName} > ${LongName}` : ShortName
-    }
+    },
+    // Sync with acquisition information section
+    // Smart detection: if gmd:code contains ' > ', use combined format (CWIC style)
+    // Otherwise use split format (NSIDC/NOAA style)
+    additionalPaths: [
+      {
+        path: '//gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:instrument/eos:EOS_Instrument/gmi:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString',
+        getValue: ({ correction, node }) => {
+          const existingValue = node?.textContent || ''
+          if (existingValue.includes(' > ')) {
+            const { ShortName } = correction.newKeywordObject
+            const LongName = correction.newLongName || ''
+
+            return LongName ? `${ShortName} > ${LongName}` : ShortName
+          }
+
+          return correction.newKeywordObject.ShortName
+        }
+      },
+      {
+        path: '//gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:instrument/gmi:MI_Instrument/gmi:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString',
+        getValue: ({ correction, node }) => {
+          const existingValue = node?.textContent || ''
+          if (existingValue.includes(' > ')) {
+            const { ShortName } = correction.newKeywordObject
+            const LongName = correction.newLongName || ''
+
+            return LongName ? `${ShortName} > ${LongName}` : ShortName
+          }
+
+          return correction.newKeywordObject.ShortName
+        }
+      },
+      {
+        path: '//gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:instrument/eos:EOS_Instrument/gmi:identifier/gmd:MD_Identifier/gmd:description/gco:CharacterString',
+        getValue: ({ correction, node, editor }) => {
+          const codeNode = editor.selectNodes('../gmd:code/gco:CharacterString', node.parentNode)[0]
+          const codeValue = codeNode?.textContent || ''
+          if (!codeValue.includes(' > ')) {
+            return correction.newLongName || ''
+          }
+
+          return node?.textContent || ''
+        }
+      },
+      {
+        path: '//gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:instrument/gmi:MI_Instrument/gmi:identifier/gmd:MD_Identifier/gmd:description/gco:CharacterString',
+        getValue: ({ correction, node, editor }) => {
+          const codeNode = editor.selectNodes('../gmd:code/gco:CharacterString', node.parentNode)[0]
+          const codeValue = codeNode?.textContent || ''
+          if (!codeValue.includes(' > ')) {
+            return correction.newLongName || ''
+          }
+
+          return node?.textContent || ''
+        }
+      }
+    ]
   }),
 
   projects: createKeywordBlock('project', {

--- a/serverless/src/shared/Iso19115MetadataPathEditor.js
+++ b/serverless/src/shared/Iso19115MetadataPathEditor.js
@@ -5,6 +5,8 @@ import { extractNamespaces } from './XmlUtils'
 
 /**
  * Subclass of XmlMetadataPathEditor specialized for ISO 19115 XML structure.
+ * Handles namespace resolution and provides specific methods for updating
+ * keyword blocks and leaf nodes within ISO 19115 metadata.
  */
 export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
   constructor(xmlString) {
@@ -32,15 +34,23 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
     this.resolver = xpath.useNamespaces(this.namespaces)
   }
 
-  // In Iso19115Editor class
+  /**
+   * Executes an XPath expression and ensures only element nodes are returned.
+   * @param {string} expression - The XPath string.
+   * @param {Node} contextNode - The XML node to execute the search against.
+   * @returns {Node[]} Array of matching Element nodes.
+   */
   selectNodes(expression, contextNode = this.document) {
-  // Use the registered resolver instance
     return this.resolver(expression, contextNode)
-      .filter((node) => node?.nodeType === 1) // ELEMENT_NODE
+      .filter((node) => node?.nodeType === 1) // Ensure only ELEMENT_NODE
   }
 
   /**
-   * Helper to identify the correct keyword node based on the config.
+   * Identifies the specific keyword node to update or delete within a block.
+   * @param {Node} targetNode - The parent MD_Keywords block.
+   * @param {Object} correction - The user-provided change data.
+   * @param {Object} config - The configuration defining matching logic.
+   * @returns {Node|undefined} The matching node if found.
    */
   findMatchingNode(targetNode, correction, config) {
     const keywordNodes = this.selectNodes('./gmd:keyword', targetNode)
@@ -52,7 +62,7 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
         fieldPaths: config.find.fieldPaths
       })
 
-      // Use matchKeys if defined, otherwise fall back to oldKeywordObject keys
+      // Use defined matchKeys or default to existing object keys
       const matchKeys = config.find.matchKeys || Object.keys(correction.oldKeywordObject)
 
       return matchKeys.every((key) => {
@@ -65,7 +75,11 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
   }
 
   /**
-   * Updates leaf (direct) nodes like isotopiccategory and productlevelid.
+   * Updates or deletes leaf nodes (direct elements) based on configuration.
+   * Handles multi-step path deletions and attribute-based updates.
+   * @param {Object} correction - The change data.
+   * @param {Object} config - The node configuration mapping.
+   * @returns {boolean} True if the operation was successful.
    */
   updateLeafNode(correction, config) {
     const { action, oldKeywordObject } = correction
@@ -98,7 +112,6 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
             })
           })
         } else if (targetNode.parentNode) {
-          // Use 'else if' to flatten the structure and satisfy the linter
           targetNode.parentNode.removeChild(targetNode)
         }
 
@@ -143,8 +156,14 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
     return false
   }
 
+  /**
+   * Updates complex keyword block nodes.
+   * Handles deletion of nested keywords and recursive cleanup of empty parents.
+   * @param {Object} correction - The change data.
+   * @param {Object} config - Configuration for the block node.
+   * @returns {boolean} True if the operation was successful.
+   */
   updateBlockNode(correction, config) {
-    // 1. Find the parent block using your namespaced XPath
     const targetNode = this.selectNodes(config.nodeXPath)[0] || null
     if (!targetNode) return false
 
@@ -153,10 +172,10 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
       const matchingNode = this.findMatchingNode(targetNode, correction, config)
       if (!matchingNode) return false
 
-      // Remove the identified node
+      // Remove target node
       matchingNode.parentNode.removeChild(matchingNode)
 
-      // Cleanup empty parent blocks
+      // Cleanup: Remove parent blocks if they are now empty
       const remainingKeywords = this.selectNodes('./gmd:keyword', targetNode)
       if (remainingKeywords.length === 0) {
         const mdKeywordsParent = targetNode.parentNode
@@ -179,7 +198,7 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
       if (matchingNode) {
         let fieldNode = null
 
-        // Attempt dynamic path if defined in the config
+        // Determine dynamic path or default
         if (replaceConfig.fieldPath) {
           const path = typeof replaceConfig.fieldPath === 'function'
             ? replaceConfig.fieldPath({
@@ -192,13 +211,13 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
           [fieldNode] = this.selectNodes(relativePath, matchingNode)
         }
 
-        // Fallback: look for standard gco:CharacterString
+        // Fallback search for standard string elements
         if (!fieldNode) {
           [fieldNode] = this.selectNodes('./gco:CharacterString', matchingNode)
                     || this.selectNodes('gco:CharacterString', matchingNode)
         }
 
-        // Perform update
+        // Apply text update
         if (fieldNode) {
           const newValue = replaceConfig.source.getValue({ correction })
           this.setElementText(fieldNode, newValue)

--- a/serverless/src/shared/Iso19115MetadataPathEditor.js
+++ b/serverless/src/shared/Iso19115MetadataPathEditor.js
@@ -39,29 +39,33 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
 
     // 2. Handle the 'delete' action
     if (correction.action === 'delete') {
-      const oldVal = correction.oldKeywordObject.Value || correction.oldKeywordObject.ShortName
+      // Normalize search string to lowercase
+      const oldVal = (correction.oldKeywordObject.Value || correction.oldKeywordObject.ShortName || '').toLowerCase().trim()
 
-      // Find the specific <gmd:keyword> node containing the string to delete
-      // We look for a CharacterString that contains the old value
-      // We use the block (targetNode) as the context to keep search scoped
-      const xPath = `.//gmd:keyword/gco:CharacterString[contains(., '${oldVal}')]`
-      const targetCharString = this.selectNodes(xPath, targetNode)[0]
+      // 1. Get all potential CharacterString nodes within the block
+      const allCharStrings = this.selectNodes('.//gmd:keyword/gco:CharacterString', targetNode)
+
+      // 2. Find the node using a case-insensitive partial match (.includes)
+      const targetCharString = allCharStrings.find((node) => {
+        const textValue = (node.textContent || '').toLowerCase().trim()
+
+        return textValue.includes(oldVal)
+      })
 
       if (!targetCharString) return false
 
-      // A. Remove the specific keyword entry
+      // 3. Remove the specific keyword entry
       const keywordNode = targetCharString.parentNode
       keywordNode.parentNode.removeChild(keywordNode)
 
-      // B. Check if any keywords remain in the MD_Keywords block
+      // 4. Check if any keywords remain in the MD_Keywords block
       const remainingKeywords = this.selectNodes('.//gmd:keyword', targetNode)
 
       if (remainingKeywords.length === 0) {
-        // C. If no keywords remain, remove the MD_Keywords block
+        // ... (rest of your cleanup logic remains exactly the same)
         const mdKeywordsParent = targetNode.parentNode
         mdKeywordsParent.removeChild(targetNode)
 
-        // D. Check if the gmd:descriptiveKeywords wrapper is now empty
         const remainingBlocks = this.selectNodes('./gmd:MD_Keywords', mdKeywordsParent)
         if (remainingBlocks.length === 0) {
           mdKeywordsParent.parentNode.removeChild(mdKeywordsParent)
@@ -88,8 +92,8 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
         // Compare ALL keys present in the correction.oldKeywordObject
         // This works for { Value: '...' } AND { ShortName: '...' }
         return Object.keys(correction.oldKeywordObject).every((key) => {
-          const parsedValue = parsedObject[key] ? trimString(parsedObject[key]) : ''
-          const correctionValue = correction.oldKeywordObject[key] ? trimString(correction.oldKeywordObject[key]) : ''
+          const parsedValue = parsedObject[key] ? trimString(parsedObject[key]).toLowerCase() : ''
+          const correctionValue = correction.oldKeywordObject[key] ? trimString(correction.oldKeywordObject[key]).toLowerCase() : ''
 
           return parsedValue === correctionValue
         })

--- a/serverless/src/shared/Iso19115MetadataPathEditor.js
+++ b/serverless/src/shared/Iso19115MetadataPathEditor.js
@@ -185,13 +185,24 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
     if (correction.action === 'delete') {
       const parentBlock = matchingNode.parentNode
 
-      // Clean up synchronized paths globally first
+      // Initialize keywordValue here so it is available in the scope
+      const keywordValue = matchingNode.textContent.trim()
+
+      // Clean up synchronized paths globally, but with a value constraint
       if (config.replace) {
         config.replace
           .filter((replConfig) => typeof replConfig.fieldPath === 'string' && replConfig.fieldPath.startsWith('//'))
           .forEach((replConfig) => {
-            this.selectNodes(replConfig.fieldPath, this.document)
-              .forEach((node) => node?.parentNode?.removeChild(node))
+            // Find all nodes in the document that match the path
+            const allPotentialMatches = this.selectNodes(replConfig.fieldPath, this.document)
+
+            // Filter those nodes: only remove the ones whose text content
+            // matches the keyword we are currently deleting
+            allPotentialMatches
+              .filter((node) => node.textContent.trim() === keywordValue)
+              .forEach((node) => {
+                if (node?.parentNode) node.parentNode.removeChild(node)
+              })
           })
       }
 
@@ -214,8 +225,9 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
     // 3. Handle 'replace' action
     if (correction.action === 'replace') {
       const results = config.replace.map((replaceConfig) => {
-        let fieldNode = null
+        let fieldNodes = []
 
+        // 1. Attempt to find nodes via the provided path
         if (replaceConfig.fieldPath) {
           const path = typeof replaceConfig.fieldPath === 'function'
             ? replaceConfig.fieldPath({
@@ -225,16 +237,22 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
             : replaceConfig.fieldPath
 
           const context = path.startsWith('//') ? this.document : matchingNode
-          const relativePath = path.startsWith('//') ? path : `./${path}`;
-          [fieldNode] = this.selectNodes(relativePath, context)
+          const relativePath = path.startsWith('//') ? path : `./${path}`
+
+          fieldNodes = this.selectNodes(relativePath, context)
         }
 
-        if (!fieldNode) {
-          [fieldNode] = this.selectNodes('./gco:CharacterString', matchingNode)
+        // 2. Fallback: If no nodes were found via path,
+        // ALWAYS check for the default text node (remove the !replaceConfig.fieldPath check)
+        if (fieldNodes.length === 0) {
+          fieldNodes = this.selectNodes('./gco:CharacterString', matchingNode)
         }
 
-        if (fieldNode) {
-          this.setElementText(fieldNode, replaceConfig.source.getValue({ correction }))
+        // 3. Update every node found
+        if (fieldNodes.length > 0) {
+          fieldNodes.forEach((node) => {
+            this.setElementText(node, replaceConfig.source.getValue({ correction }))
+          })
 
           return true
         }

--- a/serverless/src/shared/Iso19115MetadataPathEditor.js
+++ b/serverless/src/shared/Iso19115MetadataPathEditor.js
@@ -113,31 +113,35 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
     if (!targetNode) return false
 
     // 2. Handle the 'delete' action
+    // 2. Handle the 'delete' action
     if (correction.action === 'delete') {
-      // Normalize search string to lowercase
-      const oldVal = (correction.oldKeywordObject.Value || correction.oldKeywordObject.ShortName || '').toLowerCase().trim()
+      // 1. Get all potential keyword nodes within the block
+      const keywordNodes = this.selectNodes('./gmd:keyword', targetNode)
 
-      // 1. Get all potential CharacterString nodes within the block
-      const allCharStrings = this.selectNodes('.//gmd:keyword/gco:CharacterString', targetNode)
+      // 2. Find the correct node using your config's getNodeValueObject
+      const matchingNode = keywordNodes.find((node) => {
+        const parsedObject = config.find.getNodeValueObject({
+          node,
+          editor: this,
+          fieldPaths: config.find.fieldPaths
+        })
 
-      // 2. Find the node using a case-insensitive partial match (.includes)
-      const targetCharString = allCharStrings.find((node) => {
-        const textValue = (node.textContent || '').toLowerCase().trim()
+        return Object.keys(correction.oldKeywordObject).every((key) => {
+          const parsedValue = parsedObject[key] ? trimString(parsedObject[key]).toLowerCase() : ''
+          const correctionValue = correction.oldKeywordObject[key] ? trimString(correction.oldKeywordObject[key]).toLowerCase() : ''
 
-        return textValue.includes(oldVal)
+          return parsedValue === correctionValue
+        })
       })
 
-      if (!targetCharString) return false
+      if (!matchingNode) return false
 
-      // 3. Remove the specific keyword entry
-      const keywordNode = targetCharString.parentNode
-      keywordNode.parentNode.removeChild(keywordNode)
+      // 3. Remove the identified node
+      matchingNode.parentNode.removeChild(matchingNode)
 
-      // 4. Check if any keywords remain in the MD_Keywords block
-      const remainingKeywords = this.selectNodes('.//gmd:keyword', targetNode)
-
+      // 4. Cleanup empty parent blocks (same logic as before)
+      const remainingKeywords = this.selectNodes('./gmd:keyword', targetNode)
       if (remainingKeywords.length === 0) {
-        // ... (rest of your cleanup logic remains exactly the same)
         const mdKeywordsParent = targetNode.parentNode
         mdKeywordsParent.removeChild(targetNode)
 
@@ -174,12 +178,31 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
         })
       })
 
+      // Inside Iso19115MetadataPathEditor.js, within the 'replace' action block:
       if (matchingNode) {
-        // Since matchingNode is already the <gmd:keyword> element,
-        // we look for the child <gco:CharacterString> directly.
-        const fieldNode = this.selectNodes('./gco:CharacterString', matchingNode)[0]
-                    || this.selectNodes('gco:CharacterString', matchingNode)[0]
+        let fieldNode = null
 
+        // 1. Attempt to find the dynamic path if defined in the config
+        if (replaceConfig.fieldPath) {
+          const path = typeof replaceConfig.fieldPath === 'function'
+            ? replaceConfig.fieldPath({
+              node: matchingNode,
+              editor: this
+            })
+            : replaceConfig.fieldPath
+
+          const relativePath = path.startsWith('./') ? path : `./${path}`;
+          // Use destructuring to capture the first match directly
+          [fieldNode] = this.selectNodes(relativePath, matchingNode)
+        }
+
+        // 2. Fallback: If dynamic path failed, look for standard gco:CharacterString
+        if (!fieldNode) {
+          [fieldNode] = this.selectNodes('./gco:CharacterString', matchingNode)
+                    || this.selectNodes('gco:CharacterString', matchingNode)
+        }
+
+        // 3. Perform update if node found
         if (fieldNode) {
           const newValue = replaceConfig.source.getValue({ correction })
           this.setElementText(fieldNode, newValue)

--- a/serverless/src/shared/Iso19115MetadataPathEditor.js
+++ b/serverless/src/shared/Iso19115MetadataPathEditor.js
@@ -1,7 +1,7 @@
 import xpath from 'xpath'
 
 import XmlMetadataPathEditor from './XmlMetadataPathEditor'
-import { extractNamespaces, trimString } from './XmlUtils'
+import { extractNamespaces } from './XmlUtils'
 
 /**
  * Subclass of XmlMetadataPathEditor specialized for ISO 19115 XML structure.
@@ -9,16 +9,27 @@ import { extractNamespaces, trimString } from './XmlUtils'
 export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
   constructor(xmlString) {
     super(xmlString)
-    // Get the root element
     const root = this.document.documentElement
 
-    // Build the namespace map from the root's attributes
-    const namespaces = extractNamespaces(root)
+    // 1. Get dynamic namespaces
+    const extracted = extractNamespaces(root)
 
-    // Store for use in XPath resolution
-    this.namespaces = namespaces
-    const resolver = xpath.useNamespaces(namespaces)
-    this.resolver = resolver
+    // 2. Define standard ISO 19115 namespaces
+    const standardNamespaces = {
+      gco: 'http://www.isotc211.org/2005/gco',
+      gmd: 'http://www.isotc211.org/2005/gmd',
+      gmi: 'http://www.isotc211.org/2005/gmi',
+      gmx: 'http://www.isotc211.org/2005/gmx',
+      gml: 'http://www.opengis.net/gml/3.2'
+    }
+
+    // 3. Merge them, prioritizing extracted ones (if any)
+    this.namespaces = {
+      ...standardNamespaces,
+      ...extracted
+    }
+
+    this.resolver = xpath.useNamespaces(this.namespaces)
   }
 
   // In Iso19115Editor class
@@ -26,6 +37,31 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
   // Use the registered resolver instance
     return this.resolver(expression, contextNode)
       .filter((node) => node?.nodeType === 1) // ELEMENT_NODE
+  }
+
+  /**
+   * Helper to identify the correct keyword node based on the config.
+   */
+  findMatchingNode(targetNode, correction, config) {
+    const keywordNodes = this.selectNodes('./gmd:keyword', targetNode)
+
+    return keywordNodes.find((node) => {
+      const parsedObject = config.find.getNodeValueObject({
+        node,
+        editor: this,
+        fieldPaths: config.find.fieldPaths
+      })
+
+      // Use matchKeys if defined, otherwise fall back to oldKeywordObject keys
+      const matchKeys = config.find.matchKeys || Object.keys(correction.oldKeywordObject)
+
+      return matchKeys.every((key) => {
+        const parsedValue = (parsedObject[key] || '').toLowerCase().trim()
+        const correctionValue = (correction.oldKeywordObject[key] || '').toLowerCase().trim()
+
+        return parsedValue === correctionValue
+      })
+    })
   }
 
   /**
@@ -113,33 +149,14 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
     if (!targetNode) return false
 
     // 2. Handle the 'delete' action
-    // 2. Handle the 'delete' action
     if (correction.action === 'delete') {
-      // 1. Get all potential keyword nodes within the block
-      const keywordNodes = this.selectNodes('./gmd:keyword', targetNode)
-
-      // 2. Find the correct node using your config's getNodeValueObject
-      const matchingNode = keywordNodes.find((node) => {
-        const parsedObject = config.find.getNodeValueObject({
-          node,
-          editor: this,
-          fieldPaths: config.find.fieldPaths
-        })
-
-        return Object.keys(correction.oldKeywordObject).every((key) => {
-          const parsedValue = parsedObject[key] ? trimString(parsedObject[key]).toLowerCase() : ''
-          const correctionValue = correction.oldKeywordObject[key] ? trimString(correction.oldKeywordObject[key]).toLowerCase() : ''
-
-          return parsedValue === correctionValue
-        })
-      })
-
+      const matchingNode = this.findMatchingNode(targetNode, correction, config)
       if (!matchingNode) return false
 
-      // 3. Remove the identified node
+      // Remove the identified node
       matchingNode.parentNode.removeChild(matchingNode)
 
-      // 4. Cleanup empty parent blocks (same logic as before)
+      // Cleanup empty parent blocks
       const remainingKeywords = this.selectNodes('./gmd:keyword', targetNode)
       if (remainingKeywords.length === 0) {
         const mdKeywordsParent = targetNode.parentNode
@@ -157,32 +174,12 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
     // 3. Handle the 'replace' action
     if (correction.action === 'replace') {
       const replaceConfig = config.replace[0]
+      const matchingNode = this.findMatchingNode(targetNode, correction, config)
 
-      // 1. Get all keyword nodes in this block
-      const keywordNodes = this.selectNodes('./gmd:keyword', targetNode)
-
-      const matchingNode = keywordNodes.find((node) => {
-        const parsedObject = config.find.getNodeValueObject({
-          node,
-          editor: this,
-          fieldPaths: config.find.fieldPaths
-        })
-
-        // Compare ALL keys present in the correction.oldKeywordObject
-        // This works for { Value: '...' } AND { ShortName: '...' }
-        return Object.keys(correction.oldKeywordObject).every((key) => {
-          const parsedValue = parsedObject[key] ? trimString(parsedObject[key]).toLowerCase() : ''
-          const correctionValue = correction.oldKeywordObject[key] ? trimString(correction.oldKeywordObject[key]).toLowerCase() : ''
-
-          return parsedValue === correctionValue
-        })
-      })
-
-      // Inside Iso19115MetadataPathEditor.js, within the 'replace' action block:
       if (matchingNode) {
         let fieldNode = null
 
-        // 1. Attempt to find the dynamic path if defined in the config
+        // Attempt dynamic path if defined in the config
         if (replaceConfig.fieldPath) {
           const path = typeof replaceConfig.fieldPath === 'function'
             ? replaceConfig.fieldPath({
@@ -192,17 +189,16 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
             : replaceConfig.fieldPath
 
           const relativePath = path.startsWith('./') ? path : `./${path}`;
-          // Use destructuring to capture the first match directly
           [fieldNode] = this.selectNodes(relativePath, matchingNode)
         }
 
-        // 2. Fallback: If dynamic path failed, look for standard gco:CharacterString
+        // Fallback: look for standard gco:CharacterString
         if (!fieldNode) {
           [fieldNode] = this.selectNodes('./gco:CharacterString', matchingNode)
                     || this.selectNodes('gco:CharacterString', matchingNode)
         }
 
-        // 3. Perform update if node found
+        // Perform update
         if (fieldNode) {
           const newValue = replaceConfig.source.getValue({ correction })
           this.setElementText(fieldNode, newValue)
@@ -211,7 +207,7 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
         }
       }
 
-      return false // Match not found or fieldNode missing
+      return false
     }
 
     return false

--- a/serverless/src/shared/Iso19115MetadataPathEditor.js
+++ b/serverless/src/shared/Iso19115MetadataPathEditor.js
@@ -1,0 +1,140 @@
+import xpath from 'xpath'
+
+import XmlMetadataPathEditor from './XmlMetadataPathEditor'
+import {
+  extractNamespaces,
+  getScalarKeywordText,
+  trimString
+} from './XmlUtils'
+
+/**
+ * Subclass of XmlMetadataPathEditor specialized for ISO 19115 XML structure.
+ */
+export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
+  constructor(xmlString) {
+    super(xmlString)
+    // Get the root element
+    const root = this.document.documentElement
+
+    // Build the namespace map from the root's attributes
+    const namespaces = extractNamespaces(root)
+
+    // Store for use in XPath resolution
+    this.namespaces = namespaces
+    const resolver = xpath.useNamespaces(namespaces)
+    this.resolver = resolver
+  }
+
+  // In Iso19115Editor class
+  selectNodes(expression, contextNode = this.document) {
+  // Use the registered resolver instance
+    return this.resolver(expression, contextNode)
+      .filter((node) => node?.nodeType === 1) // ELEMENT_NODE
+  }
+
+  updateBlockNode(correction, config) {
+    // 1. Find the parent block using your namespaced XPath
+    const targetNode = this.selectNodes(config.nodeXPath)[0] || null
+    if (!targetNode) return false
+
+    // 2. Handle the 'delete' action
+    if (correction.action === 'delete') {
+      const oldVal = correction.oldKeywordObject.Value || correction.oldKeywordObject.ShortName
+
+      // Find the specific <gmd:keyword> node containing the string to delete
+      // We look for a CharacterString that contains the old value
+      // We use the block (targetNode) as the context to keep search scoped
+      const xPath = `.//gmd:keyword/gco:CharacterString[contains(., '${oldVal}')]`
+      const targetCharString = this.selectNodes(xPath, targetNode)[0]
+
+      if (!targetCharString) return false
+
+      // A. Remove the specific keyword entry
+      const keywordNode = targetCharString.parentNode
+      keywordNode.parentNode.removeChild(keywordNode)
+
+      // B. Check if any keywords remain in the MD_Keywords block
+      const remainingKeywords = this.selectNodes('.//gmd:keyword', targetNode)
+
+      if (remainingKeywords.length === 0) {
+        // C. If no keywords remain, remove the MD_Keywords block
+        const mdKeywordsParent = targetNode.parentNode
+        mdKeywordsParent.removeChild(targetNode)
+
+        // D. Check if the gmd:descriptiveKeywords wrapper is now empty
+        const remainingBlocks = this.selectNodes('./gmd:MD_Keywords', mdKeywordsParent)
+        if (remainingBlocks.length === 0) {
+          mdKeywordsParent.parentNode.removeChild(mdKeywordsParent)
+        }
+      }
+
+      return true
+    }
+
+    // 3. Handle the 'replace' action
+    if (correction.action === 'replace') {
+      const replaceConfig = config.replace[0]
+
+      // 1. Get all keyword nodes in this block
+      const keywordNodes = this.selectNodes('./gmd:keyword', targetNode)
+
+      const matchingNode = keywordNodes.find((node) => {
+        const parsedObject = config.find.getNodeValueObject({
+          node,
+          editor: this,
+          fieldPaths: config.find.fieldPaths
+        })
+
+        // Compare ALL keys present in the correction.oldKeywordObject
+        // This works for { Value: '...' } AND { ShortName: '...' }
+        return Object.keys(correction.oldKeywordObject).every((key) => {
+          const parsedValue = parsedObject[key] ? trimString(parsedObject[key]) : ''
+          const correctionValue = correction.oldKeywordObject[key] ? trimString(correction.oldKeywordObject[key]) : ''
+
+          return parsedValue === correctionValue
+        })
+      })
+
+      // In Iso19115MetadataPathEditor.js
+
+      if (matchingNode) {
+        // Since matchingNode is already the <gmd:keyword> element,
+        // we look for the child <gco:CharacterString> directly.
+        const fieldNode = this.selectNodes('./gco:CharacterString', matchingNode)[0]
+                    || this.selectNodes('gco:CharacterString', matchingNode)[0]
+
+        if (fieldNode) {
+          const newValue = replaceConfig.source.getValue({ correction })
+          this.setElementText(fieldNode, newValue)
+
+          return true
+        }
+      }
+
+      return false // Match not found or fieldNode missing
+    }
+
+    return false
+  }
+
+  /**
+   * Override updateLeafNode to handle gco:CharacterString wrapping.
+   * ISO 19115 frequently stores text values inside <gco:CharacterString> nodes.
+   */
+  updateLeafNode(correction, config) {
+    const targetNode = this.selectNodes(config.nodeXPath)[0] || null
+    if (!targetNode) return false
+
+    // Target the specific gco:CharacterString child
+    const charString = targetNode.getElementsByTagNameNS(this.namespaces.gco, 'CharacterString')[0]
+    if (charString) {
+      const value = getScalarKeywordText(correction?.newKeywordObject)
+      this.setElementText(charString, value)
+
+      return true
+    }
+
+    return false
+  }
+}
+export default Iso19115MetadataPathEditor

--- a/serverless/src/shared/Iso19115MetadataPathEditor.js
+++ b/serverless/src/shared/Iso19115MetadataPathEditor.js
@@ -1,11 +1,7 @@
 import xpath from 'xpath'
 
 import XmlMetadataPathEditor from './XmlMetadataPathEditor'
-import {
-  extractNamespaces,
-  getScalarKeywordText,
-  trimString
-} from './XmlUtils'
+import { extractNamespaces, trimString } from './XmlUtils'
 
 /**
  * Subclass of XmlMetadataPathEditor specialized for ISO 19115 XML structure.
@@ -30,6 +26,59 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
   // Use the registered resolver instance
     return this.resolver(expression, contextNode)
       .filter((node) => node?.nodeType === 1) // ELEMENT_NODE
+  }
+
+  /**
+   * Updates leaf (direct) nodes like isotopiccategory.
+   */
+  updateLeafNode(correction, config) {
+    const { action, oldKeywordObject } = correction
+    const oldVal = (oldKeywordObject.Value || '').toLowerCase().trim()
+
+    // 1. Get all relevant nodes
+    const allNodes = this.selectNodes(config.nodeXPath)
+
+    // 2. Handle DELETE
+    if (action === 'delete') {
+      const targetNode = allNodes.find((node) => (node.textContent || '').toLowerCase().trim() === oldVal)
+      if (targetNode) {
+        targetNode.parentNode.removeChild(targetNode)
+
+        return true
+      }
+
+      return false
+    }
+
+    // 3. Handle REPLACE
+    if (action === 'replace') {
+      const matchingNode = allNodes.find((node) => (node.textContent || '').toLowerCase().trim() === oldVal)
+
+      if (matchingNode) {
+        // We iterate through the replace config array using the correction object
+        config.replace.forEach((replConfig) => {
+          // The source.getValue function uses the 'correction' object (which contains newKeywordObject)
+          const newValue = replConfig.source.getValue({ correction })
+
+          if (replConfig.fieldPath.includes('@')) {
+            const [elementName, attrName] = replConfig.fieldPath.split('/@')
+            const targetElement = this.selectNodes(`./${elementName}`, matchingNode)[0]
+            if (targetElement) {
+              targetElement.setAttribute(attrName, newValue)
+            }
+          } else {
+            const fieldNode = this.selectNodes(`./${replConfig.fieldPath}`, matchingNode)[0]
+            if (fieldNode) {
+              this.setElementText(fieldNode, newValue)
+            }
+          }
+        })
+
+        return true
+      }
+    }
+
+    return false
   }
 
   updateBlockNode(correction, config) {
@@ -99,8 +148,6 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
         })
       })
 
-      // In Iso19115MetadataPathEditor.js
-
       if (matchingNode) {
         // Since matchingNode is already the <gmd:keyword> element,
         // we look for the child <gco:CharacterString> directly.
@@ -116,26 +163,6 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
       }
 
       return false // Match not found or fieldNode missing
-    }
-
-    return false
-  }
-
-  /**
-   * Override updateLeafNode to handle gco:CharacterString wrapping.
-   * ISO 19115 frequently stores text values inside <gco:CharacterString> nodes.
-   */
-  updateLeafNode(correction, config) {
-    const targetNode = this.selectNodes(config.nodeXPath)[0] || null
-    if (!targetNode) return false
-
-    // Target the specific gco:CharacterString child
-    const charString = targetNode.getElementsByTagNameNS(this.namespaces.gco, 'CharacterString')[0]
-    if (charString) {
-      const value = getScalarKeywordText(correction?.newKeywordObject)
-      this.setElementText(charString, value)
-
-      return true
     }
 
     return false

--- a/serverless/src/shared/Iso19115MetadataPathEditor.js
+++ b/serverless/src/shared/Iso19115MetadataPathEditor.js
@@ -158,31 +158,52 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
 
   /**
    * Updates complex keyword block nodes.
-   * Handles deletion of nested keywords and recursive cleanup of empty parents.
+   * Handles deletion and replacement of keywords, including synchronized
+   * updates across global paths (like CI_ResponsibleParty).
    * @param {Object} correction - The change data.
    * @param {Object} config - Configuration for the block node.
    * @returns {boolean} True if the operation was successful.
    */
   updateBlockNode(correction, config) {
-    const targetNode = this.selectNodes(config.nodeXPath)[0] || null
-    if (!targetNode) return false
+    const targetNodes = this.selectNodes(config.nodeXPath)
+    if (!targetNodes || targetNodes.length === 0) return false
 
-    // 2. Handle the 'delete' action
+    // Identify the first block that contains the matching node
+    const matchingData = targetNodes
+      .map((node) => ({
+        node,
+        matchingNode: this.findMatchingNode(node, correction, config)
+      }))
+      .find((data) => data.matchingNode !== null)
+
+    // Return early if no match is found, preventing downstream errors
+    if (!matchingData) return false
+
+    const { matchingNode } = matchingData
+
+    // 2. Handle 'delete' action
     if (correction.action === 'delete') {
-      const matchingNode = this.findMatchingNode(targetNode, correction, config)
-      if (!matchingNode) return false
+      const parentBlock = matchingNode.parentNode
 
-      // Remove target node
+      // Clean up synchronized paths globally first
+      if (config.replace) {
+        config.replace
+          .filter((replConfig) => typeof replConfig.fieldPath === 'string' && replConfig.fieldPath.startsWith('//'))
+          .forEach((replConfig) => {
+            this.selectNodes(replConfig.fieldPath, this.document)
+              .forEach((node) => node?.parentNode?.removeChild(node))
+          })
+      }
+
+      // Remove the target keyword
       matchingNode.parentNode.removeChild(matchingNode)
 
-      // Cleanup: Remove parent blocks if they are now empty
-      const remainingKeywords = this.selectNodes('./gmd:keyword', targetNode)
-      if (remainingKeywords.length === 0) {
-        const mdKeywordsParent = targetNode.parentNode
-        mdKeywordsParent.removeChild(targetNode)
+      // Cleanup parent blocks if empty
+      if (this.selectNodes('./gmd:keyword', parentBlock).length === 0) {
+        const mdKeywordsParent = parentBlock.parentNode
+        mdKeywordsParent.removeChild(parentBlock)
 
-        const remainingBlocks = this.selectNodes('./gmd:MD_Keywords', mdKeywordsParent)
-        if (remainingBlocks.length === 0) {
+        if (this.selectNodes('./gmd:MD_Keywords', mdKeywordsParent).length === 0) {
           mdKeywordsParent.parentNode.removeChild(mdKeywordsParent)
         }
       }
@@ -190,15 +211,11 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
       return true
     }
 
-    // 3. Handle the 'replace' action
+    // 3. Handle 'replace' action
     if (correction.action === 'replace') {
-      const replaceConfig = config.replace[0]
-      const matchingNode = this.findMatchingNode(targetNode, correction, config)
-
-      if (matchingNode) {
+      const results = config.replace.map((replaceConfig) => {
         let fieldNode = null
 
-        // Determine dynamic path or default
         if (replaceConfig.fieldPath) {
           const path = typeof replaceConfig.fieldPath === 'function'
             ? replaceConfig.fieldPath({
@@ -207,28 +224,28 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
             })
             : replaceConfig.fieldPath
 
-          const relativePath = path.startsWith('./') ? path : `./${path}`;
-          [fieldNode] = this.selectNodes(relativePath, matchingNode)
+          const context = path.startsWith('//') ? this.document : matchingNode
+          const relativePath = path.startsWith('//') ? path : `./${path}`;
+          [fieldNode] = this.selectNodes(relativePath, context)
         }
 
-        // Fallback search for standard string elements
         if (!fieldNode) {
           [fieldNode] = this.selectNodes('./gco:CharacterString', matchingNode)
-                    || this.selectNodes('gco:CharacterString', matchingNode)
         }
 
-        // Apply text update
         if (fieldNode) {
-          const newValue = replaceConfig.source.getValue({ correction })
-          this.setElementText(fieldNode, newValue)
+          this.setElementText(fieldNode, replaceConfig.source.getValue({ correction }))
 
           return true
         }
-      }
 
-      return false
+        return false
+      })
+
+      return results.some((success) => success === true)
     }
 
+    // If action is neither 'delete' nor 'replace'
     return false
   }
 }

--- a/serverless/src/shared/Iso19115MetadataPathEditor.js
+++ b/serverless/src/shared/Iso19115MetadataPathEditor.js
@@ -29,20 +29,42 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
   }
 
   /**
-   * Updates leaf (direct) nodes like isotopiccategory.
+   * Updates leaf (direct) nodes like isotopiccategory and productlevelid.
    */
   updateLeafNode(correction, config) {
     const { action, oldKeywordObject } = correction
     const oldVal = (oldKeywordObject.Value || '').toLowerCase().trim()
-
-    // 1. Get all relevant nodes
     const allNodes = this.selectNodes(config.nodeXPath)
 
-    // 2. Handle DELETE
     if (action === 'delete') {
-      const targetNode = allNodes.find((node) => (node.textContent || '').toLowerCase().trim() === oldVal)
+      // 1. Find the primary node to confirm the object exists
+      const targetNode = allNodes.find((node) => {
+        const valueObj = config.find.getNodeValueObject({
+          node,
+          editor: this
+        })
+
+        const foundVal = (valueObj.Value || '').toLowerCase().trim()
+        const match = foundVal === oldVal
+
+        return match
+      })
+
       if (targetNode) {
-        targetNode.parentNode.removeChild(targetNode)
+        // 2. Strategy: If explicit delete paths are provided, use them (e.g., productlevelid)
+        if (config.delete && config.delete.length > 0) {
+          config.delete.forEach((delConfig) => {
+            const nodesToDelete = this.selectNodes(delConfig.path, this.document)
+            nodesToDelete.forEach((node) => {
+              if (node && node.parentNode) {
+                node.parentNode.removeChild(node)
+              }
+            })
+          })
+        } else if (targetNode.parentNode) {
+          // Use 'else if' to flatten the structure and satisfy the linter
+          targetNode.parentNode.removeChild(targetNode)
+        }
 
         return true
       }
@@ -50,27 +72,31 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
       return false
     }
 
-    // 3. Handle REPLACE
     if (action === 'replace') {
-      const matchingNode = allNodes.find((node) => (node.textContent || '').toLowerCase().trim() === oldVal)
+      const matchingNode = allNodes.find((node) => {
+        const valueObj = config.find.getNodeValueObject({
+          node,
+          editor: this
+        })
+
+        return (valueObj.Value || '').toLowerCase().trim() === oldVal
+      })
 
       if (matchingNode) {
-        // We iterate through the replace config array using the correction object
         config.replace.forEach((replConfig) => {
-          // The source.getValue function uses the 'correction' object (which contains newKeywordObject)
           const newValue = replConfig.source.getValue({ correction })
+          const isGlobal = replConfig.fieldPath.startsWith('//')
+          const context = isGlobal ? this.document : matchingNode
 
+          // If updating an attribute (contains @)
           if (replConfig.fieldPath.includes('@')) {
-            const [elementName, attrName] = replConfig.fieldPath.split('/@')
-            const targetElement = this.selectNodes(`./${elementName}`, matchingNode)[0]
-            if (targetElement) {
-              targetElement.setAttribute(attrName, newValue)
-            }
+            const [path, attr] = replConfig.fieldPath.split('/@')
+            const targetElement = this.selectNodes(isGlobal ? path : `./${path}`, context)[0]
+            if (targetElement) targetElement.setAttribute(attr, newValue)
           } else {
-            const fieldNode = this.selectNodes(`./${replConfig.fieldPath}`, matchingNode)[0]
-            if (fieldNode) {
-              this.setElementText(fieldNode, newValue)
-            }
+            // Standard text content update
+            const targetNode = this.selectNodes(isGlobal ? replConfig.fieldPath : `./${replConfig.fieldPath}`, context)[0]
+            if (targetNode) this.setElementText(targetNode, newValue)
           }
         })
 

--- a/serverless/src/shared/Iso19115MetadataPathEditor.js
+++ b/serverless/src/shared/Iso19115MetadataPathEditor.js
@@ -133,7 +133,6 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
 
       if (matchingNode) {
         config.replace.forEach((replConfig) => {
-          const newValue = replConfig.source.getValue({ correction })
           const isGlobal = replConfig.fieldPath.startsWith('//')
           const context = isGlobal ? this.document : matchingNode
 
@@ -141,11 +140,25 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
           if (replConfig.fieldPath.includes('@')) {
             const [path, attr] = replConfig.fieldPath.split('/@')
             const targetElement = this.selectNodes(isGlobal ? path : `./${path}`, context)[0]
-            if (targetElement) targetElement.setAttribute(attr, newValue)
+            if (targetElement) {
+              const newValue = replConfig.source.getValue({
+                correction,
+                node: targetElement,
+                editor: this
+              })
+              targetElement.setAttribute(attr, newValue)
+            }
           } else {
             // Standard text content update
             const targetNode = this.selectNodes(isGlobal ? replConfig.fieldPath : `./${replConfig.fieldPath}`, context)[0]
-            if (targetNode) this.setElementText(targetNode, newValue)
+            if (targetNode) {
+              const newValue = replConfig.source.getValue({
+                correction,
+                node: targetNode,
+                editor: this
+              })
+              this.setElementText(targetNode, newValue)
+            }
           }
         })
 
@@ -188,7 +201,56 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
       // Initialize keywordValue here so it is available in the scope
       const keywordValue = matchingNode.textContent.trim()
 
+      // Get the ShortName for matching acquisition information entries
+      const oldShortName = correction.oldKeywordObject?.ShortName
+
+      // Only platforms and instruments have acquisition information sections
+      const isPlatformOrInstrument = correction.scheme === 'platforms' || correction.scheme === 'instruments'
+
+      // For platforms/instruments, delete from acquisition section too
+      if (isPlatformOrInstrument && oldShortName && config.replace) {
+        // Find all MD_Identifier nodes that match this platform/instrument
+        const allIdentifiers = this.selectNodes('//gmd:MD_Identifier', this.document)
+        const identifiersToDelete = allIdentifiers.filter((identifier) => {
+          const codeNodes = this.selectNodes('.//gmd:code/gco:CharacterString', identifier)
+          if (codeNodes.length > 0) {
+            const codeValue = codeNodes[0].textContent?.trim() || ''
+
+            return codeValue === oldShortName || codeValue.startsWith(`${oldShortName} > `)
+          }
+
+          return false
+        })
+
+        // Delete the parent platform/instrument nodes from acquisition section
+        identifiersToDelete.forEach((identifier) => {
+          // Navigate up DOM tree to find the acquisition platform/instrument wrapper node
+          let currentNode = identifier.parentNode
+          while (currentNode) {
+            const { localName } = currentNode
+            // Check if we found a platform or instrument node
+            if (localName === 'EOS_Platform' || localName === 'MI_Platform'
+                || localName === 'EOS_Instrument' || localName === 'MI_Instrument') {
+              // Found the acquisition wrapper node, remove it entirely
+              if (currentNode.parentNode) {
+                currentNode.parentNode.removeChild(currentNode)
+              }
+
+              break
+            }
+
+            // Move up the tree
+            currentNode = currentNode.parentNode
+            // Stop if we reach the document root
+            if (currentNode === this.document.documentElement) {
+              break
+            }
+          }
+        })
+      }
+
       // Clean up synchronized paths globally, but with a value constraint
+      // This handles providers and other non-acquisition paths
       if (config.replace) {
         config.replace
           .filter((replConfig) => typeof replConfig.fieldPath === 'string' && replConfig.fieldPath.startsWith('//'))
@@ -224,12 +286,33 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
 
     // 3. Handle 'replace' action
     if (correction.action === 'replace') {
+      // Pre-scan: Build a map of identifiers that should be updated
+      // This prevents issues when processing multiple paths in sequence
+      const oldShortName = correction.oldKeywordObject?.ShortName
+      let identifiersToUpdate = []
+
+      if (oldShortName) {
+        // Find all MD_Identifier nodes that have code matching oldShortName
+        const allIdentifiers = this.selectNodes('//gmd:MD_Identifier', this.document)
+        identifiersToUpdate = allIdentifiers.filter((identifier) => {
+          const codeNodes = this.selectNodes('.//gmd:code/gco:CharacterString', identifier)
+          if (codeNodes.length > 0) {
+            const codeValue = codeNodes[0].textContent?.trim() || ''
+
+            return codeValue === oldShortName || codeValue.startsWith(`${oldShortName} > `)
+          }
+
+          return false
+        })
+      }
+
       const results = config.replace.map((replaceConfig) => {
         let fieldNodes = []
+        let path = null
 
         // 1. Attempt to find nodes via the provided path
         if (replaceConfig.fieldPath) {
-          const path = typeof replaceConfig.fieldPath === 'function'
+          path = typeof replaceConfig.fieldPath === 'function'
             ? replaceConfig.fieldPath({
               node: matchingNode,
               editor: this
@@ -243,18 +326,42 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
         }
 
         // 2. Fallback: If no nodes were found via path,
-        // ALWAYS check for the default text node (remove the !replaceConfig.fieldPath check)
-        if (fieldNodes.length === 0) {
+        // ONLY check for the default text node if the path is relative (not global)
+        // Global paths (starting with //) should not fall back to keyword block updates
+        if (fieldNodes.length === 0 && (!path || !path.startsWith('//'))) {
           fieldNodes = this.selectNodes('./gco:CharacterString', matchingNode)
         }
 
         // 3. Update every node found
         if (fieldNodes.length > 0) {
+          // For global paths (starting with //), filter to only update matching nodes
+          // This prevents updating all platforms when we only want to update one
+          if (path && path.startsWith('//') && identifiersToUpdate.length > 0) {
+            // Filter nodes: only include nodes within the pre-scanned identifiers
+            fieldNodes = fieldNodes.filter((node) => {
+              // Navigate up to find the MD_Identifier parent
+              let identifier = node.parentNode
+              while (identifier && identifier.localName !== 'MD_Identifier') {
+                identifier = identifier.parentNode
+                if (!identifier || identifier === this.document.documentElement) {
+                  return false
+                }
+              }
+
+              // Check if this identifier is in our list to update
+              return identifiersToUpdate.includes(identifier)
+            })
+          }
+
           fieldNodes.forEach((node) => {
-            this.setElementText(node, replaceConfig.source.getValue({ correction }))
+            this.setElementText(node, replaceConfig.source.getValue({
+              correction,
+              node,
+              editor: this
+            }))
           })
 
-          return true
+          return fieldNodes.length > 0
         }
 
         return false

--- a/serverless/src/shared/Iso19115MetadataPathEditor.js
+++ b/serverless/src/shared/Iso19115MetadataPathEditor.js
@@ -210,13 +210,43 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
       // For platforms/instruments, delete from acquisition section too
       if (isPlatformOrInstrument && oldShortName && config.replace) {
         // Find all MD_Identifier nodes that match this platform/instrument
+        // AND have the correct codeSpace to identify them as acquisition info
         const allIdentifiers = this.selectNodes('//gmd:MD_Identifier', this.document)
         const identifiersToDelete = allIdentifiers.filter((identifier) => {
           const codeNodes = this.selectNodes('.//gmd:code/gco:CharacterString', identifier)
-          if (codeNodes.length > 0) {
-            const codeValue = codeNodes[0].textContent?.trim() || ''
+          if (codeNodes.length === 0) {
+            return false
+          }
 
-            return codeValue === oldShortName || codeValue.startsWith(`${oldShortName} > `)
+          const codeValue = codeNodes[0].textContent?.trim() || ''
+          const codeMatches = codeValue === oldShortName || codeValue.startsWith(`${oldShortName} > `)
+
+          if (!codeMatches) {
+            return false
+          }
+
+          // Check codeSpace to ensure this is an acquisition identifier
+          const codeSpaceNodes = this.selectNodes('.//gmd:codeSpace/gco:CharacterString', identifier)
+          if (codeSpaceNodes.length > 0) {
+            const codeSpaceValue = codeSpaceNodes[0].textContent?.trim() || ''
+
+            // Match acquisition-specific codeSpace values based on scheme
+            const isAcquisitionIdentifier = correction.scheme === 'platforms'
+              ? codeSpaceValue === 'gov.nasa.esdis.umm.platformshortname'
+              : codeSpaceValue === 'gov.nasa.esdis.umm.instrumentshortname'
+
+            return isAcquisitionIdentifier
+          }
+
+          // If no codeSpace, check if identifier is within acquisitionInformation context
+          let current = identifier.parentNode
+          while (current && current !== this.document.documentElement) {
+            if (current.localName === 'acquisitionInformation'
+          || current.localName === 'MI_AcquisitionInformation') {
+              return true
+            }
+
+            current = current.parentNode
           }
 
           return false
@@ -230,7 +260,7 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
             const { localName } = currentNode
             // Check if we found a platform or instrument node
             if (localName === 'EOS_Platform' || localName === 'MI_Platform'
-                || localName === 'EOS_Instrument' || localName === 'MI_Instrument') {
+          || localName === 'EOS_Instrument' || localName === 'MI_Instrument') {
               // Found the acquisition wrapper node, remove it entirely
               if (currentNode.parentNode) {
                 currentNode.parentNode.removeChild(currentNode)

--- a/serverless/src/shared/Iso19115MetadataPathEditor.js
+++ b/serverless/src/shared/Iso19115MetadataPathEditor.js
@@ -187,7 +187,7 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
         node,
         matchingNode: this.findMatchingNode(node, correction, config)
       }))
-      .find((data) => data.matchingNode !== null)
+      .find((data) => data.matchingNode !== null && data.matchingNode !== undefined)
 
     // Return early if no match is found, preventing downstream errors
     if (!matchingData) return false
@@ -275,6 +275,43 @@ export class Iso19115MetadataPathEditor extends XmlMetadataPathEditor {
             if (currentNode === this.document.documentElement) {
               break
             }
+          }
+        })
+      }
+
+      if (correction.scheme === 'projects' && oldShortName) {
+        // Find all project identifiers in acquisitionInformation
+        const allIdentifiers = this.selectNodes('//gmi:operation//gmd:MD_Identifier', this.document)
+
+        const identifiersToDelete = allIdentifiers.filter((identifier) => {
+          // Check for the specific codeSpace used in your config
+          const codeSpaceNodes = this.selectNodes('.//gmd:codeSpace/gco:CharacterString', identifier)
+          const codeSpace = codeSpaceNodes[0]?.textContent?.trim()
+
+          if (codeSpace !== 'gov.nasa.esdis.umm.projectshortname') return false
+
+          // Verify it matches the project we are deleting
+          const codeNodes = this.selectNodes('.//gmd:code/gco:CharacterString', identifier)
+          const codeValue = codeNodes[0]?.textContent?.trim() || ''
+
+          // Check for exact match or the combined 'ShortName > LongName' format
+          return codeValue === oldShortName || codeValue.startsWith(`${oldShortName} > `)
+        })
+
+        // Remove the parent MI_Operation node
+        identifiersToDelete.forEach((identifier) => {
+          let currentNode = identifier.parentNode
+          while (currentNode) {
+            if (currentNode.localName === 'MI_Operation') {
+              if (currentNode.parentNode) {
+                currentNode.parentNode.removeChild(currentNode)
+              }
+
+              break
+            }
+
+            currentNode = currentNode.parentNode
+            if (currentNode === this.document.documentElement) break
           }
         })
       }

--- a/serverless/src/shared/XmlMetadataPathEditor.js
+++ b/serverless/src/shared/XmlMetadataPathEditor.js
@@ -1,38 +1,15 @@
 import { DOMParser, XMLSerializer } from '@xmldom/xmldom'
 import xpath from 'xpath'
 
+import {
+  getScalarKeywordText,
+  isSimpleFieldPath,
+  normalizeValueObject,
+  trimString
+} from './XmlUtils'
+
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8"?>'
 const ELEMENT_NODE = 1
-const SIMPLE_ABSOLUTE_FIELD_PATH = /^\/\/[A-Za-z_][\w.-]*(\/[A-Za-z_][\w.-]*)*$/
-
-/**
- * Normalize optional text inputs so object comparisons and XML writes behave consistently.
- *
- * @example
- * trimString('  SPOT-4  ')
- * // 'SPOT-4'
- */
-const trimString = (value) => ((typeof value === 'string') ? value.trim() : '')
-
-/**
- * Trims a keyword-style object down to the specific keys being compared so find/replace matching
- * stays consistent even when callers provide extra fields or untrimmed values.
- *
- * @param {Record<string, any>|null|undefined} valueObject Candidate keyword-style object.
- * @param {string[]} valueKeys Ordered keys that matter for the current comparison.
- * @returns {Record<string, string>} Trimmed object containing only the requested keys.
- *
- * @example
- * normalizeValueObject({ Type: ' GET DATA ', Subtype: ' GIOVANNI ' }, ['Type', 'Subtype'])
- * // { Type: 'GET DATA', Subtype: 'GIOVANNI' }
- */
-const normalizeValueObject = (valueObject, valueKeys) => valueKeys.reduce(
-  (normalizedObject, valueKey) => ({
-    ...normalizedObject,
-    [valueKey]: trimString(valueObject?.[valueKey])
-  }),
-  {}
-)
 
 /**
  * Normalizes text for case-insensitive XML node matching while preserving write-time casing.
@@ -56,27 +33,6 @@ const normalizeComparableText = (value) => trimString(value).toLowerCase()
  */
 export const hasAnyObjectValue = (keywordObject) => Object.values(keywordObject || {})
   .some((value) => trimString(value).length > 0)
-
-/**
- * Resolves the most useful scalar representation of a keyword object for leaf/scalar updates.
- *
- * @example
- * getScalarKeywordText({ Value: 'OCEANS', ShortName: 'ignored' })
- * // 'OCEANS'
- */
-const getScalarKeywordText = (keywordObject = {}) => {
-  const preferredValue = [keywordObject.Value, keywordObject.ShortName]
-    .map((value) => trimString(value))
-    .find((value) => value.length > 0)
-
-  if (preferredValue) {
-    return preferredValue
-  }
-
-  return Object.values(keywordObject)
-    .map((value) => trimString(value))
-    .find((value) => value.length > 0) || ''
-}
 
 /**
  * Rewrites simple element XPath into a namespace-agnostic `local-name()` form.
@@ -296,7 +252,7 @@ export class XmlMetadataPathEditor {
    */
   resolveAbsoluteFieldElement(fieldPath, { createIfMissing = false } = {}) {
     const matchedNode = this.selectNodes(fieldPath)[0] || null
-    if (matchedNode || !createIfMissing || !SIMPLE_ABSOLUTE_FIELD_PATH.test(fieldPath)) {
+    if (matchedNode || !createIfMissing || !isSimpleFieldPath(fieldPath)) {
       return matchedNode
     }
 

--- a/serverless/src/shared/XmlUtils.js
+++ b/serverless/src/shared/XmlUtils.js
@@ -1,0 +1,79 @@
+/**
+ * Normalize optional text inputs so object comparisons and XML writes behave consistently.
+ */
+export const trimString = (value) => ((typeof value === 'string') ? value.trim() : '')
+
+/**
+ * Regex for validating if a string is a simple absolute XML field path (e.g., //Path/To/Node).
+ */
+export const SIMPLE_ABSOLUTE_FIELD_PATH = /^\/\/[A-Za-z_][\w.-]*(\/[A-Za-z_][\w.-]*)*$/
+
+/**
+ * Validates if the provided string is a valid simple absolute XML field path.
+ * * @param {string} path - The path string to validate.
+ * @returns {boolean} True if the path matches the expected pattern.
+ */
+export const isSimpleFieldPath = (path) => SIMPLE_ABSOLUTE_FIELD_PATH.test(path)
+
+/**
+ * Resolves the most useful scalar representation of a keyword object for leaf/scalar updates.
+ * This is now the single source of truth for both ISO 19115 and generic XML editors.
+ *
+ * @example
+ * getScalarKeywordText({ Value: 'OCEANS', ShortName: 'ignored' })
+ * // 'OCEANS'
+ */
+export const getScalarKeywordText = (keywordObject = {}) => {
+  // 1. Define preference list (Value, then ShortName)
+  const preferredValue = [keywordObject.Value, keywordObject.ShortName]
+    .map((value) => trimString(value))
+    .find((value) => value.length > 0)
+
+  // 2. Return if found
+  if (preferredValue) {
+    return preferredValue
+  }
+
+  // 3. Fallback: return the first non-empty value in the object
+  return Object.values(keywordObject)
+    .map((value) => trimString(value))
+    .find((value) => value.length > 0) || ''
+}
+
+/**
+ * Trims a keyword-style object down to the specific keys being compared so find/replace matching
+ * stays consistent even when callers provide extra fields or untrimmed values.
+ *
+ * @param {Record<string, any>|null|undefined} valueObject Candidate keyword-style object.
+ * @param {string[]} valueKeys Ordered keys that matter for the current comparison.
+ * @returns {Record<string, string>} Trimmed object containing only the requested keys.
+ *
+ * @example
+ * normalizeValueObject({ Type: ' GET DATA ', Subtype: ' GIOVANNI ' }, ['Type', 'Subtype'])
+ * // { Type: 'GET DATA', Subtype: 'GIOVANNI' }
+ */
+export const normalizeValueObject = (valueObject, valueKeys) => valueKeys.reduce(
+  (normalizedObject, valueKey) => ({
+    ...normalizedObject,
+    [valueKey]: trimString(valueObject?.[valueKey])
+  }),
+  {}
+)
+
+/**
+ * Extracts namespace declarations (xmlns:prefix) from a given XML root element.
+ * * @param {Element} rootElement - The DOM root element.
+ * @returns {Object} A map where keys are prefixes and values are namespace URIs.
+ */
+export const extractNamespaces = (rootElement) => {
+  const namespaces = {}
+  for (let i = 0; i < rootElement.attributes.length; i += 1) {
+    const attr = rootElement.attributes[i]
+    if (attr.name.startsWith('xmlns:')) {
+      const prefix = attr.name.replace('xmlns:', '')
+      namespaces[prefix] = attr.value
+    }
+  }
+
+  return namespaces
+}

--- a/serverless/src/shared/__tests__/Iso19115DomEditor.test.js
+++ b/serverless/src/shared/__tests__/Iso19115DomEditor.test.js
@@ -1,0 +1,84 @@
+import {
+  describe,
+  expect,
+  test,
+  vi
+} from 'vitest'
+
+import { ISO_19115_SCHEME_EDITORS } from '@/shared/Iso19115DomEditor'
+
+describe('ISO_19115_SCHEME_EDITORS', () => {
+  let mockEditor
+
+  beforeEach(() => {
+    mockEditor = {
+      updateBlockNode: vi.fn(),
+      updateLeafNode: vi.fn()
+    }
+  })
+
+  test('should trigger updateBlockNode for keyword types', () => {
+    const correction = {
+      action: 'replace',
+      oldKeywordObject: { Value: 'test' }
+    }
+
+    // Test a block-based editor (e.g., sciencekeywords)
+    ISO_19115_SCHEME_EDITORS.sciencekeywords(mockEditor, correction)
+
+    expect(mockEditor.updateBlockNode).toHaveBeenCalledWith(
+      correction,
+      expect.objectContaining({
+        nodeXPath: expect.stringContaining('MD_KeywordTypeCode')
+      })
+    )
+  })
+
+  test('should trigger updateLeafNode for leaf types', () => {
+    const correction = {
+      action: 'replace',
+      newKeywordObject: { Value: 'category' }
+    }
+
+    // Test a leaf-based editor (e.g., isotopiccategory)
+    ISO_19115_SCHEME_EDITORS.isotopiccategory(mockEditor, correction)
+
+    expect(mockEditor.updateLeafNode).toHaveBeenCalledWith(
+      correction,
+      expect.objectContaining({
+        nodeXPath: expect.stringContaining('topicCategory')
+      })
+    )
+  })
+
+  test('should correctly format value for platforms', () => {
+    const correction = {
+      newKeywordObject: { ShortName: 'Aqua' },
+      newLongName: 'Aqua Satellite'
+    }
+    const formatPlatform = () => {
+      const { ShortName } = correction.newKeywordObject
+      const LongName = correction.newLongName || ''
+
+      return LongName ? `${ShortName} > ${LongName}` : ShortName
+    }
+
+    expect(formatPlatform(correction)).toBe('Aqua > Aqua Satellite')
+  })
+
+  test('should handle deletion for productlevelid', () => {
+    const correction = {
+      action: 'delete',
+      oldKeywordObject: { Value: 'L1' }
+    }
+
+    ISO_19115_SCHEME_EDITORS.productlevelid(mockEditor, correction)
+
+    expect(mockEditor.updateLeafNode).toHaveBeenCalledWith(
+      correction,
+      expect.objectContaining({
+        delete: expect.any(Array)
+      })
+    )
+  })
+})

--- a/serverless/src/shared/__tests__/Iso19115MetadataPathEditor.test.js
+++ b/serverless/src/shared/__tests__/Iso19115MetadataPathEditor.test.js
@@ -398,4 +398,49 @@ describe('Iso19115MetadataPathEditor', () => {
 
     expect(result).toBe(false)
   })
+
+  test('updateBlockNode should update ALL matching nodes when multiple are found', () => {
+    const xml = `
+    <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>Original Value</gco:CharacterString>
+            <gco:CharacterString>Original Value</gco:CharacterString>
+          </gmd:keyword>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_Metadata>`
+
+    const testEditor = new Iso19115MetadataPathEditor(xml)
+
+    const config = {
+      nodeXPath: '//gmd:descriptiveKeywords/gmd:MD_Keywords',
+      find: {
+        getNodeValueObject: () => ({ Value: 'Original Value' }),
+        matchKeys: ['Value']
+      },
+      replace: [{
+        fieldPath: 'gco:CharacterString',
+        source: { getValue: () => 'New Value' }
+      }]
+    }
+
+    const correction = {
+      action: 'replace',
+      oldKeywordObject: { Value: 'Original Value' },
+      newKeywordObject: { Value: 'New Value' }
+    }
+
+    const result = testEditor.updateBlockNode(correction, config)
+
+    expect(result).toBe(true)
+
+    // Verify that ALL CharacterString nodes were updated
+    const updatedNodes = testEditor.selectNodes('//gco:CharacterString', testEditor.document)
+    expect(updatedNodes.length).toBe(2)
+    updatedNodes.forEach((node) => {
+      expect(node.textContent).toBe('New Value')
+    })
+  })
 })

--- a/serverless/src/shared/__tests__/Iso19115MetadataPathEditor.test.js
+++ b/serverless/src/shared/__tests__/Iso19115MetadataPathEditor.test.js
@@ -1,0 +1,357 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  test
+} from 'vitest'
+
+import Iso19115MetadataPathEditor from '@/shared/Iso19115MetadataPathEditor'
+
+describe('Iso19115MetadataPathEditor', () => {
+  let editor
+  const xmlString = `
+    <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
+      <gmd:identificationInfo>
+        <gmd:MD_DataIdentification>
+          <gmd:topicCategory>
+            <gmd:MD_TopicCategoryCode codeListValue="farming">farming</gmd:MD_TopicCategoryCode>
+          </gmd:topicCategory>
+        </gmd:MD_DataIdentification>
+      </gmd:identificationInfo>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword><gco:CharacterString>Old Keyword</gco:CharacterString></gmd:keyword>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_Metadata>`
+
+  beforeEach(() => {
+    editor = new Iso19115MetadataPathEditor(xmlString)
+  })
+
+  test('should initialize namespaces correctly', () => {
+    expect(editor.namespaces).toHaveProperty('gmd')
+    expect(editor.namespaces.gmd).toBe('http://www.isotc211.org/2005/gmd')
+  })
+
+  test('selectNodes should filter by ELEMENT_NODE', () => {
+    const nodes = editor.selectNodes('//gmd:topicCategory')
+    expect(nodes.length).toBe(1)
+    expect(nodes[0].nodeType).toBe(1)
+  })
+
+  test('updateLeafNode should delete a simple leaf node', () => {
+    const config = {
+      nodeXPath: '//gmd:topicCategory',
+      find: { getNodeValueObject: () => ({ Value: 'farming' }) }
+    }
+    const correction = {
+      action: 'delete',
+      oldKeywordObject: { Value: 'farming' }
+    }
+
+    const result = editor.updateLeafNode(correction, config)
+
+    expect(result).toBe(true)
+    const nodes = editor.selectNodes('//gmd:topicCategory')
+    expect(nodes.length).toBe(0)
+  })
+
+  test('updateLeafNode should execute explicit delete paths when provided', () => {
+  // 1. Ensure the XML contains the node being searched for
+    const xml = `
+    <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd">
+      <gmd:processingLevel>
+        <gmd:MD_Identifier>
+          <gmd:code><gco:CharacterString>L1</gco:CharacterString></gmd:code>
+        </gmd:MD_Identifier>
+      </gmd:processingLevel>
+    </gmd:MD_Metadata>`
+
+    // Create a new editor instance with this specific XML
+    const testEditor = new Iso19115MetadataPathEditor(xml)
+
+    const config = {
+      nodeXPath: '//gmd:processingLevel/gmd:MD_Identifier',
+      find: { getNodeValueObject: (ctx) => ({ Value: ctx.node.textContent }) },
+      delete: [
+        { path: '//gmd:processingLevel/gmd:MD_Identifier' }
+      ]
+    }
+    const correction = {
+      action: 'delete',
+      oldKeywordObject: { Value: 'l1' }
+    }
+
+    // This will now find the targetNode and proceed to execute the delete block
+    const result = testEditor.updateLeafNode(correction, config)
+
+    expect(result).toBe(true)
+  })
+
+  test('updateLeafNode should update element attribute when fieldPath includes @', () => {
+    const xml = `
+    <gmd:topicCategory xmlns:gmd="http://www.isotc211.org/2005/gmd">
+      <gmd:MD_TopicCategoryCode codeListValue="oldValue">oldValue</gmd:MD_TopicCategoryCode>
+    </gmd:topicCategory>`
+
+    const testEditor = new Iso19115MetadataPathEditor(xml)
+
+    const config = {
+      nodeXPath: '//gmd:topicCategory',
+      find: { getNodeValueObject: () => ({ Value: 'oldValue' }) },
+      replace: [{
+      // Path targets the attribute on the child element
+        fieldPath: 'gmd:MD_TopicCategoryCode/@codeListValue',
+        source: { getValue: () => 'newValue' }
+      }]
+    }
+
+    const correction = {
+      action: 'replace',
+      oldKeywordObject: { Value: 'oldValue' }
+    }
+
+    const result = testEditor.updateLeafNode(correction, config)
+
+    expect(result).toBe(true)
+
+    // Verify the attribute was updated in the DOM
+    const element = testEditor.selectNodes('//gmd:MD_TopicCategoryCode')[0]
+    expect(element.getAttribute('codeListValue')).toBe('newValue')
+  })
+
+  test('updateLeafNode should return false if node to delete is not found', () => {
+    const config = {
+      nodeXPath: '//gmd:topicCategory',
+      find: { getNodeValueObject: () => ({ Value: 'missing' }) }
+    }
+    const correction = {
+      action: 'delete',
+      oldKeywordObject: { Value: 'non-existent' }
+    }
+
+    const result = editor.updateLeafNode(correction, config)
+    expect(result).toBe(false)
+  })
+
+  test('updateLeafNode should replace text content', () => {
+    const config = {
+      nodeXPath: '//gmd:topicCategory',
+      find: { getNodeValueObject: () => ({ Value: 'farming' }) },
+      replace: [{
+        fieldPath: 'gmd:MD_TopicCategoryCode',
+        source: { getValue: () => 'updated-value' }
+      }]
+    }
+    const correction = {
+      action: 'replace',
+      oldKeywordObject: { Value: 'farming' }
+    }
+
+    const result = editor.updateLeafNode(correction, config)
+    expect(result).toBe(true)
+    // Verification would depend on the implementation of setElementText
+  })
+
+  test('updateBlockNode should find and update keyword nodes', () => {
+    const config = {
+      nodeXPath: '//gmd:descriptiveKeywords/gmd:MD_Keywords',
+      find: {
+        getNodeValueObject: () => ({ Value: 'Old Keyword' }),
+        matchKeys: ['Value']
+      },
+      replace: [{
+        fieldPath: 'gco:CharacterString',
+        source: { getValue: () => 'New Keyword' }
+      }]
+    }
+    const correction = {
+      action: 'replace',
+      oldKeywordObject: { Value: 'Old Keyword' },
+      newKeywordObject: { Value: 'New Keyword' }
+    }
+
+    const result = editor.updateBlockNode(correction, config)
+    expect(result).toBe(true)
+  })
+
+  test('updateBlockNode should delete empty parents after removing last keyword', () => {
+    const config = {
+      nodeXPath: '//gmd:descriptiveKeywords/gmd:MD_Keywords',
+      find: {
+        getNodeValueObject: () => ({ Value: 'Old Keyword' }),
+        matchKeys: ['Value']
+      }
+    }
+    const correction = {
+      action: 'delete',
+      oldKeywordObject: { Value: 'Old Keyword' }
+    }
+
+    const result = editor.updateBlockNode(correction, config)
+    expect(result).toBe(true)
+
+    // Verify node removal
+    const remaining = editor.selectNodes('//gmd:descriptiveKeywords')
+    expect(remaining.length).toBe(0)
+  })
+
+  test('updateBlockNode should fallback to gco:CharacterString when specific fieldPath fails', () => {
+    const xml = `
+    <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:type>
+             <gmd:MD_KeywordTypeCode codeListValue="theme" />
+          </gmd:type>
+          <gmd:keyword>
+            <gco:CharacterString>Original Value</gco:CharacterString>
+          </gmd:keyword>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_Metadata>`
+
+    const testEditor = new Iso19115MetadataPathEditor(xml)
+
+    const config = {
+      nodeXPath: '//gmd:descriptiveKeywords/gmd:MD_Keywords',
+      find: {
+      // Add the missing function here
+        getNodeValueObject: ({ node }) => ({ Value: node.textContent.trim() }),
+        matchKeys: ['Value']
+      },
+      replace: [{
+        fieldPath: 'invalid/path',
+        source: { getValue: () => 'New Value' }
+      }]
+    }
+
+    const correction = {
+      action: 'replace',
+      oldKeywordObject: { Value: 'Original Value' },
+      newKeywordObject: { Value: 'New Value' }
+    }
+
+    const result = testEditor.updateBlockNode(correction, config)
+
+    expect(result).toBe(true)
+
+    const updatedNode = testEditor.selectNodes('//gco:CharacterString', testEditor.document)[0]
+    expect(updatedNode.textContent).toBe('New Value')
+  })
+
+  test('updateBlockNode should return false for unsupported actions', () => {
+    const xml = `
+    <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd">
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:type>
+             <gmd:MD_KeywordTypeCode codeListValue="theme" />
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_Metadata>`
+
+    const testEditor = new Iso19115MetadataPathEditor(xml)
+
+    const config = {
+      nodeXPath: '//gmd:descriptiveKeywords/gmd:MD_Keywords',
+      find: { matchKeys: ['Value'] }
+    }
+
+    // Use an action that is not 'delete' or 'replace'
+    const correction = {
+      action: 'unsupported',
+      oldKeywordObject: { Value: 'test' }
+    }
+
+    const result = testEditor.updateBlockNode(correction, config)
+
+    expect(result).toBe(false)
+  })
+
+  test('updateBlockNode should return false when replacement node is not found', () => {
+    const xml = `
+    <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>Existing Keyword</gco:CharacterString>
+          </gmd:keyword>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_Metadata>`
+
+    const testEditor = new Iso19115MetadataPathEditor(xml)
+
+    const config = {
+      nodeXPath: '//gmd:descriptiveKeywords/gmd:MD_Keywords',
+      find: {
+        getNodeValueObject: ({ node }) => ({ Value: node.textContent.trim() }),
+        matchKeys: ['Value']
+      },
+      replace: [{
+        fieldPath: 'gco:CharacterString',
+        source: { getValue: () => 'New Value' }
+      }]
+    }
+
+    // Correction object targeting a keyword that DOES NOT exist in the XML
+    const correction = {
+      action: 'replace',
+      oldKeywordObject: { Value: 'Non-existent Keyword' },
+      newKeywordObject: { Value: 'New Value' }
+    }
+
+    const result = testEditor.updateBlockNode(correction, config)
+
+    expect(result).toBe(false)
+  })
+
+  test('updateBlockNode should return false when matching node exists but field node cannot be found', () => {
+  // Use an XML structure that explicitly lacks a gco:CharacterString
+  // within the matched keyword scope.
+    const xml = `
+    <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd">
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gmd:SomeOtherElement>Original Value</gmd:SomeOtherElement>
+          </gmd:keyword>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_Metadata>`
+
+    const testEditor = new Iso19115MetadataPathEditor(xml)
+
+    const config = {
+      nodeXPath: '//gmd:descriptiveKeywords/gmd:MD_Keywords',
+      find: {
+        getNodeValueObject: () => ({ Value: 'Original Value' }),
+        matchKeys: ['Value']
+      },
+      replace: [{
+      // Ensure this path does not exist
+        fieldPath: 'non-existent/path',
+        source: { getValue: () => 'New Value' }
+      }]
+    }
+
+    const correction = {
+      action: 'replace',
+      oldKeywordObject: { Value: 'Original Value' },
+      newKeywordObject: { Value: 'New Value' }
+    }
+
+    // 1. findMatchingNode finds the keyword node containing 'Original Value'.
+    // 2. The explicit fieldPath fails.
+    // 3. The fallback selectNodes('./gco:CharacterString', matchingNode) returns nothing.
+    // 4. fieldNode remains null.
+    // 5. The 'if (fieldNode)' check fails, skipping the update.
+    // 6. Execution hits the 'return false' at line 156.
+    const result = testEditor.updateBlockNode(correction, config)
+
+    expect(result).toBe(false)
+  })
+})

--- a/serverless/src/shared/__tests__/Iso19115MetadataPathEditor.test.js
+++ b/serverless/src/shared/__tests__/Iso19115MetadataPathEditor.test.js
@@ -29,6 +29,50 @@ describe('Iso19115MetadataPathEditor', () => {
     editor = new Iso19115MetadataPathEditor(xmlString)
   })
 
+  test('should fallback to gco:CharacterString when explicit fieldPath is missing or invalid', () => {
+  // 1. Setup: Keyword block WITHOUT a specific sub-path defined in replaceConfig,
+  // but WITH a standard gco:CharacterString
+    const xml = `
+  <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
+    <gmd:descriptiveKeywords>
+      <gmd:MD_Keywords>
+        <gmd:keyword>
+          <gco:CharacterString>Old Value</gco:CharacterString>
+        </gmd:keyword>
+      </gmd:MD_Keywords>
+    </gmd:descriptiveKeywords>
+  </gmd:MD_Metadata>`
+
+    editor = new Iso19115MetadataPathEditor(xml)
+
+    // 2. Setup: Config with no fieldPath, forcing the fallback
+    const config = {
+      nodeXPath: '//gmd:descriptiveKeywords/gmd:MD_Keywords',
+      find: {
+        matchKeys: ['Value'],
+        getNodeValueObject: ({ node }) => ({ Value: node.textContent.trim() })
+      },
+      replace: [{
+      // No fieldPath provided
+        source: { getValue: () => 'New Value' }
+      }]
+    }
+
+    const correction = {
+      action: 'replace',
+      oldKeywordObject: { Value: 'Old Value' },
+      newKeywordObject: { Value: 'New Value' }
+    }
+
+    // 3. Execute
+    const success = editor.updateBlockNode(correction, config)
+
+    // 4. Assertions
+    expect(success).toBe(true)
+    expect(editor.serialize()).toContain('New Value')
+    expect(editor.serialize()).not.toContain('Old Value')
+  })
+
   test('should initialize namespaces correctly', () => {
     expect(editor.namespaces).toHaveProperty('gmd')
     expect(editor.namespaces.gmd).toBe('http://www.isotc211.org/2005/gmd')

--- a/serverless/src/shared/__tests__/Iso19115MetadataPathEditor.test.js
+++ b/serverless/src/shared/__tests__/Iso19115MetadataPathEditor.test.js
@@ -443,4 +443,97 @@ describe('Iso19115MetadataPathEditor', () => {
       expect(node.textContent).toBe('New Value')
     })
   })
+
+  test('updateBlockNode should remove synchronized global paths on delete', () => {
+    const xml = `
+    <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword><gco:CharacterString>Target Value</gco:CharacterString></gmd:keyword>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:contact>
+        <gmd:organisationName>
+          <gco:CharacterString>Target Value</gco:CharacterString>
+        </gmd:organisationName>
+      </gmd:contact>
+    </gmd:MD_Metadata>`
+
+    const testEditor = new Iso19115MetadataPathEditor(xml)
+
+    const config = {
+      nodeXPath: '//gmd:descriptiveKeywords/gmd:MD_Keywords',
+      find: {
+        getNodeValueObject: ({ node }) => ({ Value: node.textContent.trim() }),
+        matchKeys: ['Value']
+      },
+      replace: [{
+        fieldPath: '//gmd:contact/gmd:organisationName/gco:CharacterString',
+        source: { getValue: () => 'New Value' }
+      }]
+    }
+
+    const correction = {
+      action: 'delete',
+      oldKeywordObject: { Value: 'Target Value' }
+    }
+
+    const result = testEditor.updateBlockNode(correction, config)
+
+    expect(result).toBe(true)
+
+    // FIX: Target the specific leaf node (gco:CharacterString) that was removed
+    const syncNodes = testEditor.selectNodes('//gmd:contact/gmd:organisationName/gco:CharacterString', testEditor.document)
+    expect(syncNodes.length).toBe(0)
+  })
+
+  test('updateBlockNode should return false if MD_Identifier lacks a codeSpace during platform delete', () => {
+  // XML where a platform identifier exists, but is missing the <gmd:codeSpace> node
+    const xml = `
+    <gmi:MI_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gco="http://www.isotc211.org/2005/gco">
+      <gmd:someOtherSection>
+        <gmd:MD_Identifier>
+          <gmd:code><gco:CharacterString>PLAT1</gco:CharacterString></gmd:code>
+        </gmd:MD_Identifier>
+      </gmd:someOtherSection>
+      
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:type><gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode></gmd:type>
+          <gmd:keyword><gco:CharacterString>PLAT1</gco:CharacterString></gmd:keyword>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmi:MI_Metadata>`
+
+    const testEditor = new Iso19115MetadataPathEditor(xml)
+
+    // Configure a platform delete action
+    const config = {
+      nodeXPath: '//gmd:descriptiveKeywords/gmd:MD_Keywords',
+      find: {
+        getNodeValueObject: ({ node }) => ({ ShortName: node.textContent.trim() }),
+        matchKeys: ['ShortName']
+      },
+      // FIX: Change 'replace: true' to an empty array to satisfy .filter()
+      replace: []
+    }
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'delete',
+      oldKeywordObject: { ShortName: 'PLAT1' }
+    }
+
+    // Act: Attempt to delete the platform
+    const result = testEditor.updateBlockNode(correction, config)
+
+    // Assert:
+    // The operation is considered successful (true) because the main keyword was deleted,
+    // but internally, the cleanup for the acquisition identifier (line 169) was skipped.
+    expect(result).toBe(true)
+
+    // Verify that the acquisition identifier still exists because it wasn't cleaned up
+    const identifierNodes = testEditor.selectNodes('//gmd:MD_Identifier', testEditor.document)
+    expect(identifierNodes.length).toBe(1)
+  })
 })

--- a/serverless/src/shared/__tests__/XmlUtils.test.js
+++ b/serverless/src/shared/__tests__/XmlUtils.test.js
@@ -1,0 +1,73 @@
+import {
+  describe,
+  expect,
+  test
+} from 'vitest'
+
+import {
+  getScalarKeywordText,
+  isSimpleFieldPath,
+  normalizeValueObject,
+  trimString
+} from '../XmlUtils'
+
+describe('XmlUtils', () => {
+  describe('trimString', () => {
+    test('trims whitespace from strings', () => {
+      expect(trimString('  hello  ')).toBe('hello')
+    })
+
+    test('returns empty string for non-string inputs', () => {
+      expect(trimString(null)).toBe('')
+      expect(trimString(undefined)).toBe('')
+      expect(trimString(123)).toBe('')
+    })
+  })
+
+  describe('getScalarKeywordText', () => {
+    test('prioritizes Value over ShortName', () => {
+      const obj = {
+        Value: '  Science  ',
+        ShortName: 'Sci'
+      }
+      expect(getScalarKeywordText(obj)).toBe('Science')
+    })
+
+    test('falls back to ShortName if Value is missing', () => {
+      const obj = { ShortName: '  Physics  ' }
+      expect(getScalarKeywordText(obj)).toBe('Physics')
+    })
+
+    test('falls back to any available property if Value/ShortName are missing', () => {
+      const obj = { Category: '  Oceanography  ' }
+      expect(getScalarKeywordText(obj)).toBe('Oceanography')
+    })
+  })
+
+  describe('normalizeValueObject', () => {
+    test('extracts only requested keys and trims them', () => {
+      const input = {
+        Type: '  A  ',
+        Subtype: '  B  ',
+        Extra: 'C'
+      }
+      const keys = ['Type', 'Subtype']
+      expect(normalizeValueObject(input, keys)).toEqual({
+        Type: 'A',
+        Subtype: 'B'
+      })
+    })
+  })
+
+  describe('isSimpleFieldPath', () => {
+    test('validates simple absolute paths', () => {
+      expect(isSimpleFieldPath('//DIF/Product_Level_Id')).toBe(true)
+      expect(isSimpleFieldPath('//Root/Child/GrandChild')).toBe(true)
+    })
+
+    test('rejects invalid paths', () => {
+      expect(isSimpleFieldPath('Root/Child')).toBe(false) // No //
+      expect(isSimpleFieldPath('//123/Node')).toBe(false) // Invalid start
+    })
+  })
+})

--- a/serverless/src/shared/__tests__/applyIso19115InstrumentsCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115InstrumentsCorrections.test.js
@@ -1,0 +1,532 @@
+import {
+  describe,
+  expect,
+  test
+} from 'vitest'
+
+import { ISO_19115_SCHEME_EDITORS } from '../Iso19115DomEditor'
+import Iso19115MetadataPathEditor from '../Iso19115MetadataPathEditor'
+
+// Mock with BOTH keyword blocks AND NSIDC acquisition information
+// Tests synchronization between the two sections for the same instruments
+const mockIso19115WithKeywordsAndAcquisition = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>ATLAS &gt; Advanced Topographic Laser Altimeter System</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>MODIS &gt; Moderate Resolution Imaging Spectroradiometer</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="instrument">instrument</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Instrument Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2016-06-01</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:instrument>
+        <eos:EOS_Instrument id="_ATLAS">
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>ATLAS</gco:CharacterString>
+              </gmd:code>
+              <gmd:codeSpace>
+                <gco:CharacterString>gov.nasa.esdis.umm.instrumentshortname</gco:CharacterString>
+              </gmd:codeSpace>
+              <gmd:description>
+                <gco:CharacterString>Advanced Topographic Laser Altimeter System</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:type>
+            <gco:CharacterString>instrument</gco:CharacterString>
+          </gmi:type>
+        </eos:EOS_Instrument>
+      </gmi:instrument>
+      <gmi:instrument>
+        <eos:EOS_Instrument id="_MODIS">
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>MODIS</gco:CharacterString>
+              </gmd:code>
+              <gmd:codeSpace>
+                <gco:CharacterString>gov.nasa.esdis.umm.instrumentshortname</gco:CharacterString>
+              </gmd:codeSpace>
+              <gmd:description>
+                <gco:CharacterString>Moderate Resolution Imaging Spectroradiometer</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:type>
+            <gco:CharacterString>instrument</gco:CharacterString>
+          </gmi:type>
+        </eos:EOS_Instrument>
+      </gmi:instrument>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+describe('Instrument corrections with synchronized keyword blocks and acquisition information', () => {
+  test('should update BOTH keyword block and acquisition sections for ATLAS', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'ATLAS' },
+      newKeywordObject: { ShortName: 'ATLAS-2' },
+      newLongName: 'Advanced Topographic Laser Altimeter System Version 2'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // 1. Verify keyword block updated
+    expect(updatedXml).toContain('ATLAS-2 &gt; Advanced Topographic Laser Altimeter System Version 2')
+    expect(updatedXml).not.toContain('ATLAS &gt; Advanced Topographic Laser Altimeter System')
+
+    // 2. Verify acquisition gmd:code updated (ShortName only in NSIDC split format)
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_ATLAS">[\s\S]*?<gmd:code>\s*<gco:CharacterString>ATLAS-2<\/gco:CharacterString>/)
+
+    // 3. Verify acquisition identifier gmd:description updated (LongName only in NSIDC split format)
+    expect(updatedXml).toMatch(/<gmd:MD_Identifier>[\s\S]*?<gmd:code>\s*<gco:CharacterString>ATLAS-2<\/gco:CharacterString>[\s\S]*?<gmd:description>\s*<gco:CharacterString>Advanced Topographic Laser Altimeter System Version 2<\/gco:CharacterString>/)
+
+    // 4. Verify MODIS remains unchanged
+    expect(updatedXml).toContain('MODIS &gt; Moderate Resolution Imaging Spectroradiometer')
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_MODIS">[\s\S]*?<gmd:code>\s*<gco:CharacterString>MODIS<\/gco:CharacterString>/)
+  })
+
+  test('should update BOTH sections for MODIS without affecting ATLAS', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'MODIS' },
+      newKeywordObject: { ShortName: 'MODIS-2' },
+      newLongName: 'Moderate Resolution Imaging Spectroradiometer Version 2'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // 1. MODIS keyword updated
+    expect(updatedXml).toContain('MODIS-2 &gt; Moderate Resolution Imaging Spectroradiometer Version 2')
+    expect(updatedXml).not.toContain('MODIS &gt; Moderate Resolution Imaging Spectroradiometer')
+
+    // 2. MODIS acquisition code updated
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_MODIS">[\s\S]*?<gmd:code>\s*<gco:CharacterString>MODIS-2<\/gco:CharacterString>/)
+
+    // 3. MODIS acquisition description updated
+    expect(updatedXml).toMatch(/<gmd:MD_Identifier>[\s\S]*?<gmd:code>\s*<gco:CharacterString>MODIS-2<\/gco:CharacterString>[\s\S]*?<gmd:description>\s*<gco:CharacterString>Moderate Resolution Imaging Spectroradiometer Version 2<\/gco:CharacterString>/)
+
+    // 4. ATLAS remains unchanged in both sections
+    expect(updatedXml).toContain('ATLAS &gt; Advanced Topographic Laser Altimeter System')
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_ATLAS">[\s\S]*?<gmd:code>\s*<gco:CharacterString>ATLAS<\/gco:CharacterString>/)
+  })
+
+  test('should handle sequential updates to different instruments', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    // First update ATLAS
+    const atlasCorrection = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'ATLAS' },
+      newKeywordObject: { ShortName: 'ATLAS-NEW' },
+      newLongName: 'New ATLAS Description'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const atlasSuccess = config(editor, atlasCorrection)
+
+    // Then update MODIS
+    const modisCorrection = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'MODIS' },
+      newKeywordObject: { ShortName: 'MODIS-NEW' },
+      newLongName: 'New MODIS Description'
+    }
+
+    const modisSuccess = config(editor, modisCorrection)
+
+    expect(atlasSuccess).toBe(true)
+    expect(modisSuccess).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Both keyword blocks updated correctly
+    expect(updatedXml).toContain('ATLAS-NEW &gt; New ATLAS Description')
+    expect(updatedXml).toContain('MODIS-NEW &gt; New MODIS Description')
+
+    // Both acquisition sections updated independently
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_ATLAS">[\s\S]*?<gmd:code>\s*<gco:CharacterString>ATLAS-NEW<\/gco:CharacterString>/)
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_MODIS">[\s\S]*?<gmd:code>\s*<gco:CharacterString>MODIS-NEW<\/gco:CharacterString>/)
+
+    // Descriptions updated independently
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_ATLAS">[\s\S]*?<gmd:code>\s*<gco:CharacterString>ATLAS-NEW<\/gco:CharacterString>[\s\S]*?<gmd:description>\s*<gco:CharacterString>New ATLAS Description<\/gco:CharacterString>/)
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_MODIS">[\s\S]*?<gmd:code>\s*<gco:CharacterString>MODIS-NEW<\/gco:CharacterString>[\s\S]*?<gmd:description>\s*<gco:CharacterString>New MODIS Description<\/gco:CharacterString>/)
+  })
+
+  test('should preserve codeSpace when updating instruments', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'ATLAS' },
+      newKeywordObject: { ShortName: 'ATLAS-3' },
+      newLongName: 'Advanced Topographic Laser Altimeter System V3'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    config(editor, correction)
+
+    const updatedXml = editor.serialize()
+
+    // CodeSpace should remain unchanged
+    expect(updatedXml).toContain('gov.nasa.esdis.umm.instrumentshortname')
+    expect(updatedXml).toMatch(/<gmd:codeSpace>\s*<gco:CharacterString>gov.nasa.esdis.umm.instrumentshortname<\/gco:CharacterString>/)
+  })
+
+  test('should handle instrument with only ShortName update', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'ATLAS' },
+      newKeywordObject: { ShortName: 'ATLAS-5' }
+      // No newLongName provided
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword should have just ShortName
+    expect(updatedXml).toContain('<gco:CharacterString>ATLAS-5</gco:CharacterString>')
+
+    // Acquisition code should be updated
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_ATLAS">[\s\S]*?<gmd:code>\s*<gco:CharacterString>ATLAS-5<\/gco:CharacterString>/)
+  })
+
+  test('should delete instrument from BOTH keyword block and acquisition section', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'delete',
+      oldKeywordObject: { ShortName: 'ATLAS' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword block should not contain ATLAS
+    expect(updatedXml).not.toContain('ATLAS &gt; Advanced Topographic Laser Altimeter System')
+
+    // MODIS keyword should remain
+    expect(updatedXml).toContain('MODIS &gt; Moderate Resolution Imaging Spectroradiometer')
+
+    // Acquisition section should still exist but ATLAS instrument should be removed
+    expect(updatedXml).toContain('gmi:acquisitionInformation')
+    expect(updatedXml).not.toContain('<eos:EOS_Instrument id="_ATLAS">')
+    expect(updatedXml).not.toContain('ATLAS</gco:CharacterString>')
+
+    // MODIS should still be in acquisition section
+    expect(updatedXml).toContain('<eos:EOS_Instrument id="_MODIS">')
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_MODIS">[\s\S]*?<gmd:code>\s*<gco:CharacterString>MODIS<\/gco:CharacterString>/)
+  })
+
+  test('should verify both instruments are independent in updates', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    // Update only ATLAS
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'ATLAS' },
+      newKeywordObject: { ShortName: 'ATLAS-MODIFIED' },
+      newLongName: 'Modified ATLAS'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    config(editor, correction)
+
+    const updatedXml = editor.serialize()
+
+    // ATLAS keyword updated correctly
+    expect(updatedXml).toContain('ATLAS-MODIFIED &gt; Modified ATLAS')
+
+    // ATLAS acquisition updated
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_ATLAS">[\s\S]*?<gmd:code>\s*<gco:CharacterString>ATLAS-MODIFIED<\/gco:CharacterString>/)
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_ATLAS">[\s\S]*?<gmd:description>\s*<gco:CharacterString>Modified ATLAS<\/gco:CharacterString>/)
+
+    // MODIS completely unchanged in both keyword and acquisition
+    expect(updatedXml).toContain('MODIS &gt; Moderate Resolution Imaging Spectroradiometer')
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_MODIS">[\s\S]*?<gmd:code>\s*<gco:CharacterString>MODIS<\/gco:CharacterString>/)
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_MODIS">[\s\S]*?<gmd:description>\s*<gco:CharacterString>Moderate Resolution Imaging Spectroradiometer<\/gco:CharacterString>/)
+  })
+
+  test('should handle empty LongName gracefully', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'MODIS' },
+      newKeywordObject: { ShortName: 'MODIS-SIMPLE' },
+      newLongName: ''
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword should be just ShortName when LongName is empty
+    expect(updatedXml).toContain('<gco:CharacterString>MODIS-SIMPLE</gco:CharacterString>')
+
+    // Should not create malformed "MODIS-SIMPLE > "
+    expect(updatedXml).not.toContain('MODIS-SIMPLE &gt; ')
+  })
+
+  test('should handle special characters in instrument names', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'ATLAS' },
+      newKeywordObject: { ShortName: 'ATLAS-1/2' },
+      newLongName: 'Advanced Laser & System (Test)'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Special characters should be preserved in keyword
+    expect(updatedXml).toContain('ATLAS-1/2 &gt; Advanced Laser &amp; System (Test)')
+
+    // Special characters should be preserved in acquisition
+    expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>ATLAS-1\/2<\/gco:CharacterString>/)
+  })
+
+  test('should maintain XML structure integrity after updates', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'ATLAS' },
+      newKeywordObject: { ShortName: 'ATLAS-FINAL' },
+      newLongName: 'Final ATLAS Version'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    config(editor, correction)
+
+    const updatedXml = editor.serialize()
+
+    // Verify XML is well-formed by checking key structural elements
+    expect(updatedXml).toContain('<gmi:MI_Metadata')
+    expect(updatedXml).toContain('</gmi:MI_Metadata>')
+    expect(updatedXml).toContain('<gmd:identificationInfo>')
+    expect(updatedXml).toContain('</gmd:identificationInfo>')
+    expect(updatedXml).toContain('<gmi:acquisitionInformation>')
+    expect(updatedXml).toContain('</gmi:acquisitionInformation>')
+
+    // Verify all namespaces are preserved
+    expect(updatedXml).toMatch(/xmlns:eos="http:\/\/earthdata.nasa.gov\/schema\/eos"/)
+    expect(updatedXml).toMatch(/xmlns:gco="http:\/\/www.isotc211.org\/2005\/gco"/)
+    expect(updatedXml).toMatch(/xmlns:gmd="http:\/\/www.isotc211.org\/2005\/gmd"/)
+    expect(updatedXml).toMatch(/xmlns:gmi="http:\/\/www.isotc211.org\/2005\/gmi"/)
+  })
+
+  test('should handle MI_Instrument namespace variant', () => {
+    const miInstrumentXml = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>TEST-SENSOR &gt; Test Sensor</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="instrument">instrument</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:instrument>
+        <gmi:MI_Instrument>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>TEST-SENSOR</gco:CharacterString>
+              </gmd:code>
+              <gmd:description>
+                <gco:CharacterString>Test Sensor</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:type>
+            <gco:CharacterString>sensor</gco:CharacterString>
+          </gmi:type>
+        </gmi:MI_Instrument>
+      </gmi:instrument>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(miInstrumentXml)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'TEST-SENSOR' },
+      newKeywordObject: { ShortName: 'TEST-SENSOR-2' },
+      newLongName: 'Test Sensor Version 2'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword updated
+    expect(updatedXml).toContain('TEST-SENSOR-2 &gt; Test Sensor Version 2')
+
+    // MI_Instrument acquisition updated
+    expect(updatedXml).toMatch(/<gmi:MI_Instrument>[\s\S]*?<gmd:code>\s*<gco:CharacterString>TEST-SENSOR-2<\/gco:CharacterString>/)
+    expect(updatedXml).toMatch(/<gmd:description>\s*<gco:CharacterString>Test Sensor Version 2<\/gco:CharacterString>/)
+  })
+
+  test('should handle delete with MI_Instrument namespace', () => {
+    const miInstrumentXml = `
+<gmi:MI_Metadata 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>SENSOR-A</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="instrument">instrument</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:instrument>
+        <gmi:MI_Instrument>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>SENSOR-A</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </gmi:MI_Instrument>
+      </gmi:instrument>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(miInstrumentXml)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'delete',
+      oldKeywordObject: { ShortName: 'SENSOR-A' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword removed
+    expect(updatedXml).not.toContain('SENSOR-A')
+
+    // MI_Instrument removed from acquisition
+    expect(updatedXml).not.toContain('<gmi:MI_Instrument>')
+
+    // But acquisition section structure remains
+    expect(updatedXml).toContain('gmi:acquisitionInformation')
+  })
+})

--- a/serverless/src/shared/__tests__/applyIso19115InstrumentsCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115InstrumentsCorrections.test.js
@@ -705,4 +705,225 @@ describe('Instrument corrections with synchronized keyword blocks and acquisitio
     // But acquisition section structure remains
     expect(updatedXml).toContain('gmi:acquisitionInformation')
   })
+
+  test('should detect combined format in acquisition code and update accordingly', () => {
+    // Test coverage for: if (existingValue.includes(' > '))
+    const xmlWithCombinedFormat = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>VIIRS &gt; Visible Infrared Imaging Radiometer Suite</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="instrument">instrument</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:instrument>
+        <eos:EOS_Instrument>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>VIIRS &gt; Visible Infrared Imaging Radiometer Suite</gco:CharacterString>
+              </gmd:code>
+              <gmd:description>
+                <gco:CharacterString>Custom instrument description</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </eos:EOS_Instrument>
+      </gmi:instrument>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(xmlWithCombinedFormat)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'VIIRS' },
+      newKeywordObject: { ShortName: 'VIIRS-2' },
+      newLongName: 'Visible Infrared Imaging Radiometer Suite Version 2'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword block updated
+    expect(updatedXml).toContain('VIIRS-2 &gt; Visible Infrared Imaging Radiometer Suite Version 2')
+
+    // CRITICAL: Code should use combined format because existing code includes ' > '
+    // This covers the if (existingValue.includes(' > ')) branch
+    expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>VIIRS-2 &gt; Visible Infrared Imaging Radiometer Suite Version 2<\/gco:CharacterString>/)
+
+    // Description should be preserved (CWIC format)
+    expect(updatedXml).toContain('Custom instrument description')
+  })
+
+  test('should use combined format with empty LongName when existing code has delimiter', () => {
+    // Test coverage for: if (existingValue.includes(' > ')) with LongName being falsy
+    // This tests: return LongName ? `${ShortName} > ${LongName}` : ShortName
+    const xmlWithDelimiter = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>CERES &gt; Clouds and the Earth's Radiant Energy System</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="instrument">instrument</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:instrument>
+        <gmi:MI_Instrument>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>CERES &gt; Clouds and the Earth's Radiant Energy System</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </gmi:MI_Instrument>
+      </gmi:instrument>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(xmlWithDelimiter)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'CERES' },
+      newKeywordObject: { ShortName: 'CERES-2' }
+      // No newLongName - testing the ternary with falsy LongName
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword block updated with just ShortName (no LongName provided)
+    expect(updatedXml).toContain('<gco:CharacterString>CERES-2</gco:CharacterString>')
+
+    // Code detected ' > ' in existing value, enters if branch
+    // But LongName is falsy, so ternary returns just ShortName
+    // This covers: const { ShortName } = correction.newKeywordObject
+    // and: return LongName ? `${ShortName} > ${LongName}` : ShortName
+    expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>CERES-2<\/gco:CharacterString>/)
+  })
+
+  test('should handle both EOS_Instrument and MI_Instrument with combined format detection', () => {
+    // Test coverage for both namespace variants with includes(' > ') check
+    const mixedXml = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>AIRS &gt; Atmospheric Infrared Sounder</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="instrument">instrument</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:instrument>
+        <eos:EOS_Instrument>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>AIRS &gt; Atmospheric Infrared Sounder</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </eos:EOS_Instrument>
+      </gmi:instrument>
+      <gmi:instrument>
+        <gmi:MI_Instrument>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>AIRS &gt; Atmospheric Infrared Sounder</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </gmi:MI_Instrument>
+      </gmi:instrument>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(mixedXml)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'AIRS' },
+      newKeywordObject: { ShortName: 'AIRS-2' },
+      newLongName: 'Atmospheric Infrared Sounder Version 2'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword updated
+    expect(updatedXml).toContain('AIRS-2 &gt; Atmospheric Infrared Sounder Version 2')
+
+    // Both EOS_Instrument and MI_Instrument should detect ' > ' and use combined format
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument>[\s\S]*?<gmd:code>\s*<gco:CharacterString>AIRS-2 &gt; Atmospheric Infrared Sounder Version 2<\/gco:CharacterString>/)
+    expect(updatedXml).toMatch(/<gmi:MI_Instrument>[\s\S]*?<gmd:code>\s*<gco:CharacterString>AIRS-2 &gt; Atmospheric Infrared Sounder Version 2<\/gco:CharacterString>/)
+  })
 })

--- a/serverless/src/shared/__tests__/applyIso19115InstrumentsCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115InstrumentsCorrections.test.js
@@ -340,6 +340,182 @@ describe('Instrument corrections with synchronized keyword blocks and acquisitio
 
     // Should not create malformed "MODIS-SIMPLE > "
     expect(updatedXml).not.toContain('MODIS-SIMPLE &gt; ')
+
+    // Verify acquisition gmd:description is empty string (line 255 coverage for instruments)
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_MODIS">[\s\S]*?<gmd:description>\s*<gco:CharacterString><\/gco:CharacterString>/)
+  })
+
+  test('should handle undefined newLongName (not just empty string)', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'ATLAS' },
+      newKeywordObject: { ShortName: 'ATLAS-MINIMAL' }
+      // NewLongName is completely omitted (undefined)
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword should be just ShortName when newLongName is undefined (line 188 coverage for instruments)
+    expect(updatedXml).toContain('<gco:CharacterString>ATLAS-MINIMAL</gco:CharacterString>')
+    expect(updatedXml).not.toContain('ATLAS-MINIMAL &gt;')
+
+    // Verify acquisition code has only ShortName
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_ATLAS">[\s\S]*?<gmd:code>\s*<gco:CharacterString>ATLAS-MINIMAL<\/gco:CharacterString>/)
+
+    // Verify acquisition description is empty string when newLongName is falsy (line 255 coverage)
+    expect(updatedXml).toMatch(/<eos:EOS_Instrument id="_ATLAS">[\s\S]*?<gmd:description>\s*<gco:CharacterString><\/gco:CharacterString>/)
+  })
+
+  test('should preserve CWIC format free-text description when updating with combined format', () => {
+    // This specifically tests line 269 for instruments: return node?.textContent || ''
+    const cwicXml = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>SIRAL &gt; SAR Interferometric Radar Altimeter</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="instrument">instrument</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:instrument>
+        <gmi:MI_Instrument>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>SIRAL &gt; SAR Interferometric Radar Altimeter</gco:CharacterString>
+              </gmd:code>
+              <gmd:description>
+                <gco:CharacterString>This is a custom free-text description that should be preserved in CWIC format for instruments</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:type>
+            <gco:CharacterString>radar</gco:CharacterString>
+          </gmi:type>
+          <gmi:description>
+            <gco:CharacterString>SIRAL is a synthetic aperture radar altimeter operating in Ku-band</gco:CharacterString>
+          </gmi:description>
+        </gmi:MI_Instrument>
+      </gmi:instrument>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(cwicXml)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'SIRAL' },
+      newKeywordObject: { ShortName: 'SIRAL-2' },
+      newLongName: 'SAR Interferometric Radar Altimeter Version 2'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword updated with combined format
+    expect(updatedXml).toContain('SIRAL-2 &gt; SAR Interferometric Radar Altimeter Version 2')
+
+    // Acquisition code updated with combined format (detected ' > ')
+    expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>SIRAL-2 &gt; SAR Interferometric Radar Altimeter Version 2<\/gco:CharacterString>/)
+
+    // CRITICAL: Free-text description should be PRESERVED (line 269 coverage for instruments)
+    // This tests the fallback: return node?.textContent || ''
+    expect(updatedXml).toContain('This is a custom free-text description that should be preserved in CWIC format for instruments')
+
+    // Instrument-level description also preserved
+    expect(updatedXml).toContain('SIRAL is a synthetic aperture radar altimeter operating in Ku-band')
+  })
+
+  test('should handle CWIC format with null/undefined description node gracefully', () => {
+    // Edge case: what if description node doesn't exist in CWIC format?
+    const cwicXmlNoDesc = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos"
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx" 
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>TEST-RADAR &gt; Test Radar</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="instrument">instrument</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:instrument>
+        <gmi:MI_Instrument>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>TEST-RADAR &gt; Test Radar</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </gmi:MI_Instrument>
+      </gmi:instrument>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(cwicXmlNoDesc)
+
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'TEST-RADAR' },
+      newKeywordObject: { ShortName: 'TEST-RADAR-2' },
+      newLongName: 'Test Radar Version 2'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Should handle gracefully even without description node (line 269: || '' fallback)
+    expect(updatedXml).toContain('TEST-RADAR-2 &gt; Test Radar Version 2')
+    expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>TEST-RADAR-2 &gt; Test Radar Version 2<\/gco:CharacterString>/)
   })
 
   test('should handle special characters in instrument names', () => {

--- a/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
@@ -112,6 +112,66 @@ const mockIso19115 = `
           </gmd:thesaurusName>
         </gmd:MD_Keywords>
       </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>MEASURES &gt; Making Earth System Data Records for Use in Research Environments</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>MAGIA &gt; Structure, Stratigraphy, and Sedimentology North of the Antarctic Peninsula</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="project">project</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Project Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-01-24</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>Continent &gt; North America &gt; Greenland</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>Continent &gt; North America &gt; Canada &gt; Alberta</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="place">place</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Location Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-02-05</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
 </gmi:MI_Metadata>`
 
 const mockIso19115WithOneScienceKeyword = `
@@ -163,7 +223,7 @@ describe('when applying sciencekeywords ISO-19115 corrections', () => {
         Category: 'EARTH SCIENCE',
         Topic: 'OCEANS',
         Term: 'MARINE SEDIMENTS',
-        VariableLevel1: '',
+        VariableLevel1: 'PARTICLE SIZE',
         VariableLevel2: '',
         VariableLevel3: '',
         DetailedVariable: ''
@@ -177,8 +237,8 @@ describe('when applying sciencekeywords ISO-19115 corrections', () => {
 
     // Verify the XML was updated
     const updatedXml = editor.serialize()
-    expect(updatedXml).toContain('<gco:CharacterString>EARTH SCIENCE &gt; OCEANS &gt; MARINE SEDIMENTS</gco:CharacterString>')
-    expect(updatedXml).not.toContain('AEROSOLS')
+    expect(updatedXml).toContain('EARTH SCIENCE &gt; OCEANS &gt; MARINE SEDIMENTS &gt; PARTICLE SIZE')
+    expect(updatedXml).not.toContain('EARTH SCIENCE &gt; ATMOSPHERE &gt; AEROSOLS')
   })
 
   test('should delete existing science keyword block correctly', () => {
@@ -191,15 +251,13 @@ describe('when applying sciencekeywords ISO-19115 corrections', () => {
 
     const config = ISO_19115_SCHEME_EDITORS.sciencekeywords
 
-    // Note: You may need to add an updateBlockNode implementation for 'delete'
-    // in iso19115DomEditor.js similar to the one shown below.
     const success = config(editor, correction)
 
     expect(success).toBe(true)
 
     // Verify the XML no longer contains the MD_Keywords block
     const updatedXml = editor.serialize()
-    expect(updatedXml).not.toContain('EARTH SCIENCE > ATMOSPHERE > AEROSOLS')
+    expect(updatedXml).not.toContain('EARTH SCIENCE &gt; ATMOSPHERE &gt; AEROSOLS')
   })
 
   test('should delete single existing science keyword block correctly', () => {
@@ -212,8 +270,6 @@ describe('when applying sciencekeywords ISO-19115 corrections', () => {
 
     const config = ISO_19115_SCHEME_EDITORS.sciencekeywords
 
-    // Note: You may need to add an updateBlockNode implementation for 'delete'
-    // in iso19115DomEditor.js similar to the one shown below.
     const success = config(editor, correction)
 
     expect(success).toBe(true)
@@ -225,11 +281,58 @@ describe('when applying sciencekeywords ISO-19115 corrections', () => {
   })
 })
 
+describe('when applying locations ISO-19115 corrections', () => {
+  test('should replace existing location correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+    const correction = {
+      scheme: 'locations',
+      action: 'replace',
+      oldKeywordObject: { Value: 'CONTINENT > NORTH AMERICA > CANADA > ALBERTA' },
+      newKeywordObject: {
+        Category: 'CONTINENT',
+        Type: 'NORTH AMERICA',
+        Subregion1: 'MEXICO',
+        Subregion2: '',
+        Subregion3: '',
+        DetailedLocation: ''
+      }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.locations
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    // Verify the XML was updated
+    const updatedXml = editor.serialize()
+    expect(updatedXml).toContain('CONTINENT &gt; NORTH AMERICA &gt; MEXICO')
+    expect(updatedXml).not.toContain('Continent &gt; North America &gt; Canada &gt; Alberta')
+  })
+
+  test('should delete existing locations block correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+    const correction = {
+      scheme: 'locations',
+      action: 'delete',
+      oldKeywordObject: { Value: 'Continent > North America > Greenland' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.locations
+
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    // Verify the XML no longer contains the MD_Keywords block
+    const updatedXml = editor.serialize()
+    expect(updatedXml).not.toContain('Continent &gt; North America &gt; Greenland')
+  })
+})
+
 describe('when applying platforms ISO-19115 corrections', () => {
   test('should replace existing platform keyword correctly', () => {
     const editor = new Iso19115MetadataPathEditor(mockIso19115)
 
-    // Example: Replace "AQUA > Earth Observing System"
     const correction = {
       scheme: 'platforms',
       action: 'replace',
@@ -246,7 +349,7 @@ describe('when applying platforms ISO-19115 corrections', () => {
     expect(success).toBe(true)
 
     const updatedXml = editor.serialize()
-    expect(updatedXml).toContain('<gco:CharacterString>AQUA &gt; New Platform Description</gco:CharacterString>')
+    expect(updatedXml).toContain('AQUA &gt; New Platform Description')
     expect(updatedXml).not.toContain('AQUA &gt; Earth Observing System')
   })
 
@@ -274,7 +377,7 @@ describe('when applying instruments ISO-19115 corrections', () => {
   test('should replace existing instrument keyword correctly', () => {
     const editor = new Iso19115MetadataPathEditor(mockIso19115)
 
-    // Example: Replace "AQUA > Earth Observing System"
+    // Example: Replace "MODIS > Earth Observing System"
     const correction = {
       scheme: 'instruments',
       action: 'replace',
@@ -291,7 +394,7 @@ describe('when applying instruments ISO-19115 corrections', () => {
     expect(success).toBe(true)
 
     const updatedXml = editor.serialize()
-    expect(updatedXml).toContain('<gco:CharacterString>MODIS-1 &gt; New Instrument Description</gco:CharacterString>')
+    expect(updatedXml).toContain('MODIS-1 &gt; New Instrument Description')
     expect(updatedXml).not.toContain('MODIS &gt; Moderate-Resolution Imaging Spectroradiometer')
   })
 
@@ -312,5 +415,49 @@ describe('when applying instruments ISO-19115 corrections', () => {
     const updatedXml = editor.serialize()
     expect(updatedXml).not.toContain('ATLAS &gt; Advanced Topographic Laser Altimeter System')
     expect(updatedXml).toContain('MODIS &gt; Moderate-Resolution Imaging Spectroradiometer')
+  })
+})
+
+describe('when applying projects ISO-19115 corrections', () => {
+  test('should replace existing project keyword correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+
+    const correction = {
+      scheme: 'projects',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'MEASURES' },
+      newKeywordObject: {
+        ShortName: 'MEASURES-1'
+      },
+      newLongName: 'New Project Description'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.projects
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+    expect(updatedXml).toContain('MEASURES-1 &gt; New Project Description')
+    expect(updatedXml).not.toContain('MEASURES &gt; Making Earth System Data Records for Use in Research Environments')
+  })
+
+  test('should delete existing project keyword block correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+    const correction = {
+      scheme: 'projects',
+      action: 'delete',
+      oldKeywordObject: { ShortName: 'MEASURES' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.projects
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    // Verify the specific keyword is gone
+    const updatedXml = editor.serialize()
+    expect(updatedXml).not.toContain('MEASURES &gt; Making Earth System Data Records for Use in Research Environments')
+    expect(updatedXml).toContain('MAGIA &gt; Structure, Stratigraphy, and Sedimentology North of the Antarctic Peninsula')
   })
 })

--- a/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
@@ -14,6 +14,7 @@ const mockIso19115 = `
   xmlns:gmd="http://www.isotc211.org/2005/gmd" 
   xmlns:gmi="http://www.isotc211.org/2005/gmi" 
   xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
   xmlns:xlink="http://www.w3.org/1999/xlink" 
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <gmd:identificationInfo>
@@ -37,6 +38,82 @@ const mockIso19115 = `
           </gmd:codeSpace>
         </gmd:MD_Identifier>
       </gmd:processingLevel>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gmx:Anchor xlink:href="https://gcmdservices.gsfc.nasa.gov/kms/concept/086c68e5-1c94-4f2f-89d5-0453443ff249" xlink:actuate="onRequest">DOC/NOAA/NESDIS/NODC &gt; National Oceanographic Data Center, NESDIS, NOAA, U.S. Department of Commerce</gmx:Anchor>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gmx:Anchor xlink:href="https://gcmdservices.gsfc.nasa.gov/kms/concept/e59896e0-3b4d-43ea-9348-f1f456305d05" xlink:actuate="onRequest">DOC/NOAA/NESDIS/NCEI &gt; National Centers for Environmental Information, NESDIS, NOAA, U.S. Department of Commerce</gmx:Anchor>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="https://data.noaa.gov/resources/iso19139/schema/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="dataCentre">dataCentre</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>Global Change Master Directory (GCMD) Data Center Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2019-11-12</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="https://data.noaa.gov/resources/iso19139/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:edition>
+                <gco:CharacterString>9</gco:CharacterString>
+              </gmd:edition>
+              <gmd:citedResponsibleParty>
+                <gmd:CI_ResponsibleParty>
+                  <gmd:organisationName>
+                    <gco:CharacterString>Global Change Data Center, Science and Exploration Directorate, Goddard Space Flight Center (GSFC) National Aeronautics and Space Administration (NASA)</gco:CharacterString>
+                  </gmd:organisationName>
+                  <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                      <gmd:address>
+                        <gmd:CI_Address>
+                          <gmd:city>
+                            <gco:CharacterString>Greenbelt</gco:CharacterString>
+                          </gmd:city>
+                          <gmd:administrativeArea>
+                            <gco:CharacterString>MD</gco:CharacterString>
+                          </gmd:administrativeArea>
+                        </gmd:CI_Address>
+                      </gmd:address>
+                      <gmd:onlineResource>
+                        <gmd:CI_OnlineResource>
+                          <gmd:linkage>
+                            <gmd:URL>https://wiki.earthdata.nasa.gov/display/gcmdkey</gmd:URL>
+                          </gmd:linkage>
+                          <gmd:protocol>
+                            <gco:CharacterString>HTTPS</gco:CharacterString>
+                          </gmd:protocol>
+                          <gmd:name>
+                            <gco:CharacterString>GCMD Keyword Forum Page</gco:CharacterString>
+                          </gmd:name>
+                          <gmd:description>
+                            <gco:CharacterString>The information provided on this page seeks to define how the GCMD Keywords are structured, used and accessed. It also provides information on how users can participate in the further development of the keywords.</gco:CharacterString>
+                          </gmd:description>
+                          <gmd:function>
+                            <gmd:CI_OnLineFunctionCode codeList="https://data.noaa.gov/resources/iso19139/schema/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
+                          </gmd:function>
+                        </gmd:CI_OnlineResource>
+                      </gmd:onlineResource>
+                    </gmd:CI_Contact>
+                  </gmd:contactInfo>
+                  <gmd:role>
+                    <gmd:CI_RoleCode codeList="https://data.noaa.gov/resources/iso19139/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="custodian">custodian</gmd:CI_RoleCode>
+                  </gmd:role>
+                </gmd:CI_ResponsibleParty>
+              </gmd:citedResponsibleParty>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
       <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>   
           <gmd:keyword>
@@ -590,5 +667,49 @@ describe('when applying productlevelid ISO-19115 corrections', () => {
     // Verify that the Identifier block is completely gone from both expected locations
     expect(updatedXml).not.toContain('gov.nasa.esdis.umm.processinglevelid')
     expect(updatedXml).not.toContain('<gco:CharacterString>3</gco:CharacterString>')
+  })
+})
+
+describe('when applying providers ISO-19115 corrections', () => {
+  test('should replace existing providers keyword correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+
+    const correction = {
+      scheme: 'providers',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'DOC/NOAA/NESDIS/NCEI' },
+      newKeywordObject: {
+        ShortName: 'DOC/NOAA/NESDIS/NCEI-1'
+      },
+      newLongName: 'New Provider Description'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.providers
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+    expect(updatedXml).toContain('DOC/NOAA/NESDIS/NCEI-1 &gt; New Provider Description')
+    expect(updatedXml).not.toContain('DOC/NOAA/NESDIS/NCEI &gt; National Centers for Environmental Information, NESDIS, NOAA, U.S. Department of Commerce')
+  })
+
+  test('should delete existing providers keyword block correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+    const correction = {
+      scheme: 'providers',
+      action: 'delete',
+      oldKeywordObject: { ShortName: 'DOC/NOAA/NESDIS/NCEI' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.providers
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    // Verify the specific keyword is gone
+    const updatedXml = editor.serialize()
+    expect(updatedXml).not.toContain('DOC/NOAA/NESDIS/NCEI &gt; National Centers for Environmental Information, NESDIS, NOAA, U.S. Department of Commerce')
+    expect(updatedXml).toContain('DOC/NOAA/NESDIS/NODC &gt; National Oceanographic Data Center, NESDIS, NOAA, U.S. Department of Commerce')
   })
 })

--- a/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
@@ -16,7 +16,18 @@ const mockIso19115 = `
   xmlns:gml="http://www.opengis.net/gml/3.2" 
   xmlns:xlink="http://www.w3.org/1999/xlink" 
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <gmd:descriptiveKeywords>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode codeListValue="LOCATION">LOCATION</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode codeListValue="FARMING">FARMING</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode codeListValue="ELEVATION">ELEVATION</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>   
           <gmd:keyword>
             <gco:CharacterString>EARTH SCIENCE &gt; Cryosphere &gt; Glaciers/Ice Sheets &gt; Firn &gt; Snow Grain Size</gco:CharacterString>
@@ -172,6 +183,8 @@ const mockIso19115 = `
           </gmd:thesaurusName>
         </gmd:MD_Keywords>
       </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
 </gmi:MI_Metadata>`
 
 const mockIso19115WithOneScienceKeyword = `
@@ -183,7 +196,9 @@ const mockIso19115WithOneScienceKeyword = `
   xmlns:gml="http://www.opengis.net/gml/3.2" 
   xmlns:xlink="http://www.w3.org/1999/xlink" 
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <gmd:descriptiveKeywords>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>
           <gmd:keyword>
             <gco:CharacterString>EARTH SCIENCE &gt; ATMOSPHERE &gt; AEROSOLS</gco:CharacterString>
@@ -210,6 +225,8 @@ const mockIso19115WithOneScienceKeyword = `
           </gmd:thesaurusName>
         </gmd:MD_Keywords>
       </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
 </gmi:MI_Metadata>`
 
 describe('when applying sciencekeywords ISO-19115 corrections', () => {
@@ -459,5 +476,49 @@ describe('when applying projects ISO-19115 corrections', () => {
     const updatedXml = editor.serialize()
     expect(updatedXml).not.toContain('MEASURES &gt; Making Earth System Data Records for Use in Research Environments')
     expect(updatedXml).toContain('MAGIA &gt; Structure, Stratigraphy, and Sedimentology North of the Antarctic Peninsula')
+  })
+})
+
+describe('topiccategory scheme', () => {
+  test('should replace existing topic category correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+
+    const correction = {
+      scheme: 'isotopiccategory',
+      action: 'replace',
+      oldKeywordObject: { Value: 'FARMING' },
+      newKeywordObject: { Value: 'BIOTA' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.isotopiccategory
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+    // Verify both the text content and the attribute were updated
+    expect(updatedXml).toContain('<gmd:MD_TopicCategoryCode codeListValue="BIOTA">BIOTA</gmd:MD_TopicCategoryCode>')
+    expect(updatedXml).not.toContain('codeListValue="FARMING">FARMING')
+  })
+
+  test('should delete existing topic category correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+
+    const correction = {
+      scheme: 'isotopiccategory',
+      action: 'delete',
+      oldKeywordObject: { Value: 'LOCATION' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.isotopiccategory
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    // Verify the specific category element is removed
+    const updatedXml = editor.serialize()
+    expect(updatedXml).not.toContain('codeListValue="LOCATION">LOCATION')
+    // Verify other categories remain
+    expect(updatedXml).toContain('codeListValue="FARMING">FARMING')
   })
 })

--- a/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
@@ -1,0 +1,316 @@
+import {
+  describe,
+  expect,
+  test
+} from 'vitest'
+
+import { ISO_19115_SCHEME_EDITORS } from '../Iso19115DomEditor'
+import Iso19115MetadataPathEditor from '../Iso19115MetadataPathEditor'
+
+const mockIso19115 = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:xlink="http://www.w3.org/1999/xlink" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>   
+          <gmd:keyword>
+            <gco:CharacterString>EARTH SCIENCE &gt; Cryosphere &gt; Glaciers/Ice Sheets &gt; Firn &gt; Snow Grain Size</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>EARTH SCIENCE &gt; ATMOSPHERE &gt; AEROSOLS</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>EARTH SCIENCE &gt; Cryosphere &gt; Glaciers/Ice Sheets &gt; Glacier Topography/Ice Sheet Topography &gt; Surface Morphology</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>EARTH SCIENCE &gt; Cryosphere &gt; Glaciers/Ice Sheets &gt; Glacier Topography/Ice Sheet Topography &gt; Surface Morphology</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Science Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-02-05</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>TERRA &gt; Earth Observing System, TERRA (AM-1)</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>AQUA &gt; Earth Observing System</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Platform Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2016-06-10</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+            <gmd:keyword>
+            <gco:CharacterString>ATLAS &gt; Advanced Topographic Laser Altimeter System</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>MODIS &gt; Moderate-Resolution Imaging Spectroradiometer</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="instrument">instrument</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Instrument Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2016-06-01</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+</gmi:MI_Metadata>`
+
+const mockIso19115WithOneScienceKeyword = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:xlink="http://www.w3.org/1999/xlink" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>EARTH SCIENCE &gt; ATMOSPHERE &gt; AEROSOLS</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Science Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-02-05</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+</gmi:MI_Metadata>`
+
+describe('when applying sciencekeywords ISO-19115 corrections', () => {
+  test('should replace existing science keyword correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+    const correction = {
+      scheme: 'sciencekeywords',
+      action: 'replace',
+      oldKeywordObject: { Value: 'EARTH SCIENCE > ATMOSPHERE > AEROSOLS' },
+      newKeywordObject: {
+        Category: 'EARTH SCIENCE',
+        Topic: 'OCEANS',
+        Term: 'MARINE SEDIMENTS',
+        VariableLevel1: '',
+        VariableLevel2: '',
+        VariableLevel3: '',
+        DetailedVariable: ''
+      }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.sciencekeywords
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    // Verify the XML was updated
+    const updatedXml = editor.serialize()
+    expect(updatedXml).toContain('<gco:CharacterString>EARTH SCIENCE &gt; OCEANS &gt; MARINE SEDIMENTS</gco:CharacterString>')
+    expect(updatedXml).not.toContain('AEROSOLS')
+  })
+
+  test('should delete existing science keyword block correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+    const correction = {
+      scheme: 'sciencekeywords',
+      action: 'delete',
+      oldKeywordObject: { Value: 'EARTH SCIENCE > ATMOSPHERE > AEROSOLS' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.sciencekeywords
+
+    // Note: You may need to add an updateBlockNode implementation for 'delete'
+    // in iso19115DomEditor.js similar to the one shown below.
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    // Verify the XML no longer contains the MD_Keywords block
+    const updatedXml = editor.serialize()
+    expect(updatedXml).not.toContain('EARTH SCIENCE > ATMOSPHERE > AEROSOLS')
+  })
+
+  test('should delete single existing science keyword block correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithOneScienceKeyword)
+    const correction = {
+      scheme: 'sciencekeywords',
+      action: 'delete',
+      oldKeywordObject: { Value: 'EARTH SCIENCE > ATMOSPHERE > AEROSOLS' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.sciencekeywords
+
+    // Note: You may need to add an updateBlockNode implementation for 'delete'
+    // in iso19115DomEditor.js similar to the one shown below.
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    // Verify the XML no longer contains the MD_Keywords block
+    const updatedXml = editor.serialize()
+    expect(updatedXml).not.toContain('EARTH SCIENCE > ATMOSPHERE > AEROSOLS')
+    expect(updatedXml).not.toContain('<gmd:descriptiveKeywords>')
+  })
+})
+
+describe('when applying platforms ISO-19115 corrections', () => {
+  test('should replace existing platform keyword correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+
+    // Example: Replace "AQUA > Earth Observing System"
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'AQUA' },
+      newKeywordObject: {
+        ShortName: 'AQUA',
+        LongName: 'New Platform Description'
+      }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+    expect(updatedXml).toContain('<gco:CharacterString>AQUA &gt; New Platform Description</gco:CharacterString>')
+    expect(updatedXml).not.toContain('AQUA &gt; Earth Observing System')
+  })
+
+  test('should delete existing platform keyword block correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+    const correction = {
+      scheme: 'platforms',
+      action: 'delete',
+      oldKeywordObject: { ShortName: 'AQUA' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    // Verify the specific keyword is gone
+    const updatedXml = editor.serialize()
+    expect(updatedXml).not.toContain('AQUA &gt; Earth Observing System, AQUA')
+    expect(updatedXml).toContain('TERRA &gt; Earth Observing System, TERRA (AM-1)')
+  })
+})
+
+describe('when applying instruments ISO-19115 corrections', () => {
+  test('should replace existing instrument keyword correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+
+    // Example: Replace "AQUA > Earth Observing System"
+    const correction = {
+      scheme: 'instruments',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'MODIS' },
+      newKeywordObject: {
+        ShortName: 'MODIS-1',
+        LongName: 'New Instrument Description'
+      }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+    expect(updatedXml).toContain('<gco:CharacterString>MODIS-1 &gt; New Instrument Description</gco:CharacterString>')
+    expect(updatedXml).not.toContain('MODIS &gt; Moderate-Resolution Imaging Spectroradiometer')
+  })
+
+  test('should delete existing instrument keyword block correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+    const correction = {
+      scheme: 'instruments',
+      action: 'delete',
+      oldKeywordObject: { ShortName: 'ATLAS' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.instruments
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    // Verify the specific keyword is gone
+    const updatedXml = editor.serialize()
+    expect(updatedXml).not.toContain('ATLAS &gt; Advanced Topographic Laser Altimeter System')
+    expect(updatedXml).toContain('MODIS &gt; Moderate-Resolution Imaging Spectroradiometer')
+  })
+})

--- a/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
@@ -336,7 +336,15 @@ describe('when applying sciencekeywords ISO-19115 corrections', () => {
     const correction = {
       scheme: 'sciencekeywords',
       action: 'replace',
-      oldKeywordObject: { Value: 'EARTH SCIENCE > ATMOSPHERE > AEROSOLS' },
+      oldKeywordObject: {
+        Category: 'EARTH SCIENCE',
+        Topic: 'ATMOSPHERE',
+        Term: 'AEROSOLS',
+        VariableLevel1: '',
+        VariableLevel2: '',
+        VariableLevel3: '',
+        DetailedVariable: ''
+      },
       newKeywordObject: {
         Category: 'EARTH SCIENCE',
         Topic: 'OCEANS',
@@ -364,7 +372,15 @@ describe('when applying sciencekeywords ISO-19115 corrections', () => {
     const correction = {
       scheme: 'sciencekeywords',
       action: 'delete',
-      oldKeywordObject: { Value: 'EARTH SCIENCE > ATMOSPHERE > AEROSOLS' }
+      oldKeywordObject: {
+        Category: 'EARTH SCIENCE',
+        Topic: 'ATMOSPHERE',
+        Term: 'AEROSOLS',
+        VariableLevel1: '',
+        VariableLevel2: '',
+        VariableLevel3: '',
+        DetailedVariable: ''
+      }
     }
 
     const config = ISO_19115_SCHEME_EDITORS.sciencekeywords
@@ -383,7 +399,15 @@ describe('when applying sciencekeywords ISO-19115 corrections', () => {
     const correction = {
       scheme: 'sciencekeywords',
       action: 'delete',
-      oldKeywordObject: { Value: 'EARTH SCIENCE > ATMOSPHERE > AEROSOLS' }
+      oldKeywordObject: {
+        Category: 'EARTH SCIENCE',
+        Topic: 'ATMOSPHERE',
+        Term: 'AEROSOLS',
+        VariableLevel1: '',
+        VariableLevel2: '',
+        VariableLevel3: '',
+        DetailedVariable: ''
+      }
     }
 
     const config = ISO_19115_SCHEME_EDITORS.sciencekeywords
@@ -405,7 +429,14 @@ describe('when applying locations ISO-19115 corrections', () => {
     const correction = {
       scheme: 'locations',
       action: 'replace',
-      oldKeywordObject: { Value: 'CONTINENT > NORTH AMERICA > CANADA > ALBERTA' },
+      oldKeywordObject: {
+        Category: 'CONTINENT',
+        Type: 'NORTH AMERICA',
+        Subregion1: 'CANADA',
+        Subregion2: 'ALBERTA',
+        Subregion3: '',
+        DetailedLocation: ''
+      },
       newKeywordObject: {
         Category: 'CONTINENT',
         Type: 'NORTH AMERICA',
@@ -432,7 +463,14 @@ describe('when applying locations ISO-19115 corrections', () => {
     const correction = {
       scheme: 'locations',
       action: 'delete',
-      oldKeywordObject: { Value: 'Continent > North America > Greenland' }
+      oldKeywordObject: {
+        Category: 'Continent',
+        Type: 'North America',
+        Subregion1: 'Greenland',
+        Subregion2: '',
+        Subregion3: '',
+        DetailedLocation: ''
+      }
     }
 
     const config = ISO_19115_SCHEME_EDITORS.locations

--- a/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
@@ -27,6 +27,16 @@ const mockIso19115 = `
       <gmd:topicCategory>
         <gmd:MD_TopicCategoryCode codeListValue="ELEVATION">ELEVATION</gmd:MD_TopicCategoryCode>
       </gmd:topicCategory>
+      <gmd:processingLevel>
+        <gmd:MD_Identifier>
+          <gmd:code>
+            <gco:CharacterString>3</gco:CharacterString>
+          </gmd:code>
+          <gmd:codeSpace>
+            <gco:CharacterString>gov.nasa.esdis.umm.processinglevelid</gco:CharacterString>
+          </gmd:codeSpace>
+        </gmd:MD_Identifier>
+      </gmd:processingLevel>
       <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>   
           <gmd:keyword>
@@ -185,6 +195,20 @@ const mockIso19115 = `
       </gmd:descriptiveKeywords>
     </gmd:MD_DataIdentification>
   </gmd:identificationInfo>
+  <gmd:contentInfo>
+    <gmd:MD_ImageDescription>
+      <gmd:processingLevelCode>
+        <gmd:MD_Identifier>
+          <gmd:code>
+            <gco:CharacterString>3</gco:CharacterString>
+          </gmd:code>
+          <gmd:codeSpace>
+            <gco:CharacterString>gov.nasa.esdis.umm.processinglevelid</gco:CharacterString>
+          </gmd:codeSpace>
+        </gmd:MD_Identifier>
+      </gmd:processingLevelCode>
+    </gmd:MD_ImageDescription>
+  </gmd:contentInfo>
 </gmi:MI_Metadata>`
 
 const mockIso19115WithOneScienceKeyword = `
@@ -479,8 +503,8 @@ describe('when applying projects ISO-19115 corrections', () => {
   })
 })
 
-describe('topiccategory scheme', () => {
-  test('should replace existing topic category correctly', () => {
+describe('when applying isotopiccategory ISO-19115 corrections', () => {
+  test('should replace existing isotopiccategory correctly', () => {
     const editor = new Iso19115MetadataPathEditor(mockIso19115)
 
     const correction = {
@@ -501,7 +525,7 @@ describe('topiccategory scheme', () => {
     expect(updatedXml).not.toContain('codeListValue="FARMING">FARMING')
   })
 
-  test('should delete existing topic category correctly', () => {
+  test('should delete existing isotopiccategory correctly', () => {
     const editor = new Iso19115MetadataPathEditor(mockIso19115)
 
     const correction = {
@@ -520,5 +544,51 @@ describe('topiccategory scheme', () => {
     expect(updatedXml).not.toContain('codeListValue="LOCATION">LOCATION')
     // Verify other categories remain
     expect(updatedXml).toContain('codeListValue="FARMING">FARMING')
+  })
+})
+
+describe('when applying productlevelid ISO-19115 corrections', () => {
+  test('should replace existing productlevelid correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+
+    const correction = {
+      scheme: 'productlevelid',
+      action: 'replace',
+      oldKeywordObject: { Value: '3' },
+      newKeywordObject: { Value: '5' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.productlevelid
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+    // 1. Data Identification location
+    expect(updatedXml).toMatch(/<gmd:processingLevel>.*<gco:CharacterString>5<\/gco:CharacterString>/s)
+    // 2. Image Description location
+    expect(updatedXml).toMatch(/<gmd:contentInfo>.*<gco:CharacterString>5<\/gco:CharacterString>/s)
+    expect(updatedXml).not.toContain('<gco:CharacterString>3</gco:CharacterString>')
+  })
+
+  test('should delete existing productlevelid correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+
+    const correction = {
+      scheme: 'productlevelid',
+      action: 'delete',
+      oldKeywordObject: { Value: '3' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.productlevelid
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Verify that the Identifier block is completely gone from both expected locations
+    expect(updatedXml).not.toContain('gov.nasa.esdis.umm.processinglevelid')
+    expect(updatedXml).not.toContain('<gco:CharacterString>3</gco:CharacterString>')
   })
 })

--- a/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
@@ -4,6 +4,7 @@ import {
   test
 } from 'vitest'
 
+import applyIso19115MetadataCorrections from '../applyIso19115MetadataCorrections'
 import { ISO_19115_SCHEME_EDITORS } from '../Iso19115DomEditor'
 import Iso19115MetadataPathEditor from '../Iso19115MetadataPathEditor'
 
@@ -329,6 +330,56 @@ const mockIso19115WithOneScienceKeyword = `
     </gmd:MD_DataIdentification>
   </gmd:identificationInfo>
 </gmi:MI_Metadata>`
+
+describe('applyIso19115MetadataCorrections', () => {
+  test('should handle missing corrections array gracefully', async () => {
+    const params = {
+      metadataPayload: '<gmi:MI_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"></gmi:MI_Metadata>'
+    }
+
+    const result = await applyIso19115MetadataCorrections(params)
+
+    expect(result.correctionCount).toBe(0)
+    expect(result.correctionsApplied).toEqual([])
+    expect(result.correctedMetadata).toBeDefined()
+  })
+
+  test('should return early when metadataPayload is missing', async () => {
+    const params = {
+      metadataPayload: undefined,
+      corrections: []
+    }
+
+    const result = await applyIso19115MetadataCorrections(params)
+
+    expect(result).toEqual({
+      correctionCount: 0,
+      correctedMetadata: undefined,
+      correctionsApplied: [],
+      stubbed: false
+    })
+  })
+
+  test('should skip corrections with unknown schemes', async () => {
+    const params = {
+      metadataPayload: '<gmi:MI_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"></gmi:MI_Metadata>',
+      corrections: [
+        {
+          scheme: 'invalid-scheme',
+          action: 'replace',
+          oldKeywordObject: { Value: 'test' },
+          newKeywordObject: { Value: 'new' }
+        }
+      ]
+    }
+
+    const result = await applyIso19115MetadataCorrections(params)
+
+    // The correction was invalid, so nothing should be applied
+    expect(result.correctionCount).toBe(0)
+    expect(result.correctionsApplied).toEqual([])
+  })
+})
 
 describe('when applying sciencekeywords ISO-19115 corrections', () => {
   test('should replace existing science keyword correctly', () => {

--- a/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
@@ -235,9 +235,9 @@ describe('when applying platforms ISO-19115 corrections', () => {
       action: 'replace',
       oldKeywordObject: { ShortName: 'AQUA' },
       newKeywordObject: {
-        ShortName: 'AQUA',
-        LongName: 'New Platform Description'
-      }
+        ShortName: 'AQUA'
+      },
+      newLongName: 'New Platform Description'
     }
 
     const config = ISO_19115_SCHEME_EDITORS.platforms
@@ -280,9 +280,9 @@ describe('when applying instruments ISO-19115 corrections', () => {
       action: 'replace',
       oldKeywordObject: { ShortName: 'MODIS' },
       newKeywordObject: {
-        ShortName: 'MODIS-1',
-        LongName: 'New Instrument Description'
-      }
+        ShortName: 'MODIS-1'
+      },
+      newLongName: 'New Instrument Description'
     }
 
     const config = ISO_19115_SCHEME_EDITORS.instruments

--- a/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
@@ -71,7 +71,7 @@ const mockIso19115 = `
               <gmd:citedResponsibleParty>
                 <gmd:CI_ResponsibleParty>
                   <gmd:organisationName>
-                    <gco:CharacterString>Global Change Data Center, Science and Exploration Directorate, Goddard Space Flight Center (GSFC) National Aeronautics and Space Administration (NASA)</gco:CharacterString>
+                    <gco:CharacterString>DOC/NOAA/NESDIS/NCEI &gt; National Centers for Environmental Information, NESDIS, NOAA, U.S. Department of Commerce</gco:CharacterString>
                   </gmd:organisationName>
                   <gmd:contactInfo>
                     <gmd:CI_Contact>

--- a/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
@@ -943,6 +943,56 @@ describe('when applying projects ISO-19115 corrections', () => {
     // For delete actions, the acquisition information would need to be handled separately
     // in the delete logic if that requirement exists. Currently testing the keyword deletion.
   })
+
+  test('removes synced MI_Operation when a project keyword is deleted', () => {
+    const mockIso19115ForProjectCleanup = `
+    <gmi:MI_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gco="http://www.isotc211.org/2005/gco">
+      <gmd:identificationInfo>
+        <gmd:MD_DataIdentification>
+          <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+              <gmd:keyword><gco:CharacterString>PROJ1</gco:CharacterString></gmd:keyword>
+              <gmd:type><gmd:MD_KeywordTypeCode codeListValue="project">project</gmd:MD_KeywordTypeCode></gmd:type>
+            </gmd:MD_Keywords>
+          </gmd:descriptiveKeywords>
+        </gmd:MD_DataIdentification>
+      </gmd:identificationInfo>
+      <gmi:acquisitionInformation>
+        <gmi:MI_AcquisitionInformation>
+          <gmi:operation>
+            <gmi:MI_Operation>
+              <gmi:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code><gco:CharacterString>PROJ1</gco:CharacterString></gmd:code>
+                  <gmd:codeSpace><gco:CharacterString>gov.nasa.esdis.umm.projectshortname</gco:CharacterString></gmd:codeSpace>
+                </gmd:MD_Identifier>
+              </gmi:identifier>
+            </gmi:MI_Operation>
+          </gmi:operation>
+        </gmi:MI_AcquisitionInformation>
+      </gmi:acquisitionInformation>
+    </gmi:MI_Metadata>
+  `
+
+    const editor = new Iso19115MetadataPathEditor(mockIso19115ForProjectCleanup)
+    const correction = {
+      scheme: 'projects',
+      action: 'delete',
+      oldKeywordObject: { ShortName: 'PROJ1' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.projects
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+    const updatedXml = editor.serialize()
+
+    // Verify project keyword is gone
+    expect(updatedXml).not.toContain('PROJ1')
+    // Verify the synced operation is gone
+    expect(updatedXml).not.toContain('MI_Operation')
+    expect(updatedXml).not.toContain('gov.nasa.esdis.umm.projectshortname')
+  })
 })
 
 describe('when applying isotopiccategory ISO-19115 corrections', () => {

--- a/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
@@ -756,6 +756,10 @@ describe('when applying productlevelid ISO-19115 corrections', () => {
     // Verify that the Identifier block is completely gone from both expected locations
     expect(updatedXml).not.toContain('gov.nasa.esdis.umm.processinglevelid')
     expect(updatedXml).not.toContain('<gco:CharacterString>3</gco:CharacterString>')
+
+    // Verify that parent wrappers are also removed
+    expect(updatedXml).not.toContain('<gmd:processingLevel>')
+    expect(updatedXml).not.toContain('<gmd:processingLevelCode>')
   })
 })
 

--- a/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
@@ -669,6 +669,282 @@ describe('when applying projects ISO-19115 corrections', () => {
   })
 })
 
+describe('when applying projects ISO-19115 corrections', () => {
+  // Create a more complete mock with acquisition information
+  const mockIso19115WithAcquisition = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:xlink="http://www.w3.org/1999/xlink" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>MEASURES > Making Earth System Data Records for Use in Research Environments</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="project">project</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Project Keywords</gco:CharacterString>
+              </gmd:title>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:operation>
+        <gmi:MI_Operation>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>MEASURES > Making Earth System Data Records for Use in Research Environments</gco:CharacterString>
+              </gmd:code>
+              <gmd:codeSpace>
+                <gco:CharacterString>gov.nasa.esdis.umm.projectshortname</gco:CharacterString>
+              </gmd:codeSpace>
+              <gmd:description>
+                <gco:CharacterString>Making Earth System Data Records for Use in Research Environments</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </gmi:MI_Operation>
+      </gmi:operation>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+  test('should replace existing project keyword correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+
+    const correction = {
+      scheme: 'projects',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'MEASURES' },
+      newKeywordObject: {
+        ShortName: 'MEASURES-1'
+      },
+      newLongName: 'New Project Description'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.projects
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+    expect(updatedXml).toContain('MEASURES-1 &gt; New Project Description')
+    expect(updatedXml).not.toContain('MEASURES &gt; Making Earth System Data Records for Use in Research Environments')
+  })
+
+  test('should replace project keyword and sync acquisition information', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithAcquisition)
+
+    const correction = {
+      scheme: 'projects',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'MEASURES' },
+      newKeywordObject: {
+        ShortName: 'MEASURES-1'
+      },
+      newLongName: 'New Project Description'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.projects
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Verify keyword block was updated
+    expect(updatedXml).toContain('MEASURES-1 &gt; New Project Description')
+    expect(updatedXml).not.toContain('MEASURES &gt; Making Earth System Data Records for Use in Research Environments')
+
+    // Verify acquisition MI_Operation code was updated
+    expect(updatedXml).toMatch(
+      /<gmi:MI_Operation>[\s\S]*?<gmd:code>[\s\S]*?<gco:CharacterString>MEASURES-1 &gt; New Project Description<\/gco:CharacterString>[\s\S]*?<\/gmd:code>[\s\S]*?<gmd:codeSpace>[\s\S]*?<gco:CharacterString>gov\.nasa\.esdis\.umm\.projectshortname<\/gco:CharacterString>/
+    )
+
+    // Verify acquisition MI_Operation description was updated
+    expect(updatedXml).toMatch(
+      /<gmi:MI_Operation>[\s\S]*?<gmd:description>[\s\S]*?<gco:CharacterString>New Project Description<\/gco:CharacterString>[\s\S]*?<\/gmd:description>/
+    )
+  })
+
+  test('should handle project with only ShortName (no LongName)', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithAcquisition)
+
+    const correction = {
+      scheme: 'projects',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'MEASURES' },
+      newKeywordObject: {
+        ShortName: 'MEASURES-2'
+      }
+      // No newLongName provided
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.projects
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Should use ShortName only (no " > LongName")
+    expect(updatedXml).toContain('<gco:CharacterString>MEASURES-2</gco:CharacterString>')
+    expect(updatedXml).not.toContain('MEASURES-2 &gt;')
+
+    // Verify acquisition code was updated to ShortName only
+    expect(updatedXml).toMatch(
+      /<gmi:MI_Operation>[\s\S]*?<gmd:code>[\s\S]*?<gco:CharacterString>MEASURES-2<\/gco:CharacterString>[\s\S]*?<\/gmd:code>/
+    )
+  })
+
+  test('should not update unrelated acquisition operations', () => {
+    const xmlWithMultipleOperations = `
+<gmi:MI_Metadata 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>MEASURES > Old Description</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="project">project</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:operation>
+        <gmi:MI_Operation>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>MEASURES > Old Description</gco:CharacterString>
+              </gmd:code>
+              <gmd:codeSpace>
+                <gco:CharacterString>gov.nasa.esdis.umm.projectshortname</gco:CharacterString>
+              </gmd:codeSpace>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </gmi:MI_Operation>
+      </gmi:operation>
+      <gmi:operation>
+        <gmi:MI_Operation>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>MEASURES > Different Operation</gco:CharacterString>
+              </gmd:code>
+              <gmd:codeSpace>
+                <gco:CharacterString>some.other.identifier.type</gco:CharacterString>
+              </gmd:codeSpace>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </gmi:MI_Operation>
+      </gmi:operation>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(xmlWithMultipleOperations)
+
+    const correction = {
+      scheme: 'projects',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'MEASURES' },
+      newKeywordObject: { ShortName: 'MEASURES-1' },
+      newLongName: 'New Description'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.projects
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Verify keyword block was updated
+    expect(updatedXml).toContain('MEASURES-1 &gt; New Description')
+    expect(updatedXml).not.toContain('MEASURES &gt; Old Description')
+
+    // Verify the project operation with correct codeSpace was updated
+    // Use a more flexible regex that doesn't depend on element order
+    expect(updatedXml).toMatch(
+      /<gmi:MI_Operation>[\s\S]*?<gmd:MD_Identifier>[\s\S]*?<gmd:code>[\s\S]*?<gco:CharacterString>MEASURES-1 &gt; New Description<\/gco:CharacterString>[\s\S]*?<\/gmd:code>[\s\S]*?<gmd:codeSpace>[\s\S]*?<gco:CharacterString>gov\.nasa\.esdis\.umm\.projectshortname<\/gco:CharacterString>[\s\S]*?<\/gmd:codeSpace>[\s\S]*?<\/gmd:MD_Identifier>[\s\S]*?<\/gmi:MI_Operation>/
+    )
+
+    // Verify the operation has the correct codeSpace
+    expect(updatedXml).toContain('gov.nasa.esdis.umm.projectshortname')
+
+    // Unrelated operation (different codeSpace) should NOT be changed
+    expect(updatedXml).toContain('some.other.identifier.type')
+    expect(updatedXml).toContain('MEASURES &gt; Different Operation')
+  })
+
+  test('should delete existing project keyword block correctly', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+    const correction = {
+      scheme: 'projects',
+      action: 'delete',
+      oldKeywordObject: { ShortName: 'MEASURES' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.projects
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    // Verify the specific keyword is gone
+    const updatedXml = editor.serialize()
+    expect(updatedXml).not.toContain('MEASURES &gt; Making Earth System Data Records for Use in Research Environments')
+    expect(updatedXml).toContain('MAGIA &gt; Structure, Stratigraphy, and Sedimentology North of the Antarctic Peninsula')
+  })
+
+  test('should delete project and remove from acquisition information', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithAcquisition)
+
+    const correction = {
+      scheme: 'projects',
+      action: 'delete',
+      oldKeywordObject: { ShortName: 'MEASURES' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.projects
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword should be removed
+    expect(updatedXml).not.toContain('MEASURES &gt; Making Earth System Data Records for Use in Research Environments')
+
+    // Note: The current implementation only handles updates via additionalPaths on replace actions.
+    // For delete actions, the acquisition information would need to be handled separately
+    // in the delete logic if that requirement exists. Currently testing the keyword deletion.
+  })
+})
+
 describe('when applying isotopiccategory ISO-19115 corrections', () => {
   test('should replace existing isotopiccategory correctly', () => {
     const editor = new Iso19115MetadataPathEditor(mockIso19115)

--- a/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
@@ -805,4 +805,113 @@ describe('when applying providers ISO-19115 corrections', () => {
     expect(updatedXml).not.toContain('DOC/NOAA/NESDIS/NCEI &gt; National Centers for Environmental Information, NESDIS, NOAA, U.S. Department of Commerce')
     expect(updatedXml).toContain('DOC/NOAA/NESDIS/NODC &gt; National Oceanographic Data Center, NESDIS, NOAA, U.S. Department of Commerce')
   })
+
+  test('should use fallback getValue with NONE for missing fieldKeys in science keywords', () => {
+    // This test covers the fallback getValue function (lines 58-61 and conceptually 70-71)
+    // getValue || (({ correction }) => fieldKeys.map((k) => correction.newKeywordObject[k] || 'NONE').join(' > '))
+    // Note: Lines 70-71 (in additionalPaths.map) use the same fallback logic but are not hit by
+    // current schemes since all schemes with additionalPaths also provide custom getValue.
+    // This test covers the main keyword block fallback which uses identical logic.
+    // For sciencekeywords, NO custom getValue is provided, so it uses the default fallback
+
+    const editor = new Iso19115MetadataPathEditor(mockIso19115)
+
+    // Provide incomplete science keyword - missing some hierarchy levels
+    const correction = {
+      scheme: 'sciencekeywords',
+      action: 'replace',
+      oldKeywordObject: {
+        Category: 'EARTH SCIENCE',
+        Topic: 'ATMOSPHERE',
+        Term: 'AEROSOLS',
+        VariableLevel1: '',
+        VariableLevel2: '',
+        VariableLevel3: '',
+        DetailedVariable: ''
+      },
+      newKeywordObject: {
+        Category: 'EARTH SCIENCE',
+        Topic: 'BIOSPHERE'
+        // Deliberately omitting Term, VariableLevel1, etc. to trigger || 'NONE' fallback
+        // The fallback function will map each missing field to 'NONE'
+      }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.sciencekeywords
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // The fallback getValue function (lines 70-71) will create:
+    // fieldKeys.map((k) => correction.newKeywordObject[k] || 'NONE').join(' > ')
+    // With fieldKeys = ['Category', 'Topic', 'Term', 'VariableLevel1', 'VariableLevel2', 'VariableLevel3', 'DetailedVariable']
+    // Result: 'EARTH SCIENCE > BIOSPHERE > NONE > NONE > NONE > NONE > NONE'
+    expect(updatedXml).toContain('EARTH SCIENCE &gt; BIOSPHERE &gt; NONE &gt; NONE &gt; NONE &gt; NONE &gt; NONE')
+  })
+
+  test('should handle providers with missing LongName in both keyword and CI_ResponsibleParty', () => {
+    // Test that verifies the getValue logic propagates correctly to additionalPaths
+    // For providers: getValue is provided, so additionalPaths will use that getValue (not the fallback)
+    const xmlWithResponsibleParty = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>NASA/JPL &gt; Jet Propulsion Laboratory</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="dataCentre">dataCentre</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:contact>
+    <gmd:CI_ResponsibleParty>
+      <gmd:organisationName>
+        <gco:CharacterString>NASA/JPL &gt; Jet Propulsion Laboratory</gco:CharacterString>
+      </gmd:organisationName>
+      <gmd:role>
+        <gmd:CI_RoleCode codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+      </gmd:role>
+    </gmd:CI_ResponsibleParty>
+  </gmd:contact>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(xmlWithResponsibleParty)
+
+    const correction = {
+      scheme: 'providers',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'NASA/JPL' },
+      newKeywordObject: {
+        ShortName: 'NASA/JPL/CALTECH'
+      },
+      newLongName: 'Jet Propulsion Laboratory, California Institute of Technology'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.providers
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Both keyword and organisationName should be updated consistently
+    expect(updatedXml).toContain('NASA/JPL/CALTECH &gt; Jet Propulsion Laboratory, California Institute of Technology')
+
+    // Verify organisationName in CI_ResponsibleParty was also updated
+    expect(updatedXml).toMatch(/<gmd:organisationName>\s*<gco:CharacterString>NASA\/JPL\/CALTECH &gt; Jet Propulsion Laboratory, California Institute of Technology<\/gco:CharacterString>/)
+  })
 })

--- a/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115MetadataCorrections.test.js
@@ -71,7 +71,7 @@ const mockIso19115 = `
               <gmd:citedResponsibleParty>
                 <gmd:CI_ResponsibleParty>
                   <gmd:organisationName>
-                    <gco:CharacterString>DOC/NOAA/NESDIS/NCEI &gt; National Centers for Environmental Information, NESDIS, NOAA, U.S. Department of Commerce</gco:CharacterString>
+                    <gco:CharacterString>DOC/NOAA/NESDIS/NCEI/R &gt; National Centers for Environmental Information, NESDIS, NOAA, U.S. Department of Commerce</gco:CharacterString>
                   </gmd:organisationName>
                   <gmd:contactInfo>
                     <gmd:CI_Contact>
@@ -849,69 +849,5 @@ describe('when applying providers ISO-19115 corrections', () => {
     // With fieldKeys = ['Category', 'Topic', 'Term', 'VariableLevel1', 'VariableLevel2', 'VariableLevel3', 'DetailedVariable']
     // Result: 'EARTH SCIENCE > BIOSPHERE > NONE > NONE > NONE > NONE > NONE'
     expect(updatedXml).toContain('EARTH SCIENCE &gt; BIOSPHERE &gt; NONE &gt; NONE &gt; NONE &gt; NONE &gt; NONE')
-  })
-
-  test('should handle providers with missing LongName in both keyword and CI_ResponsibleParty', () => {
-    // Test that verifies the getValue logic propagates correctly to additionalPaths
-    // For providers: getValue is provided, so additionalPaths will use that getValue (not the fallback)
-    const xmlWithResponsibleParty = `
-<gmi:MI_Metadata 
-  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
-  xmlns:gco="http://www.isotc211.org/2005/gco" 
-  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
-  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
-  xmlns:gml="http://www.opengis.net/gml/3.2" 
-  xmlns:gmx="http://www.isotc211.org/2005/gmx"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
-  <gmd:identificationInfo>
-    <gmd:MD_DataIdentification>
-      <gmd:descriptiveKeywords>
-        <gmd:MD_Keywords>
-          <gmd:keyword>
-            <gco:CharacterString>NASA/JPL &gt; Jet Propulsion Laboratory</gco:CharacterString>
-          </gmd:keyword>
-          <gmd:type>
-            <gmd:MD_KeywordTypeCode codeListValue="dataCentre">dataCentre</gmd:MD_KeywordTypeCode>
-          </gmd:type>
-        </gmd:MD_Keywords>
-      </gmd:descriptiveKeywords>
-    </gmd:MD_DataIdentification>
-  </gmd:identificationInfo>
-  <gmd:contact>
-    <gmd:CI_ResponsibleParty>
-      <gmd:organisationName>
-        <gco:CharacterString>NASA/JPL &gt; Jet Propulsion Laboratory</gco:CharacterString>
-      </gmd:organisationName>
-      <gmd:role>
-        <gmd:CI_RoleCode codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
-      </gmd:role>
-    </gmd:CI_ResponsibleParty>
-  </gmd:contact>
-</gmi:MI_Metadata>`
-
-    const editor = new Iso19115MetadataPathEditor(xmlWithResponsibleParty)
-
-    const correction = {
-      scheme: 'providers',
-      action: 'replace',
-      oldKeywordObject: { ShortName: 'NASA/JPL' },
-      newKeywordObject: {
-        ShortName: 'NASA/JPL/CALTECH'
-      },
-      newLongName: 'Jet Propulsion Laboratory, California Institute of Technology'
-    }
-
-    const config = ISO_19115_SCHEME_EDITORS.providers
-    const success = config(editor, correction)
-
-    expect(success).toBe(true)
-
-    const updatedXml = editor.serialize()
-
-    // Both keyword and organisationName should be updated consistently
-    expect(updatedXml).toContain('NASA/JPL/CALTECH &gt; Jet Propulsion Laboratory, California Institute of Technology')
-
-    // Verify organisationName in CI_ResponsibleParty was also updated
-    expect(updatedXml).toMatch(/<gmd:organisationName>\s*<gco:CharacterString>NASA\/JPL\/CALTECH &gt; Jet Propulsion Laboratory, California Institute of Technology<\/gco:CharacterString>/)
   })
 })

--- a/serverless/src/shared/__tests__/applyIso19115PlatformsCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115PlatformsCorrections.test.js
@@ -1389,4 +1389,225 @@ describe('Platform corrections with synchronized keyword blocks and acquisition 
     expect(updatedXml).toMatch(/xmlns:gmd="http:\/\/www.isotc211.org\/2005\/gmd"/)
     expect(updatedXml).toMatch(/xmlns:gmi="http:\/\/www.isotc211.org\/2005\/gmi"/)
   })
+
+  test('should detect combined format in acquisition code and update accordingly', () => {
+    // Test coverage for: if (existingValue.includes(' > '))
+    const xmlWithCombinedFormat = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>NOAA-20 &gt; NOAA-20</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:platform>
+        <eos:EOS_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>NOAA-20 &gt; NOAA-20</gco:CharacterString>
+              </gmd:code>
+              <gmd:description>
+                <gco:CharacterString>Custom description text</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </eos:EOS_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(xmlWithCombinedFormat)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'NOAA-20' },
+      newKeywordObject: { ShortName: 'NOAA-21' },
+      newLongName: 'NOAA-21 Satellite'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword block updated
+    expect(updatedXml).toContain('NOAA-21 &gt; NOAA-21 Satellite')
+
+    // CRITICAL: Code should use combined format because existing code includes ' > '
+    // This covers the if (existingValue.includes(' > ')) branch
+    expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>NOAA-21 &gt; NOAA-21 Satellite<\/gco:CharacterString>/)
+
+    // Description should be preserved (CWIC format)
+    expect(updatedXml).toContain('Custom description text')
+  })
+
+  test('should use combined format with empty LongName when existing code has delimiter', () => {
+    // Test coverage for: if (existingValue.includes(' > ')) with LongName being falsy
+    // This tests: return LongName ? `${ShortName} > ${LongName}` : ShortName
+    const xmlWithDelimiter = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>GOES-16 &gt; Geostationary Operational Environmental Satellite-16</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:platform>
+        <gmi:MI_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>GOES-16 &gt; Geostationary Operational Environmental Satellite-16</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </gmi:MI_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(xmlWithDelimiter)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'GOES-16' },
+      newKeywordObject: { ShortName: 'GOES-17' }
+      // No newLongName - testing the ternary with falsy LongName
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword block updated with just ShortName (no LongName provided)
+    expect(updatedXml).toContain('<gco:CharacterString>GOES-17</gco:CharacterString>')
+
+    // Code detected ' > ' in existing value, enters if branch
+    // But LongName is falsy, so ternary returns just ShortName
+    // This covers: const { ShortName } = correction.newKeywordObject
+    // and: return LongName ? `${ShortName} > ${LongName}` : ShortName
+    expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>GOES-17<\/gco:CharacterString>/)
+  })
+
+  test('should handle both EOS_Platform and MI_Platform with combined format detection', () => {
+    // Test coverage for both namespace variants with includes(' > ') check
+    const mixedXml = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>METOP-A &gt; Meteorological Operational Satellite-A</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:platform>
+        <eos:EOS_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>METOP-A &gt; Meteorological Operational Satellite-A</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </eos:EOS_Platform>
+      </gmi:platform>
+      <gmi:platform>
+        <gmi:MI_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>METOP-A &gt; Meteorological Operational Satellite-A</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </gmi:MI_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(mixedXml)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'METOP-A' },
+      newKeywordObject: { ShortName: 'METOP-B' },
+      newLongName: 'Meteorological Operational Satellite-B'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword updated
+    expect(updatedXml).toContain('METOP-B &gt; Meteorological Operational Satellite-B')
+
+    // Both EOS_Platform and MI_Platform should detect ' > ' and use combined format
+    expect(updatedXml).toMatch(/<eos:EOS_Platform>[\s\S]*?<gmd:code>\s*<gco:CharacterString>METOP-B &gt; Meteorological Operational Satellite-B<\/gco:CharacterString>/)
+    expect(updatedXml).toMatch(/<gmi:MI_Platform>[\s\S]*?<gmd:code>\s*<gco:CharacterString>METOP-B &gt; Meteorological Operational Satellite-B<\/gco:CharacterString>/)
+  })
 })

--- a/serverless/src/shared/__tests__/applyIso19115PlatformsCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115PlatformsCorrections.test.js
@@ -1,0 +1,1219 @@
+import {
+  describe,
+  expect,
+  test
+} from 'vitest'
+
+import { ISO_19115_SCHEME_EDITORS } from '../Iso19115DomEditor'
+import Iso19115MetadataPathEditor from '../Iso19115MetadataPathEditor'
+
+const mockIso19115 = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>TERRA &gt; Earth Observing System, TERRA (AM-1)</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>AQUA &gt; Earth Observing System</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Platform Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2016-06-10</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmi:MI_Metadata>`
+
+// ============================================================================
+// PLATFORM TESTS WITH ACQUISITION INFORMATION
+// Comprehensive tests for platforms across all data center formats
+// ============================================================================
+
+// Mock XML with NSIDC format (ISO MENDS compliant)
+// ShortName in gmd:code, LongName in gmd:description
+const mockIso19115WithNSIDCAcquisition = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>ICESat-2 &gt; Ice, Cloud, and land Elevation Satellite-2</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>ATLAS &gt; Advanced Topographic Laser Altimeter System</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="instrument">instrument</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:instrument>
+        <eos:EOS_Instrument id="_ATLAS">
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>ATLAS</gco:CharacterString>
+              </gmd:code>
+              <gmd:codeSpace>
+                <gco:CharacterString>gov.nasa.esdis.umm.instrumentshortname</gco:CharacterString>
+              </gmd:codeSpace>
+              <gmd:description>
+                <gco:CharacterString>Advanced Topographic Laser Altimeter System</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:type>
+            <gco:CharacterString>instrument</gco:CharacterString>
+          </gmi:type>
+        </eos:EOS_Instrument>
+      </gmi:instrument>
+      <gmi:platform>
+        <eos:EOS_Platform id="_ICESat-2">
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>ICESat-2</gco:CharacterString>
+              </gmd:code>
+              <gmd:codeSpace>
+                <gco:CharacterString>gov.nasa.esdis.umm.platformshortname</gco:CharacterString>
+              </gmd:codeSpace>
+              <gmd:description>
+                <gco:CharacterString>Ice, Cloud, and land Elevation Satellite-2</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:description>
+            <gco:CharacterString>Earth Observation Satellites</gco:CharacterString>
+          </gmi:description>
+          <gmi:instrument xlink:href="#_ATLAS"/>
+        </eos:EOS_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+// Mock XML with CWIC format (non-compliant)
+// Combined "ShortName > LongName" in gmd:code
+const mockIso19115WithCWICAcquisition = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>AQUA &gt; Earth Observing System, AQUA</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>AMSR-E &gt; Advanced Microwave Scanning Radiometer-EOS</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="instrument">instrument</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:instrument>
+        <gmi:MI_Instrument>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>AMSR-E &gt; Advanced Microwave Scanning Radiometer-EOS</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:type>
+            <gco:CharacterString>sensor</gco:CharacterString>
+          </gmi:type>
+          <gmi:description>
+            <gco:CharacterString>The Advanced Microwave Scanning Radiometer for EOS (AMSR-E) is a twelve-channel, six-frequency, total power passive-microwave radiometer system.</gco:CharacterString>
+          </gmi:description>
+        </gmi:MI_Instrument>
+      </gmi:instrument>
+      <gmi:platform>
+        <gmi:MI_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>AQUA &gt; Earth Observing System, AQUA</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:description>
+            <gco:CharacterString>Aqua is a NASA polar orbiting mission designed to collect information on the Earth's atmospheric, land and ocean systems.</gco:CharacterString>
+          </gmi:description>
+        </gmi:MI_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+// Mock XML with NOAA format (simple format)
+// ShortName only in gmd:code, free-text in gmd:description
+const mockIso19115WithNOAAAcquisition = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>NAGASAKI-MARU</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>net - zooplankton net</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="instrument">instrument</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:instrument>
+        <gmi:MI_Instrument>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>net - zooplankton net</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:type>
+            <gco:CharacterString>net - zooplankton net</gco:CharacterString>
+          </gmi:type>
+          <gmi:description>
+            <gco:CharacterString>net - zooplankton net</gco:CharacterString>
+          </gmi:description>
+        </gmi:MI_Instrument>
+      </gmi:instrument>
+      <gmi:platform>
+        <gmi:MI_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>NAGASAKI-MARU</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:description>
+            <gco:CharacterString>Additional information from ICES for the vessel NAGASAKI-MARU from JAPAN.</gco:CharacterString>
+          </gmi:description>
+        </gmi:MI_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+describe('Platform corrections with acquisition information', () => {
+  describe('NSIDC format (split: ShortName in code, LongName in description)', () => {
+    test('should update keyword block and both acquisition paths correctly', () => {
+      const editor = new Iso19115MetadataPathEditor(mockIso19115WithNSIDCAcquisition)
+
+      const correction = {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: { ShortName: 'ICESat-2' },
+        newKeywordObject: { ShortName: 'ICESat-3' },
+        newLongName: 'Ice, Cloud, and land Elevation Satellite-3'
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      const success = config(editor, correction)
+
+      expect(success).toBe(true)
+
+      const updatedXml = editor.serialize()
+
+      // 1. Verify keyword block updated
+      expect(updatedXml).toContain('ICESat-3 &gt; Ice, Cloud, and land Elevation Satellite-3')
+      expect(updatedXml).not.toContain('ICESat-2 &gt; Ice, Cloud, and land Elevation Satellite-2')
+
+      // 2. Verify acquisition gmd:code updated (ShortName only)
+      expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>ICESat-3<\/gco:CharacterString>\s*<\/gmd:code>/)
+
+      // 3. Verify acquisition gmd:description updated (LongName only)
+      expect(updatedXml).toMatch(/<gmd:description>\s*<gco:CharacterString>Ice, Cloud, and land Elevation Satellite-3<\/gco:CharacterString>/)
+    })
+
+    test('should preserve platformshortname codeSpace', () => {
+      const editor = new Iso19115MetadataPathEditor(mockIso19115WithNSIDCAcquisition)
+
+      const correction = {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: { ShortName: 'ICESat-2' },
+        newKeywordObject: { ShortName: 'ICESat-3' },
+        newLongName: 'Ice, Cloud, and land Elevation Satellite-3'
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      config(editor, correction)
+
+      const updatedXml = editor.serialize()
+      expect(updatedXml).toContain('gov.nasa.esdis.umm.platformshortname')
+    })
+
+    test('should handle platform with only ShortName (no LongName)', () => {
+      const editor = new Iso19115MetadataPathEditor(mockIso19115WithNSIDCAcquisition)
+
+      const correction = {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: { ShortName: 'ICESat-2' },
+        newKeywordObject: { ShortName: 'ICESat-3' }
+        // No newLongName provided
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      const success = config(editor, correction)
+
+      expect(success).toBe(true)
+
+      const updatedXml = editor.serialize()
+
+      // Keyword block should have just ShortName
+      expect(updatedXml).toContain('<gco:CharacterString>ICESat-3</gco:CharacterString>')
+      // Acquisition code should be updated
+      expect(updatedXml).toContain('gov.nasa.esdis.umm.platformshortname')
+      expect(updatedXml).toMatch(/<eos:EOS_Platform[\s\S]*?<gmd:code>\s*<gco:CharacterString>ICESat-3<\/gco:CharacterString>/)
+    })
+
+    test('should delete platform from both keyword block and acquisition section', () => {
+      const editor = new Iso19115MetadataPathEditor(mockIso19115WithNSIDCAcquisition)
+
+      const correction = {
+        scheme: 'platforms',
+        action: 'delete',
+        oldKeywordObject: { ShortName: 'ICESat-2' }
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      const success = config(editor, correction)
+
+      expect(success).toBe(true)
+
+      const updatedXml = editor.serialize()
+
+      // Keyword block should be gone
+      expect(updatedXml).not.toContain('ICESat-2 &gt; Ice, Cloud, and land Elevation Satellite-2')
+
+      // Acquisition platform should also be deleted
+      expect(updatedXml).not.toContain('<eos:EOS_Platform id="_ICESat-2">')
+      expect(updatedXml).not.toContain('ICESat-2</gco:CharacterString>')
+
+      // But acquisition section and instrument should remain
+      expect(updatedXml).toContain('gmi:acquisitionInformation')
+      expect(updatedXml).toContain('eos:EOS_Instrument')
+    })
+  })
+
+  describe('CWIC format (combined: ShortName > LongName in code)', () => {
+    test('should detect and preserve combined format in gmd:code', () => {
+      const editor = new Iso19115MetadataPathEditor(mockIso19115WithCWICAcquisition)
+
+      const correction = {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: { ShortName: 'AQUA' },
+        newKeywordObject: { ShortName: 'AQUA-2' },
+        newLongName: 'Earth Observing System, AQUA Version 2'
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      const success = config(editor, correction)
+
+      expect(success).toBe(true)
+
+      const updatedXml = editor.serialize()
+
+      // 1. Verify keyword block updated
+      expect(updatedXml).toContain('AQUA-2 &gt; Earth Observing System, AQUA Version 2')
+
+      // 2. Verify acquisition gmd:code uses combined format (detected ' > ' in existing)
+      expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>AQUA-2 &gt; Earth Observing System, AQUA Version 2<\/gco:CharacterString>\s*<\/gmd:code>/)
+
+      // 3. Verify acquisition gmd:description preserved (free-text not overwritten)
+      expect(updatedXml).toContain('Aqua is a NASA polar orbiting mission designed to collect information on the Earth\'s atmospheric, land and ocean systems.')
+    })
+
+    test('should not overwrite free-text description in CWIC format', () => {
+      const editor = new Iso19115MetadataPathEditor(mockIso19115WithCWICAcquisition)
+
+      const correction = {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: { ShortName: 'AQUA' },
+        newKeywordObject: { ShortName: 'AQUA-2' },
+        newLongName: 'Earth Observing System, AQUA Version 2'
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      config(editor, correction)
+
+      const updatedXml = editor.serialize()
+
+      // Free-text description should remain unchanged
+      expect(updatedXml).toContain('Aqua is a NASA polar orbiting mission')
+    })
+  })
+
+  describe('NOAA format (simple: ShortName only in code)', () => {
+    test('should update keyword block and acquisition gmd:code', () => {
+      const editor = new Iso19115MetadataPathEditor(mockIso19115WithNOAAAcquisition)
+
+      const correction = {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: { ShortName: 'NAGASAKI-MARU' },
+        newKeywordObject: { ShortName: 'NAGASAKI-MARU-2' },
+        newLongName: 'Updated Vessel Name'
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      const success = config(editor, correction)
+
+      expect(success).toBe(true)
+
+      const updatedXml = editor.serialize()
+
+      // 1. Verify keyword block updated (will include LongName if provided)
+      expect(updatedXml).toContain('NAGASAKI-MARU-2 &gt; Updated Vessel Name')
+
+      // 2. Verify acquisition gmd:code updated (ShortName only - split format)
+      expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>NAGASAKI-MARU-2<\/gco:CharacterString>/)
+
+      // 3. NOAA format doesn't have gmd:description in gmd:identifier,
+      // so the free-text gmi:description at platform level is preserved
+      expect(updatedXml).toContain('Additional information from ICES for the vessel NAGASAKI-MARU from JAPAN.')
+    })
+
+    test('should handle platforms with no LongName', () => {
+      const editor = new Iso19115MetadataPathEditor(mockIso19115WithNOAAAcquisition)
+
+      const correction = {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: { ShortName: 'NAGASAKI-MARU' },
+        newKeywordObject: { ShortName: 'NAGASAKI-MARU-2' }
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      const success = config(editor, correction)
+
+      expect(success).toBe(true)
+
+      const updatedXml = editor.serialize()
+
+      // Keyword block should just have ShortName
+      expect(updatedXml).toContain('<gco:CharacterString>NAGASAKI-MARU-2</gco:CharacterString>')
+
+      // Acquisition gmd:code should be updated
+      expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>NAGASAKI-MARU-2<\/gco:CharacterString>/)
+    })
+  })
+
+  describe('without acquisition information', () => {
+    test('should handle missing acquisition section gracefully', () => {
+      const editor = new Iso19115MetadataPathEditor(mockIso19115)
+
+      const correction = {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: { ShortName: 'AQUA' },
+        newKeywordObject: { ShortName: 'AQUA-2' },
+        newLongName: 'New Description'
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      const success = config(editor, correction)
+
+      expect(success).toBe(true)
+
+      const updatedXml = editor.serialize()
+
+      // Only keyword block should be updated
+      expect(updatedXml).toContain('AQUA-2 &gt; New Description')
+
+      // No acquisition section to update
+      expect(updatedXml).not.toContain('gmi:acquisitionInformation')
+    })
+
+    test('should replace existing platform keyword correctly', () => {
+      const editor = new Iso19115MetadataPathEditor(mockIso19115)
+
+      const correction = {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: { ShortName: 'AQUA' },
+        newKeywordObject: {
+          ShortName: 'AQUA'
+        },
+        newLongName: 'New Platform Description'
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      const success = config(editor, correction)
+
+      expect(success).toBe(true)
+
+      const updatedXml = editor.serialize()
+      expect(updatedXml).toContain('AQUA &gt; New Platform Description')
+      expect(updatedXml).not.toContain('AQUA &gt; Earth Observing System')
+    })
+
+    test('should delete existing platform keyword block correctly', () => {
+      const editor = new Iso19115MetadataPathEditor(mockIso19115)
+      const correction = {
+        scheme: 'platforms',
+        action: 'delete',
+        oldKeywordObject: { ShortName: 'AQUA' }
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      const success = config(editor, correction)
+
+      expect(success).toBe(true)
+
+      // Verify the specific keyword is gone
+      const updatedXml = editor.serialize()
+      expect(updatedXml).not.toContain('AQUA &gt; Earth Observing System, AQUA')
+      expect(updatedXml).toContain('TERRA &gt; Earth Observing System, TERRA (AM-1)')
+    })
+  })
+
+  describe('mixed namespace formats', () => {
+    test('should handle both EOS and MI namespaces', () => {
+      const mixedNamespaceXml = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>TEST-PLATFORM &gt; Test Platform</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:platform>
+        <eos:EOS_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>TEST-PLATFORM</gco:CharacterString>
+              </gmd:code>
+              <gmd:description>
+                <gco:CharacterString>Test Platform</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </eos:EOS_Platform>
+      </gmi:platform>
+      <gmi:platform>
+        <gmi:MI_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>TEST-PLATFORM</gco:CharacterString>
+              </gmd:code>
+              <gmd:description>
+                <gco:CharacterString>Test Platform</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </gmi:MI_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+      const editor = new Iso19115MetadataPathEditor(mixedNamespaceXml)
+
+      const correction = {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: { ShortName: 'TEST-PLATFORM' },
+        newKeywordObject: { ShortName: 'TEST-PLATFORM-2' },
+        newLongName: 'Updated Test Platform'
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      const success = config(editor, correction)
+
+      expect(success).toBe(true)
+
+      const updatedXml = editor.serialize()
+
+      // All three locations should be updated
+      // 1. Keyword block
+      expect(updatedXml).toContain('TEST-PLATFORM-2 &gt; Updated Test Platform')
+
+      // 2. EOS_Platform
+      const eosMatches = updatedXml.match(/eos:EOS_Platform[\s\S]*?<gmd:code>\s*<gco:CharacterString>TEST-PLATFORM-2<\/gco:CharacterString>/)
+      expect(eosMatches).toBeTruthy()
+
+      // 3. MI_Platform
+      const miMatches = updatedXml.match(/gmi:MI_Platform[\s\S]*?<gmd:code>\s*<gco:CharacterString>TEST-PLATFORM-2<\/gco:CharacterString>/)
+      expect(miMatches).toBeTruthy()
+    })
+  })
+
+  describe('edge cases', () => {
+    test('should correctly detect format when code contains > in text', () => {
+      const edgeCaseXml = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos"
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>SPECIAL&gt;PLATFORM &gt; With Greater Than</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:platform>
+        <gmi:MI_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>SPECIAL&gt;PLATFORM &gt; With Greater Than</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:description>
+            <gco:CharacterString>Free text description</gco:CharacterString>
+          </gmi:description>
+        </gmi:MI_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+      const editor = new Iso19115MetadataPathEditor(edgeCaseXml)
+
+      const correction = {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: { ShortName: 'SPECIAL>PLATFORM' },
+        newKeywordObject: { ShortName: 'SPECIAL>PLATFORM-2' },
+        newLongName: 'With Greater Than Updated'
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      const success = config(editor, correction)
+
+      expect(success).toBe(true)
+
+      const updatedXml = editor.serialize()
+
+      // Should detect combined format and preserve it
+      expect(updatedXml).toContain('SPECIAL&gt;PLATFORM-2 &gt; With Greater Than Updated')
+
+      // Free text description should be preserved
+      expect(updatedXml).toContain('Free text description')
+    })
+
+    test('should handle whitespace variations around delimiter', () => {
+      // Note: Keywords with '>' but without spaces (e.g., 'PLATFORM>Long Name')
+      // don't split properly since we split on ' > ' with spaces.
+      // This test uses proper formatting with spaces.
+      const whitespaceXml = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos"
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>PLATFORM &gt; Long Name</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:platform>
+        <gmi:MI_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>PLATFORM &gt; Long Name</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </gmi:MI_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+      const editor = new Iso19115MetadataPathEditor(whitespaceXml)
+
+      const correction = {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: { ShortName: 'PLATFORM' },
+        newKeywordObject: { ShortName: 'PLATFORM-2' },
+        newLongName: 'Updated Long Name'
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      const success = config(editor, correction)
+
+      expect(success).toBe(true)
+
+      const updatedXml = editor.serialize()
+
+      // The keyword block should be updated
+      expect(updatedXml).toContain('PLATFORM-2 &gt; Updated Long Name')
+
+      // Acquisition code detects ' > ' and preserves combined format
+      expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>PLATFORM-2 &gt; Updated Long Name<\/gco:CharacterString>/)
+    })
+
+    test('should handle empty string LongName', () => {
+      const editor = new Iso19115MetadataPathEditor(mockIso19115WithNSIDCAcquisition)
+
+      const correction = {
+        scheme: 'platforms',
+        action: 'replace',
+        oldKeywordObject: { ShortName: 'ICESat-2' },
+        newKeywordObject: { ShortName: 'ICESat-3' },
+        newLongName: ''
+      }
+
+      const config = ISO_19115_SCHEME_EDITORS.platforms
+      const success = config(editor, correction)
+
+      expect(success).toBe(true)
+
+      const updatedXml = editor.serialize()
+
+      // Keyword block should have just ShortName when LongName is empty
+      expect(updatedXml).toMatch(/<gmd:keyword>\s*<gco:CharacterString>ICESat-3<\/gco:CharacterString>/)
+    })
+  })
+})
+
+// Mock with BOTH keyword blocks AND NSIDC acquisition information
+// Tests synchronization between the two sections for the same platforms
+const mockIso19115WithKeywordsAndAcquisition = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>TERRA &gt; Earth Observing System, TERRA (AM-1)</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>AQUA &gt; Earth Observing System, AQUA</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA / GCMD Platform Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2016-06-10</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:platform>
+        <eos:EOS_Platform id="_TERRA">
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>TERRA</gco:CharacterString>
+              </gmd:code>
+              <gmd:codeSpace>
+                <gco:CharacterString>gov.nasa.esdis.umm.platformshortname</gco:CharacterString>
+              </gmd:codeSpace>
+              <gmd:description>
+                <gco:CharacterString>Earth Observing System, TERRA (AM-1)</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:description>
+            <gco:CharacterString>Earth Observation Satellites</gco:CharacterString>
+          </gmi:description>
+        </eos:EOS_Platform>
+      </gmi:platform>
+      <gmi:platform>
+        <eos:EOS_Platform id="_AQUA">
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>AQUA</gco:CharacterString>
+              </gmd:code>
+              <gmd:codeSpace>
+                <gco:CharacterString>gov.nasa.esdis.umm.platformshortname</gco:CharacterString>
+              </gmd:codeSpace>
+              <gmd:description>
+                <gco:CharacterString>Earth Observing System, AQUA</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:description>
+            <gco:CharacterString>Earth Observation Satellites</gco:CharacterString>
+          </gmi:description>
+        </eos:EOS_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+describe('Platform corrections with synchronized keyword blocks and acquisition information', () => {
+  test('should update BOTH keyword block and acquisition sections for AQUA', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'AQUA' },
+      newKeywordObject: { ShortName: 'AQUA-2' },
+      newLongName: 'Updated Earth Observing System, AQUA-2'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // 1. Verify keyword block updated
+    expect(updatedXml).toContain('AQUA-2 &gt; Updated Earth Observing System, AQUA-2')
+    expect(updatedXml).not.toContain('AQUA &gt; Earth Observing System, AQUA')
+
+    // 2. Verify acquisition gmd:code updated (ShortName only in NSIDC split format)
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_AQUA">[\s\S]*?<gmd:code>\s*<gco:CharacterString>AQUA-2<\/gco:CharacterString>/)
+
+    // 3. Verify acquisition identifier gmd:description updated (LongName only in NSIDC split format)
+    expect(updatedXml).toMatch(/<gmd:MD_Identifier>[\s\S]*?<gmd:code>\s*<gco:CharacterString>AQUA-2<\/gco:CharacterString>[\s\S]*?<gmd:description>\s*<gco:CharacterString>Updated Earth Observing System, AQUA-2<\/gco:CharacterString>/)
+
+    // 4. Verify TERRA remains unchanged in both sections
+    expect(updatedXml).toContain('TERRA &gt; Earth Observing System, TERRA (AM-1)')
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_TERRA">[\s\S]*?<gmd:code>\s*<gco:CharacterString>TERRA<\/gco:CharacterString>/)
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_TERRA">[\s\S]*?<gmd:description>\s*<gco:CharacterString>Earth Observing System, TERRA \(AM-1\)<\/gco:CharacterString>/)
+  })
+
+  test('should update BOTH sections for TERRA without affecting AQUA', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'TERRA' },
+      newKeywordObject: { ShortName: 'TERRA-2' },
+      newLongName: 'Updated Earth Observing System, TERRA-2 (AM-1)'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // 1. TERRA keyword updated
+    expect(updatedXml).toContain('TERRA-2 &gt; Updated Earth Observing System, TERRA-2 (AM-1)')
+    expect(updatedXml).not.toContain('TERRA &gt; Earth Observing System, TERRA (AM-1)')
+
+    // 2. TERRA acquisition code updated
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_TERRA">[\s\S]*?<gmd:code>\s*<gco:CharacterString>TERRA-2<\/gco:CharacterString>/)
+
+    // 3. TERRA acquisition description updated
+    expect(updatedXml).toMatch(/<gmd:MD_Identifier>[\s\S]*?<gmd:code>\s*<gco:CharacterString>TERRA-2<\/gco:CharacterString>[\s\S]*?<gmd:description>\s*<gco:CharacterString>Updated Earth Observing System, TERRA-2 \(AM-1\)<\/gco:CharacterString>/)
+
+    // 4. AQUA remains unchanged in both sections
+    expect(updatedXml).toContain('AQUA &gt; Earth Observing System, AQUA')
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_AQUA">[\s\S]*?<gmd:code>\s*<gco:CharacterString>AQUA<\/gco:CharacterString>/)
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_AQUA">[\s\S]*?<gmd:description>\s*<gco:CharacterString>Earth Observing System, AQUA<\/gco:CharacterString>/)
+  })
+
+  test('should handle sequential updates to different platforms', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    // First update AQUA
+    const aquaCorrection = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'AQUA' },
+      newKeywordObject: { ShortName: 'AQUA-NEW' },
+      newLongName: 'New AQUA Description'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const aquaSuccess = config(editor, aquaCorrection)
+
+    // Then update TERRA
+    const terraCorrection = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'TERRA' },
+      newKeywordObject: { ShortName: 'TERRA-NEW' },
+      newLongName: 'New TERRA Description'
+    }
+
+    const terraSuccess = config(editor, terraCorrection)
+
+    expect(aquaSuccess).toBe(true)
+    expect(terraSuccess).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Both keyword blocks updated correctly
+    expect(updatedXml).toContain('AQUA-NEW &gt; New AQUA Description')
+    expect(updatedXml).toContain('TERRA-NEW &gt; New TERRA Description')
+
+    // Both acquisition sections updated independently
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_AQUA">[\s\S]*?<gmd:code>\s*<gco:CharacterString>AQUA-NEW<\/gco:CharacterString>/)
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_TERRA">[\s\S]*?<gmd:code>\s*<gco:CharacterString>TERRA-NEW<\/gco:CharacterString>/)
+
+    // Descriptions updated independently
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_AQUA">[\s\S]*?<gmd:code>\s*<gco:CharacterString>AQUA-NEW<\/gco:CharacterString>[\s\S]*?<gmd:description>\s*<gco:CharacterString>New AQUA Description<\/gco:CharacterString>/)
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_TERRA">[\s\S]*?<gmd:code>\s*<gco:CharacterString>TERRA-NEW<\/gco:CharacterString>[\s\S]*?<gmd:description>\s*<gco:CharacterString>New TERRA Description<\/gco:CharacterString>/)
+  })
+
+  test('should preserve codeSpace when updating platforms', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'AQUA' },
+      newKeywordObject: { ShortName: 'AQUA-3' },
+      newLongName: 'Earth Observing System, AQUA-3'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    config(editor, correction)
+
+    const updatedXml = editor.serialize()
+
+    // CodeSpace should remain unchanged
+    expect(updatedXml).toContain('gov.nasa.esdis.umm.platformshortname')
+    expect(updatedXml).toMatch(/<gmd:codeSpace>\s*<gco:CharacterString>gov.nasa.esdis.umm.platformshortname<\/gco:CharacterString>/)
+  })
+
+  test('should preserve platform-level gmi:description (not identifier description)', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'AQUA' },
+      newKeywordObject: { ShortName: 'AQUA-4' },
+      newLongName: 'Updated System'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    config(editor, correction)
+
+    const updatedXml = editor.serialize()
+
+    // Platform-level description should be preserved
+    expect(updatedXml).toContain('<gmi:description>\n            <gco:CharacterString>Earth Observation Satellites</gco:CharacterString>')
+  })
+
+  test('should handle platform with only ShortName update', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'AQUA' },
+      newKeywordObject: { ShortName: 'AQUA-5' }
+      // No newLongName provided
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword should have just ShortName
+    expect(updatedXml).toContain('<gco:CharacterString>AQUA-5</gco:CharacterString>')
+
+    // Acquisition code should be updated
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_AQUA">[\s\S]*?<gmd:code>\s*<gco:CharacterString>AQUA-5<\/gco:CharacterString>/)
+  })
+
+  test('should delete platform from BOTH keyword block and acquisition section', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'delete',
+      oldKeywordObject: { ShortName: 'AQUA' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword block should not contain AQUA
+    expect(updatedXml).not.toContain('AQUA &gt; Earth Observing System, AQUA')
+
+    // TERRA keyword should remain
+    expect(updatedXml).toContain('TERRA &gt; Earth Observing System, TERRA (AM-1)')
+
+    // Acquisition section should still exist but AQUA platform should be removed
+    expect(updatedXml).toContain('gmi:acquisitionInformation')
+    expect(updatedXml).not.toContain('<eos:EOS_Platform id="_AQUA">')
+    expect(updatedXml).not.toContain('AQUA</gco:CharacterString>')
+
+    // TERRA should still be in acquisition section
+    expect(updatedXml).toContain('<eos:EOS_Platform id="_TERRA">')
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_TERRA">[\s\S]*?<gmd:code>\s*<gco:CharacterString>TERRA<\/gco:CharacterString>/)
+  })
+
+  test('should verify both platforms are independent in updates', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    // Update only AQUA
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'AQUA' },
+      newKeywordObject: { ShortName: 'AQUA-MODIFIED' },
+      newLongName: 'Modified AQUA'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    config(editor, correction)
+
+    const updatedXml = editor.serialize()
+
+    // AQUA keyword updated correctly
+    expect(updatedXml).toContain('AQUA-MODIFIED &gt; Modified AQUA')
+
+    // AQUA acquisition updated
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_AQUA">[\s\S]*?<gmd:code>\s*<gco:CharacterString>AQUA-MODIFIED<\/gco:CharacterString>/)
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_AQUA">[\s\S]*?<gmd:description>\s*<gco:CharacterString>Modified AQUA<\/gco:CharacterString>/)
+
+    // TERRA completely unchanged in both keyword and acquisition
+    expect(updatedXml).toContain('TERRA &gt; Earth Observing System, TERRA (AM-1)')
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_TERRA">[\s\S]*?<gmd:code>\s*<gco:CharacterString>TERRA<\/gco:CharacterString>/)
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_TERRA">[\s\S]*?<gmd:description>\s*<gco:CharacterString>Earth Observing System, TERRA \(AM-1\)<\/gco:CharacterString>/)
+  })
+
+  test('should handle empty LongName gracefully', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'TERRA' },
+      newKeywordObject: { ShortName: 'TERRA-SIMPLE' },
+      newLongName: ''
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword should be just ShortName when LongName is empty
+    expect(updatedXml).toContain('<gco:CharacterString>TERRA-SIMPLE</gco:CharacterString>')
+
+    // Should not create malformed "TERRA-SIMPLE > "
+    expect(updatedXml).not.toContain('TERRA-SIMPLE &gt; ')
+  })
+
+  test('should handle special characters in platform names', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'AQUA' },
+      newKeywordObject: { ShortName: 'AQUA-1/2' },
+      newLongName: 'Earth & Space System (Test)'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Special characters should be preserved in keyword
+    expect(updatedXml).toContain('AQUA-1/2 &gt; Earth &amp; Space System (Test)')
+
+    // Special characters should be preserved in acquisition
+    expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>AQUA-1\/2<\/gco:CharacterString>/)
+  })
+
+  test('should maintain XML structure integrity after updates', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'AQUA' },
+      newKeywordObject: { ShortName: 'AQUA-FINAL' },
+      newLongName: 'Final AQUA Version'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    config(editor, correction)
+
+    const updatedXml = editor.serialize()
+
+    // Verify XML is well-formed by checking key structural elements
+    expect(updatedXml).toContain('<gmi:MI_Metadata')
+    expect(updatedXml).toContain('</gmi:MI_Metadata>')
+    expect(updatedXml).toContain('<gmd:identificationInfo>')
+    expect(updatedXml).toContain('</gmd:identificationInfo>')
+    expect(updatedXml).toContain('<gmi:acquisitionInformation>')
+    expect(updatedXml).toContain('</gmi:acquisitionInformation>')
+
+    // Verify all namespaces are preserved
+    expect(updatedXml).toMatch(/xmlns:eos="http:\/\/earthdata.nasa.gov\/schema\/eos"/)
+    expect(updatedXml).toMatch(/xmlns:gco="http:\/\/www.isotc211.org\/2005\/gco"/)
+    expect(updatedXml).toMatch(/xmlns:gmd="http:\/\/www.isotc211.org\/2005\/gmd"/)
+    expect(updatedXml).toMatch(/xmlns:gmi="http:\/\/www.isotc211.org\/2005\/gmi"/)
+  })
+})

--- a/serverless/src/shared/__tests__/applyIso19115PlatformsCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115PlatformsCorrections.test.js
@@ -1610,4 +1610,225 @@ describe('Platform corrections with synchronized keyword blocks and acquisition 
     expect(updatedXml).toMatch(/<eos:EOS_Platform>[\s\S]*?<gmd:code>\s*<gco:CharacterString>METOP-B &gt; Meteorological Operational Satellite-B<\/gco:CharacterString>/)
     expect(updatedXml).toMatch(/<gmi:MI_Platform>[\s\S]*?<gmd:code>\s*<gco:CharacterString>METOP-B &gt; Meteorological Operational Satellite-B<\/gco:CharacterString>/)
   })
+
+  test('should handle unsupported action gracefully', () => {
+    // This covers line 169: return false when action is neither 'delete' nor 'replace'
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithNSIDCAcquisition)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'invalid-action', // Unsupported action
+      oldKeywordObject: { ShortName: 'ICESat-2' },
+      newKeywordObject: { ShortName: 'ICESat-3' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    // Should return false for unsupported action
+    expect(success).toBe(false)
+
+    // XML should remain unchanged
+    const updatedXml = editor.serialize()
+    expect(updatedXml).toContain('ICESat-2')
+    expect(updatedXml).not.toContain('ICESat-3')
+  })
+
+  test('should handle delete when identifier has no code nodes', () => {
+    // This covers line 222: return false when identifier has no code nodes during delete
+    const xmlWithMalformedIdentifier = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>TEST-SAT &gt; Test Satellite</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:platform>
+        <eos:EOS_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <!-- No gmd:code element - malformed -->
+              <gmd:codeSpace>
+                <gco:CharacterString>gov.nasa.esdis.umm.platformshortname</gco:CharacterString>
+              </gmd:codeSpace>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </eos:EOS_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(xmlWithMalformedIdentifier)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'delete',
+      oldKeywordObject: { ShortName: 'TEST-SAT' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    // Should still succeed in deleting the keyword block
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+    // Keyword removed from descriptiveKeywords
+    expect(updatedXml).not.toContain('TEST-SAT &gt; Test Satellite')
+    // Malformed acquisition platform remains (no code node to match)
+    expect(updatedXml).toContain('eos:EOS_Platform')
+  })
+
+  test('should handle replace when identifier has no code nodes', () => {
+    // This covers line 305: return false when identifier has no code nodes during replace
+    const xmlWithMalformedIdentifier = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>TEST-SAT &gt; Test Satellite</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:platform>
+        <eos:EOS_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <!-- No gmd:code element - malformed -->
+              <gmd:codeSpace>
+                <gco:CharacterString>gov.nasa.esdis.umm.platformshortname</gco:CharacterString>
+              </gmd:codeSpace>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </eos:EOS_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(xmlWithMalformedIdentifier)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'TEST-SAT' },
+      newKeywordObject: { ShortName: 'NEW-SAT' },
+      newLongName: 'New Satellite'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    // Should still succeed in updating the keyword block
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+    // Keyword updated in descriptiveKeywords
+    expect(updatedXml).toContain('NEW-SAT &gt; New Satellite')
+    // Malformed acquisition platform remains unchanged (no code node to match)
+    expect(updatedXml).toContain('eos:EOS_Platform')
+    expect(updatedXml).not.toContain('NEW-SAT</gco:CharacterString>')
+  })
+
+  test('should break when reaching document root during delete navigation', () => {
+    // This covers line 246: break when currentNode === this.document.documentElement
+    // Create XML where MD_Identifier is in an unexpected location (not properly nested in EOS_Platform/MI_Platform)
+    const xmlWithShallowIdentifier = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>ORPHAN-SAT &gt; Orphan Satellite</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <!-- MD_Identifier directly under MI_AcquisitionInformation without proper platform wrapper -->
+      <gmd:MD_Identifier>
+        <gmd:code>
+          <gco:CharacterString>ORPHAN-SAT</gco:CharacterString>
+        </gmd:code>
+        <gmd:codeSpace>
+          <gco:CharacterString>gov.nasa.esdis.umm.platformshortname</gco:CharacterString>
+        </gmd:codeSpace>
+      </gmd:MD_Identifier>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(xmlWithShallowIdentifier)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'delete',
+      oldKeywordObject: { ShortName: 'ORPHAN-SAT' }
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+
+    // The delete operation should find the identifier matching 'ORPHAN-SAT'
+    // When navigating up from MD_Identifier, it will check:
+    // - parentNode = MI_AcquisitionInformation (localName !== EOS_Platform/MI_Platform)
+    // - parentNode = acquisitionInformation (localName !== EOS_Platform/MI_Platform)
+    // - parentNode = MI_Metadata (this IS document.documentElement)
+    // Line 246: break is hit when currentNode === this.document.documentElement
+    const success = config(editor, correction)
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+    // Keyword should be deleted
+    expect(updatedXml).not.toContain('ORPHAN-SAT &gt; Orphan Satellite')
+    // Orphan MD_Identifier remains because navigation hit document root without finding platform wrapper
+    expect(updatedXml).toContain('ORPHAN-SAT</gco:CharacterString>')
+  })
 })

--- a/serverless/src/shared/__tests__/applyIso19115PlatformsCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyIso19115PlatformsCorrections.test.js
@@ -1159,6 +1159,179 @@ describe('Platform corrections with synchronized keyword blocks and acquisition 
 
     // Should not create malformed "TERRA-SIMPLE > "
     expect(updatedXml).not.toContain('TERRA-SIMPLE &gt; ')
+
+    // Verify acquisition gmd:description is empty string (line 255 coverage)
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_TERRA">[\s\S]*?<gmd:description>\s*<gco:CharacterString><\/gco:CharacterString>/)
+  })
+
+  test('should handle undefined newLongName (not just empty string)', () => {
+    const editor = new Iso19115MetadataPathEditor(mockIso19115WithKeywordsAndAcquisition)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'AQUA' },
+      newKeywordObject: { ShortName: 'AQUA-MINIMAL' }
+      // NewLongName is completely omitted (undefined)
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword should be just ShortName when newLongName is undefined (line 188 coverage)
+    expect(updatedXml).toContain('<gco:CharacterString>AQUA-MINIMAL</gco:CharacterString>')
+    expect(updatedXml).not.toContain('AQUA-MINIMAL &gt;')
+
+    // Verify acquisition code has only ShortName
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_AQUA">[\s\S]*?<gmd:code>\s*<gco:CharacterString>AQUA-MINIMAL<\/gco:CharacterString>/)
+
+    // Verify acquisition description is empty string when newLongName is falsy (line 255 coverage)
+    expect(updatedXml).toMatch(/<eos:EOS_Platform id="_AQUA">[\s\S]*?<gmd:description>\s*<gco:CharacterString><\/gco:CharacterString>/)
+  })
+
+  test('should preserve CWIC format free-text description when updating with combined format', () => {
+    // This specifically tests line 269: return node?.textContent || ''
+    const cwicXml = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos" 
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>SENTINEL-1A &gt; Sentinel-1A</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:platform>
+        <gmi:MI_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>SENTINEL-1A &gt; Sentinel-1A</gco:CharacterString>
+              </gmd:code>
+              <gmd:description>
+                <gco:CharacterString>This is a custom free-text description that should be preserved in CWIC format</gco:CharacterString>
+              </gmd:description>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:description>
+            <gco:CharacterString>Sentinel-1 is an imaging radar mission providing continuous all-weather imagery</gco:CharacterString>
+          </gmi:description>
+        </gmi:MI_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(cwicXml)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'SENTINEL-1A' },
+      newKeywordObject: { ShortName: 'SENTINEL-1B' },
+      newLongName: 'Sentinel-1B'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Keyword updated with combined format
+    expect(updatedXml).toContain('SENTINEL-1B &gt; Sentinel-1B')
+
+    // Acquisition code updated with combined format (detected ' > ')
+    expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>SENTINEL-1B &gt; Sentinel-1B<\/gco:CharacterString>/)
+
+    // CRITICAL: Free-text description should be PRESERVED (line 269 coverage)
+    // This tests the fallback: return node?.textContent || ''
+    expect(updatedXml).toContain('This is a custom free-text description that should be preserved in CWIC format')
+
+    // Platform-level description also preserved
+    expect(updatedXml).toContain('Sentinel-1 is an imaging radar mission providing continuous all-weather imagery')
+  })
+
+  test('should handle CWIC format with null/undefined description node gracefully', () => {
+    // Edge case: what if description node doesn't exist in CWIC format?
+    const cwicXmlNoDesc = `
+<gmi:MI_Metadata 
+  xmlns:eos="http://earthdata.nasa.gov/schema/eos"
+  xmlns:gco="http://www.isotc211.org/2005/gco" 
+  xmlns:gmd="http://www.isotc211.org/2005/gmd" 
+  xmlns:gmi="http://www.isotc211.org/2005/gmi" 
+  xmlns:gml="http://www.opengis.net/gml/3.2" 
+  xmlns:gmx="http://www.isotc211.org/2005/gmx" 
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>TEST-SAT &gt; Test Satellite</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="platform">platform</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:platform>
+        <gmi:MI_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gco:CharacterString>TEST-SAT &gt; Test Satellite</gco:CharacterString>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+        </gmi:MI_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>`
+
+    const editor = new Iso19115MetadataPathEditor(cwicXmlNoDesc)
+
+    const correction = {
+      scheme: 'platforms',
+      action: 'replace',
+      oldKeywordObject: { ShortName: 'TEST-SAT' },
+      newKeywordObject: { ShortName: 'TEST-SAT-2' },
+      newLongName: 'Test Satellite Version 2'
+    }
+
+    const config = ISO_19115_SCHEME_EDITORS.platforms
+    const success = config(editor, correction)
+
+    expect(success).toBe(true)
+
+    const updatedXml = editor.serialize()
+
+    // Should handle gracefully even without description node (line 269: || '' fallback)
+    expect(updatedXml).toContain('TEST-SAT-2 &gt; Test Satellite Version 2')
+    expect(updatedXml).toMatch(/<gmd:code>\s*<gco:CharacterString>TEST-SAT-2 &gt; Test Satellite Version 2<\/gco:CharacterString>/)
   })
 
   test('should handle special characters in platform names', () => {

--- a/serverless/src/shared/__tests__/applyUmmcMetadataCorrections.test.js
+++ b/serverless/src/shared/__tests__/applyUmmcMetadataCorrections.test.js
@@ -3153,7 +3153,6 @@ describe('when applying DataFormat UMM-C corrections', () => {
     // expect(result.correctionCount).toBe(1)
 
     const parsed = JSON.parse(result.correctedMetadata)
-    console.log('parsed:', parsed)
     // Verify the specific path was updated
     expect(parsed.ArchiveAndDistributionInformation.FileArchiveInformation[0].Format).toBe('ZARR')
     // Verify the path that did not match the oldKeywordObject remains unchanged

--- a/serverless/src/shared/__tests__/metadataCorrectionDelegateStubs.test.js
+++ b/serverless/src/shared/__tests__/metadataCorrectionDelegateStubs.test.js
@@ -202,7 +202,15 @@ describe('metadata correction delegate stubs', () => {
     const correction = {
       scheme: 'sciencekeywords',
       action: 'replace',
-      oldKeywordObject: { Value: 'EARTH SCIENCE > ATMOSPHERE > AEROSOLS' },
+      oldKeywordObject: {
+        Category: 'EARTH SCIENCE',
+        Topic: 'ATMOSPHERE',
+        Term: 'AEROSOLS',
+        VariableLevel1: '',
+        VariableLevel2: '',
+        VariableLevel3: '',
+        DetailedVariable: ''
+      },
       newKeywordObject: {
         Category: 'EARTH SCIENCE',
         Topic: 'ATMOSPHERE',

--- a/serverless/src/shared/__tests__/metadataCorrectionDelegateStubs.test.js
+++ b/serverless/src/shared/__tests__/metadataCorrectionDelegateStubs.test.js
@@ -177,22 +177,53 @@ describe('metadata correction delegate stubs', () => {
     })
   })
 
-  test('returns the expected ISO19115 delegate stub shape', async () => {
-    await expect(applyIso19115MetadataCorrections({
-      collectionConceptId: 'C2',
-      providerId: 'PROV',
-      nativeId: 'native-2'
-    })).resolves.toEqual({
-      nativeFormat: 'ISO19115',
-      delegateName: 'iso19115',
+  test('returns the expected ISO19115 payload shape when corrections are provided', async () => {
+    const mockPayload = `
+      <gmi:MI_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco">
+        <gmd:descriptiveKeywords>
+          <gmd:MD_Keywords>
+            <gmd:keyword>
+              <gco:CharacterString>EARTH SCIENCE > ATMOSPHERE > AEROSOLS</gco:CharacterString>
+            </gmd:keyword>
+            <gmd:type>
+              <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+            </gmd:type>
+            <gmd:thesaurusName>
+              <gmd:CI_Citation>
+                <gmd:title>
+                  <gco:CharacterString>NASA / GCMD Science Keywords</gco:CharacterString>
+                </gmd:title>
+              </gmd:CI_Citation>
+            </gmd:thesaurusName>
+          </gmd:MD_Keywords>
+        </gmd:descriptiveKeywords>
+      </gmi:MI_Metadata>`
+
+    const correction = {
+      scheme: 'sciencekeywords',
+      action: 'replace',
+      oldKeywordObject: { Value: 'EARTH SCIENCE > ATMOSPHERE > AEROSOLS' },
+      newKeywordObject: {
+        Category: 'EARTH SCIENCE',
+        Topic: 'ATMOSPHERE',
+        Term: 'AEROSOLS',
+        VariableLevel1: 'NEW AEROSOLS'
+      }
+    }
+
+    const result = await applyIso19115MetadataCorrections({
       collectionConceptId: 'C2',
       providerId: 'PROV',
       nativeId: 'native-2',
-      correctionCount: 0,
-      correctedMetadata: undefined,
-      correctionsApplied: [],
-      stubbed: true
+      nativeFormat: 'ISO19115',
+      metadataPayload: mockPayload,
+      corrections: [correction]
     })
+
+    expect(result.correctionCount).toBe(1)
+    expect(result.stubbed).toBe(false)
+    expect(result.correctedMetadata).toContain('NEW AEROSOLS')
+    expect(result.correctionsApplied).toEqual([correction])
   })
 
   test('returns the expected ISO_SMAP delegate stub shape', async () => {

--- a/serverless/src/shared/applyIso19115MetadataCorrections.js
+++ b/serverless/src/shared/applyIso19115MetadataCorrections.js
@@ -1,25 +1,49 @@
+import { createIso19115Editor, ISO_19115_SCHEME_EDITORS } from './Iso19115DomEditor'
 /**
  * Stub ISO 19115 delegate for KMS-675.
  *
  * Real ISO 19115 mutation is follow-on work. For now this delegate only records the handoff
  * shape.
  */
-export const applyIso19115MetadataCorrections = async ({
-  collectionConceptId,
-  providerId,
-  nativeId,
-  metadataPayload,
-  corrections = []
-}) => ({
-  nativeFormat: 'ISO19115',
-  delegateName: 'iso19115',
-  collectionConceptId,
-  providerId,
-  nativeId,
-  correctionCount: corrections.length,
-  correctedMetadata: metadataPayload,
-  correctionsApplied: corrections,
-  stubbed: true
-})
+export const applyIso19115MetadataCorrections = async (params) => {
+  const {
+    metadataPayload,
+    corrections = []
+  } = params
+
+  if (!metadataPayload) {
+    return {
+      correctionCount: 0,
+      correctedMetadata: undefined,
+      correctionsApplied: [],
+      stubbed: false
+    }
+  }
+
+  const editor = createIso19115Editor(metadataPayload)
+  const applied = corrections.reduce((acc, correction) => {
+    const scheme = String(correction.scheme || '').toLowerCase()
+    const delegate = ISO_19115_SCHEME_EDITORS[scheme]
+
+    if (!delegate) {
+      return acc
+    }
+
+    const isUpdated = delegate(editor, correction)
+    if (isUpdated) {
+      acc.push(correction)
+    }
+
+    return acc
+  }, [])
+
+  return {
+    ...params,
+    correctionCount: applied.length,
+    correctedMetadata: editor.serialize(),
+    correctionsApplied: applied,
+    stubbed: false
+  }
+}
 
 export default applyIso19115MetadataCorrections


### PR DESCRIPTION
# Overview

### What is the feature?

Update Keywords in ISO19115 (ISO-MENDS) native records

### What is the Solution?

Update keywords in following schemes as they appear in ISO-MENDS records, according to correction requests:

sciencekeywords
locations
platforms
instruments
projects
providers
isotopiccategory
productlevelid

### What areas of the application does this impact?

Consumer - Update Keywords in ISO-MENDS native records

# Testing

Run:

```bash
npx vite-node --config vite.config.js scripts/local/run_metadata_correction_iso-19115_smoke.mjs
```

The request fixture currently includes the supported UMM-C correction matrix:

- `sciencekeywords`
- `locations`
- `platforms`
- `instruments`
- `projects`
- `providers`
- `isotopiccategory`
- `productlevelid`

The script prints a JSON summary like:

```json
[metadata-correction-smoke] Applied corrections locally
{
  "fixturePath": "/Users/htranho/repos/kms/scripts/local/fixtures/metadata_correction_service.iso-19115.corrections.json",
  "collectionConceptId": "C1234567222-LOCAL",
  "nativeFormat": "ISO19115",
  "requestedCorrections": 10,
  "appliedCorrections": 10,
  "outputPath": "/Users/htranho/repos/kms/tmp/metadata_correction_service_iso-19115_smoke_output.xml",
  "writeResult": {
    "targetComponent": "cmr-writeback",
    "collectionConceptId": "C1234567222-LOCAL",
    "providerId": null,
    "nativeId": null,
    "nativeFormat": "ISO19115",
    "correctionCount": 10,
    "correctionsAppliedCount": 10,
    "correctedMetadataBytes": 16144,
    "source": "local-smoke",
    "ingestResult": {
      "enabled": false,
      "ingested": false,
      "updated": false
    }
  }
}

```

The important signals are:

- `nativeFormat` is `ISO19115`
- `requestedCorrections` matches the fixture
- `appliedCorrections` matches the expected applied count
- `writeResult.targetComponent` is `cmr-writeback`

The corrected XML is written to:

```bash
tmp/metadata_correction_service_iso-19115_smoke_output.xml
```

See scripts/local/fixtures/metadata_correction_service.iso-19115.corrections.json for requested corrections and compare them with result in tmp/metadata_correction_service_iso-19115_smoke_output.xml

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply ISO-19115 metadata corrections across science keywords, locations, platforms, instruments, projects, providers, topic categories, and processing levels.
  * Added native-format aliases `iso19115` and `isosmap` for command-line resolution.
  * Introduced an ISO-19115 XML editor and scheme-based keyword editors to update and delete targeted nodes.
* **Bug Fixes**
  * Corrections now perform real replace/delete updates with proper cleanup (including removal of emptied containers) and synchronized processing-level edits.
* **Tests**
  * Expanded ISO-19115 coverage with new fixtures, a new smoke-test workflow, and expanded editor behavior assertions.
* **Chores**
  * Improved shared XML utilities and namespace/XPath-based editing helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->