### PR TITLE
KMS-694: Added POST for metadata correction handler

### DIFF
--- a/cdk/app/lib/CmrEventProcessingStack.ts
+++ b/cdk/app/lib/CmrEventProcessingStack.ts
@@ -13,6 +13,7 @@ import { VpcSetup } from './helper/VpcSetup'
  */
 export interface CmrEventProcessingStackProps extends cdk.StackProps {
   cmrBaseUrl: string
+  metadataCorrectionRequestDelayMs?: string
   cmrWriterToken?: string
   cmrWritebackProviders?: string
   redisEnabled?: string
@@ -60,6 +61,7 @@ export class CmrEventProcessingStack extends cdk.Stack {
 
     const metadataCorrectionSetup = new MetadataCorrectionSetup(this, 'MetadataCorrection', {
       cmrBaseUrl: props.cmrBaseUrl,
+      metadataCorrectionRequestDelayMs: props.metadataCorrectionRequestDelayMs,
       cmrWriterToken: props.cmrWriterToken,
       cmrWritebackProviders: props.cmrWritebackProviders,
       prefix: props.prefix,

--- a/cdk/app/lib/KmsStack.ts
+++ b/cdk/app/lib/KmsStack.ts
@@ -99,7 +99,9 @@ export class KmsStack extends cdk.Stack {
 
     const useLocalstack = this.node.tryGetContext('useLocalstack') === 'true'
     const keywordEventsTopicName = `${prefix}-${stage}-keyword-events`
+    const metadataCorrectionRequestsTopicName = `${prefix}-${stage}-metadata-correction-requests.fifo`
     const localTopicArn = `arn:aws:sns:${this.region}:${this.account}:${keywordEventsTopicName}`
+    const metadataCorrectionRequestsTopicArn = `arn:aws:sns:${this.region}:${this.account}:${metadataCorrectionRequestsTopicName}`
 
     // Set up VPC and Security Group
     const vpcSetup = new VpcSetup(this, prefix, vpcId, useLocalstack)
@@ -167,7 +169,8 @@ export class KmsStack extends cdk.Stack {
       lambdaRole: this.lambdaRole,
       metadataCorrectionEnvironment: {
         CMR_WRITER_TOKEN: props.cmrWriterToken || '',
-        CMR_WRITEBACK_PROVIDERS: props.cmrWritebackProviders || ''
+        CMR_WRITEBACK_PROVIDERS: props.cmrWritebackProviders || '',
+        METADATA_CORRECTION_REQUESTS_TOPIC_ARN: metadataCorrectionRequestsTopicArn
       },
       prefix,
       securityGroup: this.securityGroup,

--- a/cdk/app/lib/helper/KmsLambdaFunctions.ts
+++ b/cdk/app/lib/helper/KmsLambdaFunctions.ts
@@ -23,6 +23,7 @@ interface LambdaFunctionsProps {
   metadataCorrectionEnvironment?: {
     CMR_WRITER_TOKEN: string;
     CMR_WRITEBACK_PROVIDERS: string;
+    METADATA_CORRECTION_REQUESTS_TOPIC_ARN?: string;
   };
   prefix: string;
   securityGroup: ec2.SecurityGroup;
@@ -415,6 +416,19 @@ export class LambdaFunctions {
 
     this.createApiLambda(
       scope,
+      'requestMetadataCorrection/handler.js',
+      'request-metadata-correction',
+      'requestMetadataCorrection',
+      '/metadata_correction',
+      'POST',
+      true,
+      Duration.seconds(30),
+      1024,
+      this.props.metadataCorrectionEnvironment || {}
+    )
+
+    this.createApiLambda(
+      scope,
       'runMetadataCorrection/handler.js',
       'run-metadata-correction',
       'runMetadataCorrection',
@@ -551,6 +565,20 @@ export class LambdaFunctions {
       actions: ['sns:Publish'],
       resources: [topicArn]
     }))
+
+    // The async metadata-correction API publishes one request per collection id to the
+    // shared FIFO topic owned by the processing stack, so the shared Lambda role also
+    // needs explicit publish permission to that topic when the ARN is configured.
+    const metadataCorrectionTopicArn = this.props
+      .metadataCorrectionEnvironment
+      ?.METADATA_CORRECTION_REQUESTS_TOPIC_ARN
+
+    if (metadataCorrectionTopicArn) {
+      this.props.lambdaRole.addToPolicy(new iam.PolicyStatement({
+        actions: ['sns:Publish'],
+        resources: [metadataCorrectionTopicArn]
+      }))
+    }
   }
 
   /**

--- a/cdk/app/lib/helper/MetadataCorrectionSetup.ts
+++ b/cdk/app/lib/helper/MetadataCorrectionSetup.ts
@@ -17,6 +17,7 @@ import { NODE_LAMBDA_RUNTIME } from './NodeLambdaRuntime'
  */
 interface MetadataCorrectionSetupProps {
   cmrBaseUrl: string
+  metadataCorrectionRequestDelayMs?: string
   cmrWriterToken?: string
   cmrWritebackProviders?: string
   prefix: string
@@ -64,6 +65,7 @@ export class MetadataCorrectionSetup extends Construct {
 
     const {
       cmrBaseUrl,
+      metadataCorrectionRequestDelayMs,
       cmrWriterToken,
       cmrWritebackProviders,
       prefix,
@@ -135,6 +137,9 @@ export class MetadataCorrectionSetup extends Construct {
           ...(redisEnabled ? { REDIS_ENABLED: redisEnabled } : {}),
           ...(redisHost ? { REDIS_HOST: redisHost } : {}),
           ...(redisPort ? { REDIS_PORT: redisPort } : {}),
+          ...(metadataCorrectionRequestDelayMs
+            ? { METADATA_CORRECTION_REQUEST_DELAY_MS: metadataCorrectionRequestDelayMs }
+            : {}),
           RDF4J_PASSWORD: rdf4jPassword,
           RDF4J_SERVICE_URL: rdf4jServiceUrl,
           RDF4J_USER_NAME: rdf4jUserName

--- a/cdk/app/lib/helper/MetadataCorrectionSetup.ts
+++ b/cdk/app/lib/helper/MetadataCorrectionSetup.ts
@@ -159,7 +159,8 @@ export class MetadataCorrectionSetup extends Construct {
     this.metadataCorrectionServiceLambda.addEventSource(new eventsources.SqsEventSource(
       this.metadataCorrectionRequestsQueue,
       {
-        batchSize: 1
+        batchSize: 1,
+        reportBatchItemFailures: true
       }
     ))
 

--- a/cdk/bin/main.ts
+++ b/cdk/bin/main.ts
@@ -225,6 +225,7 @@ async function main() {
 
   const cmrEventProcessingStack = new CmrEventProcessingStack(app, 'CmrEventProcessingStack', {
     cmrBaseUrl,
+    metadataCorrectionRequestDelayMs: process.env.METADATA_CORRECTION_REQUEST_DELAY_MS || '',
     cmrWriterToken: process.env.CMR_WRITER_TOKEN || '',
     cmrWritebackProviders: process.env.CMR_WRITEBACK_PROVIDERS || '',
     env,

--- a/scripts/local/run_metadata_correction_partial_batch_failure_smoke.mjs
+++ b/scripts/local/run_metadata_correction_partial_batch_failure_smoke.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+/**
+ * Local end-to-end smoke for metadata-correction consumer partial batch failure handling.
+ *
+ * This smoke drives the real `metadataCorrectionService` handler with a two-record SQS-like
+ * batch:
+ * - one valid collection correction request that should complete successfully
+ * - one invalid JSON body that should be returned in `batchItemFailures`
+ *
+ * What this proves:
+ * - successful records still run correction/writeback normally
+ * - failed records are surfaced by messageId in the AWS partial batch response shape
+ * - the consumer no longer needs to fail the whole invocation to retry only the bad message
+ *
+ * Prerequisites:
+ * - local Redis is running
+ * - LocalStack is optional; if present, set AWS_ENDPOINT_URL to avoid metric emission errors
+ *
+ * Run with:
+ *   npx vite-node --config vite.config.js scripts/local/run_metadata_correction_partial_batch_failure_smoke.mjs
+ */
+const rootDir = path.resolve(import.meta.dirname, '../..')
+const fixturePath = path.resolve(
+  rootDir,
+  'scripts/local/fixtures/metadata_correction_smoke.full_path.example.json'
+)
+const outputDir = path.resolve(rootDir, 'tmp/metadata-correction-partial-batch-failure-smoke')
+const outputPath = path.resolve(outputDir, 'result.json')
+const mockCmrPort = Number(process.env.MOCK_CMR_PORT || 3020)
+const startMockServer = String(process.env.START_MOCK_CMR || 'true').toLowerCase() !== 'false'
+const cmrBaseUrl = process.env.CMR_BASE_URL || `http://127.0.0.1:${mockCmrPort}`
+
+const fixture = JSON.parse(await fs.readFile(fixturePath, 'utf8'))
+const collection = fixture.cmr.collections[0]
+const collectionConceptId = process.env.COLLECTION_CONCEPT_ID || collection.conceptId
+const providerId = process.env.PROVIDER_ID || collection.providerId
+const successfulMessageId = 'local-partial-batch-success'
+const failedMessageId = 'local-partial-batch-failure'
+
+/**
+ * Sleeps for a short interval while the smoke waits on local dependencies.
+ *
+ * @param {number} ms Milliseconds to pause.
+ * @returns {Promise<void>}
+ */
+const sleep = (ms) => new Promise((resolve) => {
+  setTimeout(resolve, ms)
+})
+
+/**
+ * Polls the mock CMR health endpoint until it becomes reachable.
+ *
+ * @param {string} healthUrl Mock server health-check URL.
+ * @param {number} [attempt=1] Current poll attempt count.
+ * @returns {Promise<void>}
+ */
+const waitForHealth = async (healthUrl, attempt = 1) => {
+  try {
+    const response = await fetch(healthUrl)
+
+    if (response.ok) {
+      return
+    }
+  } catch {
+    // Keep polling until the child server comes up.
+  }
+
+  if (attempt >= 40) {
+    throw new Error(`Timed out waiting for mock CMR health endpoint: ${healthUrl}`)
+  }
+
+  await sleep(250)
+  await waitForHealth(healthUrl, attempt + 1)
+}
+
+/**
+ * Wraps cached concept payloads in the same API-response envelope stored in Redis.
+ *
+ * @param {object} responseBody Cached concept response body.
+ * @returns {{statusCode: number, body: string}}
+ */
+const buildCacheResponse = (responseBody) => ({
+  statusCode: 200,
+  body: JSON.stringify(responseBody)
+})
+
+/**
+ * Seeds the local Redis caches with the historical and published keyword fixtures.
+ *
+ * @returns {Promise<object>} Connected Redis client for later cleanup.
+ */
+const seedKeywordCaches = async () => {
+  process.env.REDIS_ENABLED = process.env.REDIS_ENABLED || 'true'
+  process.env.REDIS_HOST = process.env.REDIS_HOST_SERVICE_HOST || process.env.REDIS_HOST || 'localhost'
+  process.env.REDIS_PORT = process.env.REDIS_HOST_PORT || process.env.REDIS_PORT || '6380'
+  process.env.REDIS_FAIL_FAST = process.env.REDIS_FAIL_FAST || 'true'
+
+  const {
+    createConceptResponseCacheKeyByFullPath,
+    createConceptResponseCacheKeyByShortName,
+    createPublishedConceptResponseCacheKeyByFullPath,
+    createPublishedConceptResponseCacheKeyByShortName,
+    createPublishedConceptResponseCacheKeyByUuid
+  } = await import('../../serverless/src/shared/redisCacheKeys')
+  const { getRedisClient } = await import('../../serverless/src/shared/redisCacheStore')
+
+  const redisClient = await getRedisClient()
+
+  if (!redisClient) {
+    throw new Error('Unable to connect to Redis for metadata correction partial batch smoke seeding.')
+  }
+
+  const seedConcepts = async ({
+    concepts,
+    createFullPathCacheKey,
+    createShortNameCacheKey,
+    createUuidCacheKey
+  }) => Promise.all(concepts.map(async (concept) => {
+    const {
+      lookupType,
+      responseBody,
+      scheme
+    } = concept
+
+    let cacheKey
+
+    if (lookupType === 'fullPath') {
+      cacheKey = createFullPathCacheKey({
+        fullPath: concept.fullPath.toLowerCase(),
+        scheme: scheme.toLowerCase()
+      })
+    } else {
+      cacheKey = createShortNameCacheKey({
+        shortName: concept.shortName.toLowerCase(),
+        scheme: scheme.toLowerCase()
+      })
+    }
+
+    await redisClient.set(cacheKey, JSON.stringify(buildCacheResponse(responseBody)))
+
+    if (createUuidCacheKey) {
+      const uuidCacheKey = createUuidCacheKey({
+        uuid: responseBody.uuid.toLowerCase(),
+        scheme: scheme.toLowerCase()
+      })
+
+      await redisClient.set(uuidCacheKey, JSON.stringify(buildCacheResponse(responseBody)))
+    }
+  }))
+
+  await seedConcepts({
+    concepts: fixture.historicalConcepts || [],
+    createFullPathCacheKey: createConceptResponseCacheKeyByFullPath,
+    createShortNameCacheKey: createConceptResponseCacheKeyByShortName
+  })
+
+  await seedConcepts({
+    concepts: fixture.publishedConcepts || [],
+    createFullPathCacheKey: createPublishedConceptResponseCacheKeyByFullPath,
+    createShortNameCacheKey: createPublishedConceptResponseCacheKeyByShortName,
+    createUuidCacheKey: createPublishedConceptResponseCacheKeyByUuid
+  })
+
+  return redisClient
+}
+
+let mockServerProcess
+let redisClient
+
+try {
+  if (startMockServer) {
+    mockServerProcess = spawn(
+      process.execPath,
+      [path.resolve(rootDir, 'scripts/local/mock_cmr_server.mjs'), fixturePath],
+      {
+        env: {
+          ...process.env,
+          FIXTURE_FILE: fixturePath,
+          MOCK_CMR_PORT: String(mockCmrPort)
+        },
+        stdio: 'inherit'
+      }
+    )
+
+    await waitForHealth(`${cmrBaseUrl}/health`)
+  }
+
+  process.env.CMR_BASE_URL = cmrBaseUrl
+  process.env.CMR_WRITEBACK_PROVIDERS = process.env.CMR_WRITEBACK_PROVIDERS || providerId
+  process.env.CMR_WRITER_TOKEN = process.env.CMR_WRITER_TOKEN || 'local-writer-token'
+  process.env.AWS_ENDPOINT_URL = process.env.AWS_ENDPOINT_URL || 'http://127.0.0.1:4566'
+  process.env.RDF4J_SERVICE_URL = process.env.RDF4J_SERVICE_URL || 'http://localhost:8081'
+  process.env.RDF4J_USER_NAME = process.env.RDF4J_USER_NAME || 'rdf4j'
+  process.env.RDF4J_PASSWORD = process.env.RDF4J_PASSWORD || 'rdf4j'
+
+  redisClient = await seedKeywordCaches()
+
+  const { metadataCorrectionService } = await import('../../serverless/src/metadataCorrectionService/handler')
+  const { getCmrCollectionNativeMetadata } = await import('../../serverless/src/shared/getCmrCollectionNativeMetadata')
+
+  const response = await metadataCorrectionService({
+    Records: [
+      {
+        messageId: successfulMessageId,
+        body: JSON.stringify({
+          collectionConceptId
+        })
+      },
+      {
+        messageId: failedMessageId,
+        body: 'not-json'
+      }
+    ]
+  })
+
+  if (JSON.stringify(response?.batchItemFailures) !== JSON.stringify([
+    { itemIdentifier: failedMessageId }
+  ])) {
+    throw new Error(
+      'Expected only the bad record messageId in batchItemFailures. '
+      + `Received ${JSON.stringify(response?.batchItemFailures)}`
+    )
+  }
+
+  const updatedNativeMetadata = await getCmrCollectionNativeMetadata({
+    collectionConceptId
+  })
+  const updatedPlatform = updatedNativeMetadata?.Platforms?.[0]
+
+  if (!updatedPlatform) {
+    throw new Error(`Expected updated UMM Platforms[0] for ${collectionConceptId}`)
+  }
+
+  if (updatedPlatform.ShortName !== 'Aqua') {
+    throw new Error(
+      'Expected corrected UMM Platforms[0].ShortName to be Aqua, '
+      + `received ${updatedPlatform.ShortName}`
+    )
+  }
+
+  await fs.mkdir(outputDir, { recursive: true })
+  await fs.writeFile(outputPath, JSON.stringify({
+    collectionConceptId,
+    providerId,
+    successfulMessageId,
+    failedMessageId,
+    response,
+    updatedPlatform,
+    outputPath
+  }, null, 2), 'utf8')
+
+  console.log('[metadata-correction-partial-batch-failure-smoke] Completed successfully')
+  console.log(JSON.stringify({
+    collectionConceptId,
+    successfulMessageId,
+    failedMessageId,
+    batchItemFailures: response.batchItemFailures,
+    updatedPlatformShortName: updatedPlatform.ShortName,
+    outputPath
+  }, null, 2))
+} finally {
+  if (redisClient) {
+    await redisClient.quit()
+  }
+
+  if (mockServerProcess) {
+    mockServerProcess.kill('SIGTERM')
+  }
+}

--- a/scripts/local/run_metadata_correction_request_delay_smoke.mjs
+++ b/scripts/local/run_metadata_correction_request_delay_smoke.mjs
@@ -1,0 +1,365 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+/**
+ * Local end-to-end smoke for the queued manual-request delay path.
+ *
+ * This smoke drives the real `metadataCorrectionService` handler with an
+ * SQS-like record shaped like the new async API publishes:
+ * - source=metadataCorrectionApi
+ * - collectionConceptId present
+ * - requestedAt stamped near "now"
+ *
+ * It verifies the consumer waits for the configured delay window before
+ * running correction, then confirms the correction still completes and writes
+ * the expected metadata change through the mock CMR path.
+ *
+ * Prerequisites:
+ * - local Redis is running
+ * - local RDF4J is running
+ * - LocalStack is optional; if present, set AWS_ENDPOINT_URL to avoid metric
+ *   emission errors in logs
+ *
+ * Run with:
+ *   npx vite-node --config vite.config.js scripts/local/run_metadata_correction_request_delay_smoke.mjs
+ */
+const rootDir = path.resolve(import.meta.dirname, '../..')
+const fixturePath = path.resolve(
+  rootDir,
+  'scripts/local/fixtures/metadata_correction_smoke.full_path.example.json'
+)
+const outputDir = path.resolve(rootDir, 'tmp/metadata-correction-request-delay-smoke')
+const outputPath = path.resolve(outputDir, 'result.json')
+const mockCmrPort = Number(process.env.MOCK_CMR_PORT || 3020)
+const startMockServer = String(process.env.START_MOCK_CMR || 'true').toLowerCase() !== 'false'
+const cmrBaseUrl = process.env.CMR_BASE_URL || `http://127.0.0.1:${mockCmrPort}`
+const configuredDelayMs = Number(process.env.METADATA_CORRECTION_REQUEST_DELAY_MS || '2000')
+const delayAssertionToleranceMs = Number(process.env.DELAY_ASSERTION_TOLERANCE_MS || '250')
+
+const fixture = JSON.parse(await fs.readFile(fixturePath, 'utf8'))
+const collection = fixture.cmr.collections[0]
+const collectionConceptId = process.env.COLLECTION_CONCEPT_ID || collection.conceptId
+const providerId = process.env.PROVIDER_ID || collection.providerId
+
+/**
+ * Sleeps for a short interval while the smoke waits on local dependencies.
+ *
+ * @param {number} ms Milliseconds to pause.
+ * @returns {Promise<void>} Promise that resolves after the delay.
+ */
+const sleep = (ms) => new Promise((resolve) => {
+  setTimeout(resolve, ms)
+})
+
+/**
+ * Polls the mock CMR health endpoint until it becomes reachable.
+ *
+ * @param {string} healthUrl Mock server health-check URL.
+ * @param {number} [attempt=1] Current poll attempt count.
+ * @returns {Promise<void>} Resolves once the mock server is healthy.
+ */
+const waitForHealth = async (healthUrl, attempt = 1) => {
+  try {
+    const response = await fetch(healthUrl)
+
+    if (response.ok) {
+      return
+    }
+  } catch {
+    // Keep polling until the child server comes up.
+  }
+
+  if (attempt >= 40) {
+    throw new Error(`Timed out waiting for mock CMR health endpoint: ${healthUrl}`)
+  }
+
+  await sleep(250)
+  await waitForHealth(healthUrl, attempt + 1)
+}
+
+/**
+ * Wraps cached concept payloads in the same API-response envelope stored in Redis.
+ *
+ * @param {object} responseBody Cached concept response body.
+ * @returns {{statusCode: number, body: string}} Serialized cache entry payload.
+ */
+const buildCacheResponse = (responseBody) => ({
+  statusCode: 200,
+  body: JSON.stringify(responseBody)
+})
+
+/**
+ * Seeds the local Redis caches with the historical and published keyword fixtures.
+ *
+ * @returns {Promise<object>} Connected Redis client for later cleanup.
+ */
+const seedKeywordCaches = async () => {
+  process.env.REDIS_ENABLED = process.env.REDIS_ENABLED || 'true'
+  process.env.REDIS_HOST = process.env.REDIS_HOST_SERVICE_HOST || process.env.REDIS_HOST || 'localhost'
+  process.env.REDIS_PORT = process.env.REDIS_HOST_PORT || process.env.REDIS_PORT || '6380'
+  process.env.REDIS_FAIL_FAST = process.env.REDIS_FAIL_FAST || 'true'
+
+  const {
+    createConceptResponseCacheKeyByFullPath,
+    createConceptResponseCacheKeyByShortName,
+    createPublishedConceptResponseCacheKeyByFullPath,
+    createPublishedConceptResponseCacheKeyByShortName,
+    createPublishedConceptResponseCacheKeyByUuid
+  } = await import('../../serverless/src/shared/redisCacheKeys')
+  const { getRedisClient } = await import('../../serverless/src/shared/redisCacheStore')
+
+  const redisClient = await getRedisClient()
+
+  if (!redisClient) {
+    throw new Error('Unable to connect to Redis for metadata correction delay smoke seeding.')
+  }
+
+  /**
+   * Seeds one set of fixture concepts into the appropriate Redis key-space.
+   *
+   * @param {object} params Seeding parameters.
+   * @param {Array<object>} params.concepts Historical or published concept fixtures.
+   * @param {Function} params.createFullPathCacheKey Cache-key builder for full-path lookups.
+   * @param {Function} params.createShortNameCacheKey Cache-key builder for short-name lookups.
+   * @param {Function} [params.createUuidCacheKey] Optional cache-key builder for UUID lookups.
+   * @returns {Promise<void[]>} Resolves once the provided concept set is seeded.
+   */
+  const seedConcepts = async ({
+    concepts,
+    createFullPathCacheKey,
+    createShortNameCacheKey,
+    createUuidCacheKey
+  }) => Promise.all(concepts.map(async (concept) => {
+    const {
+      lookupType,
+      responseBody,
+      scheme
+    } = concept
+
+    let cacheKey
+
+    if (lookupType === 'fullPath') {
+      cacheKey = createFullPathCacheKey({
+        fullPath: concept.fullPath.toLowerCase(),
+        scheme: scheme.toLowerCase()
+      })
+    } else {
+      cacheKey = createShortNameCacheKey({
+        shortName: concept.shortName.toLowerCase(),
+        scheme: scheme.toLowerCase()
+      })
+    }
+
+    await redisClient.set(cacheKey, JSON.stringify(buildCacheResponse(responseBody)))
+
+    if (createUuidCacheKey) {
+      const uuidCacheKey = createUuidCacheKey({
+        uuid: responseBody.uuid.toLowerCase(),
+        scheme: scheme.toLowerCase()
+      })
+
+      await redisClient.set(uuidCacheKey, JSON.stringify(buildCacheResponse(responseBody)))
+    }
+  }))
+
+  await seedConcepts({
+    concepts: fixture.historicalConcepts || [],
+    createFullPathCacheKey: createConceptResponseCacheKeyByFullPath,
+    createShortNameCacheKey: createConceptResponseCacheKeyByShortName
+  })
+
+  await seedConcepts({
+    concepts: fixture.publishedConcepts || [],
+    createFullPathCacheKey: createPublishedConceptResponseCacheKeyByFullPath,
+    createShortNameCacheKey: createPublishedConceptResponseCacheKeyByShortName,
+    createUuidCacheKey: createPublishedConceptResponseCacheKeyByUuid
+  })
+
+  return redisClient
+}
+
+/**
+ * Removes any existing audit rows for the smoke collection so assertions start clean.
+ *
+ * @returns {Promise<void>} Resolves once prior audit rows have been deleted.
+ */
+const clearAuditRowsForCollection = async () => {
+  process.env.RDF4J_SERVICE_URL = process.env.RDF4J_SERVICE_URL || 'http://localhost:8081'
+  process.env.RDF4J_USER_NAME = process.env.RDF4J_USER_NAME || 'rdf4j'
+  process.env.RDF4J_PASSWORD = process.env.RDF4J_PASSWORD || 'rdf4j'
+
+  const {
+    escapeSparqlLiteral,
+    METADATA_CORRECTION_AUDIT_GRAPH
+  } = await import('../../serverless/src/shared/metadataCorrectionAudit')
+  const { sparqlRequest } = await import('../../serverless/src/shared/sparqlRequest')
+
+  const query = `
+    PREFIX gcmd: <https://gcmd.earthdata.nasa.gov/kms#>
+
+    DELETE {
+      GRAPH <${METADATA_CORRECTION_AUDIT_GRAPH}> {
+        ?record ?predicate ?object .
+      }
+    }
+    WHERE {
+      GRAPH <${METADATA_CORRECTION_AUDIT_GRAPH}> {
+        ?record a gcmd:MetadataCorrectionAuditRecord ;
+                gcmd:collectionConceptId "${escapeSparqlLiteral(collectionConceptId)}" ;
+                ?predicate ?object .
+      }
+    }
+  `
+
+  await sparqlRequest({
+    method: 'POST',
+    contentType: 'application/sparql-update',
+    accept: 'application/json',
+    body: query
+  })
+}
+
+let mockServerProcess
+let redisClient
+
+try {
+  if (startMockServer) {
+    mockServerProcess = spawn(
+      process.execPath,
+      [path.resolve(rootDir, 'scripts/local/mock_cmr_server.mjs'), fixturePath],
+      {
+        env: {
+          ...process.env,
+          FIXTURE_FILE: fixturePath,
+          MOCK_CMR_PORT: String(mockCmrPort)
+        },
+        stdio: 'inherit'
+      }
+    )
+
+    await waitForHealth(`${cmrBaseUrl}/health`)
+  }
+
+  process.env.CMR_BASE_URL = cmrBaseUrl
+  process.env.CMR_WRITEBACK_PROVIDERS = process.env.CMR_WRITEBACK_PROVIDERS || providerId
+  process.env.CMR_WRITER_TOKEN = process.env.CMR_WRITER_TOKEN || 'local-writer-token'
+  process.env.METADATA_CORRECTION_REQUEST_DELAY_MS = String(configuredDelayMs)
+  process.env.AWS_ENDPOINT_URL = process.env.AWS_ENDPOINT_URL || 'http://127.0.0.1:4566'
+
+  redisClient = await seedKeywordCaches()
+  await clearAuditRowsForCollection()
+
+  const { metadataCorrectionService } = await import('../../serverless/src/metadataCorrectionService/handler')
+  const { getMetadataCorrectionAuditLog } = await import('../../serverless/src/shared/getMetadataCorrectionAuditLog')
+  const { getCmrCollectionNativeMetadata } = await import('../../serverless/src/shared/getCmrCollectionNativeMetadata')
+
+  const requestedAt = new Date().toISOString()
+  const startedAtMs = Date.now()
+
+  const response = await metadataCorrectionService({
+    Records: [
+      {
+        messageId: 'local-request-delay-smoke-1',
+        body: JSON.stringify({
+          source: 'metadataCorrectionApi',
+          requestedAt,
+          collectionConceptId
+        })
+      }
+    ]
+  })
+
+  const finishedAtMs = Date.now()
+  const elapsedMs = finishedAtMs - startedAtMs
+  const minimumExpectedElapsedMs = configuredDelayMs - delayAssertionToleranceMs
+
+  if (elapsedMs < minimumExpectedElapsedMs) {
+    throw new Error(
+      'Expected metadata correction service to honor the configured request delay. '
+      + `ConfiguredDelayMs=${configuredDelayMs} `
+      + `ToleranceMs=${delayAssertionToleranceMs} `
+      + `ElapsedMs=${elapsedMs}`
+    )
+  }
+
+  if (response?.batchItemFailures?.length !== 0) {
+    throw new Error(
+      `Expected no batch item failures, received ${JSON.stringify(response.batchItemFailures)}`
+    )
+  }
+
+  const updatedNativeMetadata = await getCmrCollectionNativeMetadata({
+    collectionConceptId
+  })
+  const updatedPlatform = updatedNativeMetadata?.Platforms?.[0]
+
+  if (!updatedPlatform) {
+    throw new Error(`Expected updated UMM Platforms[0] for ${collectionConceptId}`)
+  }
+
+  if (updatedPlatform.ShortName !== 'Aqua') {
+    throw new Error(
+      'Expected corrected UMM Platforms[0].ShortName to be Aqua, '
+      + `received ${updatedPlatform.ShortName}`
+    )
+  }
+
+  if (updatedPlatform?.Instruments?.[0]?.ShortName !== 'Legacy MODIS') {
+    throw new Error(
+      'Expected corrected UMM Platforms[0].Instruments[0].ShortName to remain Legacy MODIS'
+    )
+  }
+
+  const auditRows = await getMetadataCorrectionAuditLog({
+    collectionConceptId,
+    limit: 20
+  })
+  const statuses = [...new Set(auditRows.map((row) => row.status))]
+
+  if (!statuses.includes('pending')) {
+    throw new Error(`Missing pending audit status for ${collectionConceptId}`)
+  }
+
+  if (!statuses.includes('applied')) {
+    throw new Error(`Missing applied audit status for ${collectionConceptId}`)
+  }
+
+  await fs.mkdir(outputDir, { recursive: true })
+  await fs.writeFile(outputPath, JSON.stringify({
+    collectionConceptId,
+    providerId,
+    cmrBaseUrl,
+    configuredDelayMs,
+    delayAssertionToleranceMs,
+    requestedAt,
+    startedAtMs,
+    finishedAtMs,
+    elapsedMs,
+    statuses,
+    updatedPlatform,
+    response,
+    rows: auditRows
+  }, null, 2), 'utf8')
+
+  console.log('[metadata-correction-request-delay-smoke] Completed successfully')
+  console.log(JSON.stringify({
+    collectionConceptId,
+    providerId,
+    configuredDelayMs,
+    delayAssertionToleranceMs,
+    elapsedMs,
+    statuses,
+    outputPath
+  }, null, 2))
+} finally {
+  if (redisClient) {
+    await redisClient.quit()
+  }
+
+  if (mockServerProcess) {
+    mockServerProcess.kill('SIGTERM')
+  }
+}

--- a/scripts/local/run_request_metadata_correction_smoke.mjs
+++ b/scripts/local/run_request_metadata_correction_smoke.mjs
@@ -1,0 +1,432 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import {
+  CreateTopicCommand,
+  DeleteTopicCommand,
+  ListTopicsCommand,
+  SNSClient,
+  SubscribeCommand
+} from '@aws-sdk/client-sns'
+import {
+  CreateQueueCommand,
+  DeleteQueueCommand,
+  GetQueueAttributesCommand,
+  ListQueuesCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+  SQSClient
+} from '@aws-sdk/client-sqs'
+
+/**
+ * Local end-to-end smoke for the async metadata-correction request endpoint.
+ *
+ * This smoke drives the real `requestMetadataCorrection` API handler with an
+ * API-Gateway-like event, publishes to a temporary FIFO SNS topic in
+ * LocalStack, and verifies a subscribed FIFO SQS queue receives one deduped
+ * message per collection concept id.
+ *
+ * What this proves:
+ * - the new async endpoint accepts one or more concept ids
+ * - duplicate ids are deduplicated while preserving accepted response order
+ * - one publish happens per accepted collection concept id
+ * - the published payload matches the async consumer contract
+ * - FIFO message groups are keyed by collection concept id
+ *
+ * Prerequisites:
+ * - LocalStack is running on `http://127.0.0.1:4566`
+ *
+ * Run with:
+ *   npx vite-node --config vite.config.js scripts/local/run_request_metadata_correction_smoke.mjs
+ */
+const rootDir = path.resolve(import.meta.dirname, '../..')
+const outputDir = path.resolve(rootDir, 'tmp/request-metadata-correction-smoke')
+const outputPath = path.resolve(outputDir, 'result.json')
+const region = process.env.AWS_REGION || 'us-east-1'
+const localstackEndpoint = process.env.AWS_ENDPOINT_URL || 'http://127.0.0.1:4566'
+const smokeId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+const topicName = `kms-dev-request-metadata-correction-smoke-${smokeId}.fifo`
+const queueName = `kms-dev-request-metadata-correction-smoke-${smokeId}.fifo`
+const queueReceiveTimeoutMs = Number(process.env.QUEUE_RECEIVE_TIMEOUT_MS || '15000')
+
+const requestCollectionConceptIds = (
+  process.env.COLLECTION_CONCEPT_IDS
+    ? process.env.COLLECTION_CONCEPT_IDS.split(',')
+    : ['C1234567890-PROV', ' C0987654321-PROV ', 'C1234567890-PROV']
+).map((value) => String(value))
+
+const expectedAcceptedCollectionConceptIds = [
+  ...new Set(requestCollectionConceptIds.map((value) => value.trim()))
+]
+
+const snsClient = new SNSClient({
+  endpoint: localstackEndpoint,
+  region,
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'test',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'test'
+  }
+})
+
+const sqsClient = new SQSClient({
+  endpoint: localstackEndpoint,
+  region,
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'test',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'test'
+  }
+})
+
+/**
+ * Sleeps for a short interval while polling LocalStack resources.
+ *
+ * @param {number} ms Milliseconds to pause.
+ * @returns {Promise<void>} Resolves after the delay.
+ */
+const sleep = (ms) => new Promise((resolve) => {
+  setTimeout(resolve, ms)
+})
+
+/**
+ * Waits for LocalStack SNS and SQS APIs to start responding.
+ *
+ * @param {number} [attempt=1] Current retry attempt.
+ * @returns {Promise<void>} Resolves when LocalStack is reachable.
+ */
+const waitForLocalStack = async (attempt = 1) => {
+  try {
+    await snsClient.send(new ListTopicsCommand({}))
+    await sqsClient.send(new ListQueuesCommand({}))
+
+    return
+  } catch {
+    // Keep polling until LocalStack comes up.
+  }
+
+  if (attempt >= 40) {
+    throw new Error(`Timed out waiting for LocalStack endpoint: ${localstackEndpoint}`)
+  }
+
+  await sleep(250)
+  await waitForLocalStack(attempt + 1)
+}
+
+/**
+ * Builds the SQS queue policy that allows the temporary SNS topic to publish.
+ *
+ * @param {Object} params Policy inputs.
+ * @param {string} params.queueArn Queue ARN.
+ * @param {string} params.topicArn Topic ARN.
+ * @returns {string} Serialized queue policy JSON.
+ */
+const buildQueuePolicy = ({
+  queueArn,
+  topicArn
+}) => JSON.stringify({
+  Version: '2012-10-17',
+  Statement: [{
+    Sid: 'AllowMetadataCorrectionSmokeTopic',
+    Effect: 'Allow',
+    Principal: {
+      Service: 'sns.amazonaws.com'
+    },
+    Action: 'sqs:SendMessage',
+    Resource: queueArn,
+    Condition: {
+      ArnEquals: {
+        'aws:SourceArn': topicArn
+      }
+    }
+  }]
+})
+
+/**
+ * Parses either a raw SNS-to-SQS message body or the default SNS envelope body.
+ *
+ * @param {string} body SQS message body.
+ * @returns {Object} Parsed metadata correction request payload.
+ */
+const parsePublishedRequestBody = (body) => {
+  const parsedBody = JSON.parse(body)
+
+  if (typeof parsedBody?.Message === 'string') {
+    return JSON.parse(parsedBody.Message)
+  }
+
+  return parsedBody
+}
+
+/**
+ * Polls the subscribed queue until the expected number of messages arrive.
+ *
+ * @param {Object} params Polling parameters.
+ * @param {string} params.queueUrl Queue URL.
+ * @param {number} params.expectedCount Expected message count.
+ * @returns {Promise<Array<Object>>} Received SQS messages.
+ */
+const waitForMessages = async ({
+  queueUrl,
+  expectedCount,
+  deadlineMs = Date.now() + queueReceiveTimeoutMs,
+  receivedMessages = [],
+  seenReceiptHandles = new Set()
+}) => {
+  if (Date.now() >= deadlineMs || receivedMessages.length >= expectedCount) {
+    return receivedMessages
+  }
+
+  const response = await sqsClient.send(new ReceiveMessageCommand({
+    QueueUrl: queueUrl,
+    MaxNumberOfMessages: 10,
+    WaitTimeSeconds: 2,
+    AttributeNames: ['All'],
+    MessageAttributeNames: ['All']
+  }))
+
+  const messages = response.Messages || []
+
+  messages.forEach((message) => {
+    if (!seenReceiptHandles.has(message.ReceiptHandle)) {
+      seenReceiptHandles.add(message.ReceiptHandle)
+      receivedMessages.push(message)
+    }
+  })
+
+  return waitForMessages({
+    queueUrl,
+    expectedCount,
+    deadlineMs,
+    receivedMessages,
+    seenReceiptHandles
+  })
+}
+
+let topicArn
+let queueUrl
+
+try {
+  await waitForLocalStack()
+
+  const createTopicResponse = await snsClient.send(new CreateTopicCommand({
+    Name: topicName,
+    Attributes: {
+      FifoTopic: 'true',
+      ContentBasedDeduplication: 'true'
+    }
+  }))
+
+  topicArn = createTopicResponse.TopicArn
+
+  if (!topicArn) {
+    throw new Error(`Failed to create smoke SNS topic for ${topicName}`)
+  }
+
+  const createQueueResponse = await sqsClient.send(new CreateQueueCommand({
+    QueueName: queueName,
+    Attributes: {
+      FifoQueue: 'true',
+      ContentBasedDeduplication: 'true'
+    }
+  }))
+
+  queueUrl = createQueueResponse.QueueUrl
+
+  if (!queueUrl) {
+    throw new Error(`Failed to create smoke SQS queue for ${queueName}`)
+  }
+
+  const queueAttributesResponse = await sqsClient.send(new GetQueueAttributesCommand({
+    QueueUrl: queueUrl,
+    AttributeNames: ['QueueArn']
+  }))
+
+  const queueArn = queueAttributesResponse.Attributes?.QueueArn
+
+  if (!queueArn) {
+    throw new Error(`Failed to resolve QueueArn for ${queueName}`)
+  }
+
+  await sqsClient.send(new SetQueueAttributesCommand({
+    QueueUrl: queueUrl,
+    Attributes: {
+      Policy: buildQueuePolicy({
+        queueArn,
+        topicArn
+      })
+    }
+  }))
+
+  await snsClient.send(new SubscribeCommand({
+    TopicArn: topicArn,
+    Protocol: 'sqs',
+    Endpoint: queueArn,
+    Attributes: {
+      RawMessageDelivery: 'true'
+    }
+  }))
+
+  process.env.AWS_ENDPOINT_URL = localstackEndpoint
+  process.env.METADATA_CORRECTION_REQUESTS_TOPIC_ARN = topicArn
+
+  const { requestMetadataCorrection } = await import('../../serverless/src/requestMetadataCorrection/handler')
+
+  const response = await requestMetadataCorrection({
+    body: JSON.stringify({
+      collectionConceptIds: requestCollectionConceptIds
+    })
+  }, {})
+
+  if (response.statusCode !== 202) {
+    throw new Error(
+      'Expected 202 response from requestMetadataCorrection, '
+      + `received ${response.statusCode}: ${response.body}`
+    )
+  }
+
+  const responseBody = JSON.parse(response.body)
+
+  if (responseBody.requestedCount !== requestCollectionConceptIds.length) {
+    throw new Error(
+      `Expected requestedCount=${requestCollectionConceptIds.length}, `
+      + `received ${responseBody.requestedCount}`
+    )
+  }
+
+  if (responseBody.acceptedCount !== expectedAcceptedCollectionConceptIds.length) {
+    throw new Error(
+      `Expected acceptedCount=${expectedAcceptedCollectionConceptIds.length}, `
+      + `received ${responseBody.acceptedCount}`
+    )
+  }
+
+  const acceptedCollectionConceptIds = responseBody.accepted
+    .map(({ collectionConceptId }) => collectionConceptId)
+
+  if (
+    JSON.stringify(acceptedCollectionConceptIds)
+    !== JSON.stringify(expectedAcceptedCollectionConceptIds)
+  ) {
+    throw new Error(
+      'Expected accepted collectionConceptIds to preserve trimmed first-seen order. '
+      + `Expected=${JSON.stringify(expectedAcceptedCollectionConceptIds)} `
+      + `Received=${JSON.stringify(acceptedCollectionConceptIds)}`
+    )
+  }
+
+  responseBody.accepted.forEach((acceptedEntry) => {
+    if (!acceptedEntry?.messageId) {
+      throw new Error(
+        `Expected messageId in accepted response entry: ${JSON.stringify(acceptedEntry)}`
+      )
+    }
+
+    if (acceptedEntry.messageGroupId !== acceptedEntry.collectionConceptId) {
+      throw new Error(
+        'Expected messageGroupId to equal collectionConceptId in accepted response entry. '
+        + `Received=${JSON.stringify(acceptedEntry)}`
+      )
+    }
+  })
+
+  const receivedMessages = await waitForMessages({
+    queueUrl,
+    expectedCount: expectedAcceptedCollectionConceptIds.length
+  })
+
+  if (receivedMessages.length !== expectedAcceptedCollectionConceptIds.length) {
+    throw new Error(
+      `Expected ${expectedAcceptedCollectionConceptIds.length} published SQS messages, `
+      + `received ${receivedMessages.length}`
+    )
+  }
+
+  const parsedMessages = receivedMessages.map((message) => ({
+    messageId: message.MessageId,
+    messageGroupId: message.Attributes?.MessageGroupId,
+    body: parsePublishedRequestBody(message.Body || '{}')
+  }))
+
+  const receivedCollectionConceptIds = parsedMessages
+    .map(({ body }) => body.collectionConceptId)
+    .sort()
+  const expectedSortedCollectionConceptIds = [...expectedAcceptedCollectionConceptIds].sort()
+
+  if (
+    JSON.stringify(receivedCollectionConceptIds)
+    !== JSON.stringify(expectedSortedCollectionConceptIds)
+  ) {
+    throw new Error(
+      'Expected published collectionConceptIds to match deduplicated request ids. '
+      + `Expected=${JSON.stringify(expectedSortedCollectionConceptIds)} `
+      + `Received=${JSON.stringify(receivedCollectionConceptIds)}`
+    )
+  }
+
+  const requestedAtValues = [
+    ...new Set(parsedMessages.map(({ body }) => body.requestedAt))
+  ]
+
+  if (requestedAtValues.length !== 1) {
+    throw new Error(
+      `Expected exactly one shared requestedAt timestamp, received ${requestedAtValues.length}`
+    )
+  }
+
+  parsedMessages.forEach(({ body, messageGroupId }) => {
+    if (body.source !== 'metadataCorrectionApi') {
+      throw new Error(
+        `Expected published source=metadataCorrectionApi, received ${body.source}`
+      )
+    }
+
+    if (!expectedAcceptedCollectionConceptIds.includes(body.collectionConceptId)) {
+      throw new Error(
+        `Unexpected published collectionConceptId=${body.collectionConceptId}`
+      )
+    }
+
+    if (messageGroupId && messageGroupId !== body.collectionConceptId) {
+      throw new Error(
+        `Expected SQS MessageGroupId=${body.collectionConceptId}, received ${messageGroupId}`
+      )
+    }
+  })
+
+  const result = {
+    localstackEndpoint,
+    topicArn,
+    queueUrl,
+    requestCollectionConceptIds,
+    expectedAcceptedCollectionConceptIds,
+    responseBody,
+    parsedMessages,
+    outputPath
+  }
+
+  await fs.mkdir(outputDir, { recursive: true })
+  await fs.writeFile(outputPath, JSON.stringify(result, null, 2), 'utf8')
+
+  console.log('[request-metadata-correction-smoke] Completed successfully')
+  console.log(JSON.stringify({
+    requestedCount: responseBody.requestedCount,
+    acceptedCount: responseBody.acceptedCount,
+    acceptedCollectionConceptIds,
+    topicArn,
+    queueUrl,
+    outputPath
+  }, null, 2))
+} finally {
+  if (topicArn) {
+    await snsClient.send(new DeleteTopicCommand({
+      TopicArn: topicArn
+    })).catch(() => {})
+  }
+
+  if (queueUrl) {
+    await sqsClient.send(new DeleteQueueCommand({
+      QueueUrl: queueUrl
+    })).catch(() => {})
+  }
+}

--- a/serverless/src/metadataCorrectionService/__tests__/handler.test.js
+++ b/serverless/src/metadataCorrectionService/__tests__/handler.test.js
@@ -1448,7 +1448,7 @@ describe('when the metadata correction service is invoked', () => {
   })
 
   describe('when the invocation is unsuccessful', () => {
-    test('should reject requests that omit the collection concept id', async () => {
+    test('should mark requests that omit the collection concept id for retry', async () => {
       await expect(metadataCorrectionService({
         Records: [
           {
@@ -1456,14 +1456,14 @@ describe('when the metadata correction service is invoked', () => {
             body: JSON.stringify({})
           }
         ]
-      })).rejects.toThrow(
-        'Incomplete metadata correction request: missing collectionConceptId'
-      )
+      })).resolves.toEqual({
+        batchItemFailures: [{ itemIdentifier: 'message-missing-concept-id' }]
+      })
 
       expect(invokeMetadataCorrectionDelegate).not.toHaveBeenCalled()
     })
 
-    test('should reject collection requests whose detected native format is unsupported', async () => {
+    test('should mark collection requests whose detected native format is unsupported for retry', async () => {
       vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
         collectionConceptId: 'C123-UNKNOWN',
         providerId: 'PROV',
@@ -1484,13 +1484,15 @@ describe('when the metadata correction service is invoked', () => {
             })
           }
         ]
-      })).rejects.toThrow('Unsupported native format: UNKNOWN')
+      })).resolves.toEqual({
+        batchItemFailures: [{ itemIdentifier: 'message-unknown-format' }]
+      })
 
       expect(validateCmrCollectionUmm).not.toHaveBeenCalled()
       expect(invokeMetadataCorrectionDelegate).not.toHaveBeenCalled()
     })
 
-    test('should reject DIF9 collections until a dedicated DIF9 delegate exists', async () => {
+    test('should mark DIF9 collections for retry until a dedicated DIF9 delegate exists', async () => {
       vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
         collectionConceptId: 'C123-DIF9',
         providerId: 'PROV',
@@ -1511,22 +1513,24 @@ describe('when the metadata correction service is invoked', () => {
             })
           }
         ]
-      })).rejects.toThrow('Unsupported native format: DIF9')
+      })).resolves.toEqual({
+        batchItemFailures: [{ itemIdentifier: 'message-dif9-format' }]
+      })
 
       expect(validateCmrCollectionUmm).not.toHaveBeenCalled()
       expect(invokeMetadataCorrectionDelegate).not.toHaveBeenCalled()
     })
 
-    test('should reject a missing record body as an incomplete request', async () => {
+    test('should mark a missing record body as an incomplete request for retry', async () => {
       await expect(metadataCorrectionService({
         Records: [
           {
             messageId: 'message-999'
           }
         ]
-      })).rejects.toThrow(
-        'Incomplete metadata correction request: missing collectionConceptId'
-      )
+      })).resolves.toEqual({
+        batchItemFailures: [{ itemIdentifier: 'message-999' }]
+      })
 
       expect(logger.info).toHaveBeenCalledWith(
         '[metadata-correction] Received metadata correction request',
@@ -1537,7 +1541,7 @@ describe('when the metadata correction service is invoked', () => {
       )
     })
 
-    test('should log the error and throw when the record body cannot be parsed', async () => {
+    test('should log the error and mark the record body for retry when it cannot be parsed', async () => {
       await expect(metadataCorrectionService({
         Records: [
           {
@@ -1545,7 +1549,9 @@ describe('when the metadata correction service is invoked', () => {
             body: 'not-json'
           }
         ]
-      })).rejects.toThrow()
+      })).resolves.toEqual({
+        batchItemFailures: [{ itemIdentifier: 'message-123' }]
+      })
 
       expect(logger.error).toHaveBeenCalledWith(
         '[metadata-correction] Failed to process metadata correction request',
@@ -1561,7 +1567,9 @@ describe('when the metadata correction service is invoked', () => {
             body: 'not-json'
           }
         ]
-      })).rejects.toThrow()
+      })).resolves.toEqual({
+        batchItemFailures: [{ itemIdentifier: 'message-processing-failure' }]
+      })
 
       expect(emitConsumerMetricsSafely).toHaveBeenCalledWith(expect.objectContaining({
         metrics: [
@@ -1582,6 +1590,56 @@ describe('when the metadata correction service is invoked', () => {
           recordCount: 1
         })
       }))
+    })
+
+    test('should only return the failed message ids when a batch partially fails', async () => {
+      vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
+        collectionConceptId: 'C1234567890-PROV',
+        providerId: 'PROV',
+        nativeId: 'native-123',
+        revisionId: 7,
+        format: 'application/dif10+xml',
+        umm: {}
+      })
+
+      vi.mocked(getCmrCollectionNativeMetadata).mockResolvedValue({
+        revisionId: 7,
+        providerId: 'PROV',
+        nativeId: 'native-123',
+        nativeFormat: 'DIF10',
+        nativeMetadataContentType: 'application/dif10+xml',
+        conceptId: 'C1234567890-PROV',
+        rawMetadata: '<DIF></DIF>'
+      })
+
+      vi.mocked(validateCmrCollectionUmm).mockResolvedValue({
+        status: 200,
+        errors: [],
+        warnings: [],
+        responseBody: {
+          errors: [],
+          warnings: []
+        }
+      })
+
+      vi.mocked(extractKeywordValidationFailures).mockReturnValue([])
+
+      await expect(metadataCorrectionService({
+        Records: [
+          {
+            messageId: 'message-success',
+            body: JSON.stringify({
+              collectionConceptId: 'C1234567890-PROV'
+            })
+          },
+          {
+            messageId: 'message-failure',
+            body: 'not-json'
+          }
+        ]
+      })).resolves.toEqual({
+        batchItemFailures: [{ itemIdentifier: 'message-failure' }]
+      })
     })
 
     test('should log and continue when processing metric emission fails', async () => {

--- a/serverless/src/metadataCorrectionService/__tests__/handler.test.js
+++ b/serverless/src/metadataCorrectionService/__tests__/handler.test.js
@@ -6,6 +6,7 @@ import {
   vi
 } from 'vitest'
 
+import { delay } from '@/shared/delay'
 import { CONSUMER_METRIC_NAMES } from '@/shared/emitConsumerMetrics'
 import { emitConsumerMetricsSafely } from '@/shared/emitConsumerMetricsSafely'
 import { extractKeywordValidationFailures } from '@/shared/extractKeywordValidationFailures'
@@ -53,6 +54,10 @@ vi.mock('@/shared/emitConsumerMetrics', () => ({
     KEYWORDS_RESOLVED: 'KeywordsResolved'
   },
   emitConsumerMetrics: vi.fn()
+}))
+
+vi.mock('@/shared/delay', () => ({
+  delay: vi.fn()
 }))
 
 vi.mock('@/shared/emitConsumerMetricsSafely', () => ({
@@ -118,6 +123,8 @@ const NEW_TRIGGER_SCIENCE_KEYWORD_OBJECT = {
 describe('when the metadata correction service is invoked', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    delete process.env.METADATA_CORRECTION_REQUEST_DELAY_MS
+    vi.mocked(delay).mockResolvedValue(undefined)
     vi.mocked(emitConsumerMetricsSafely).mockResolvedValue(undefined)
 
     vi.mocked(invokeMetadataCorrectionDelegate).mockResolvedValue({
@@ -1210,6 +1217,181 @@ describe('when the metadata correction service is invoked', () => {
           recordCount: 1
         })
       }))
+    })
+
+    test('should delay queued manual api requests when configured before running correction', async () => {
+      const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+      process.env.METADATA_CORRECTION_REQUEST_DELAY_MS = '5000'
+
+      vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
+        collectionConceptId: 'C1234567890-PROV',
+        providerId: 'PROV',
+        nativeId: 'native-123',
+        revisionId: 7,
+        format: 'application/dif10+xml',
+        umm: {}
+      })
+
+      vi.mocked(validateCmrCollectionUmm).mockResolvedValue({
+        status: 200,
+        errors: [],
+        warnings: [],
+        responseBody: {
+          errors: [],
+          warnings: []
+        }
+      })
+
+      vi.mocked(extractKeywordValidationFailures).mockReturnValue([])
+
+      await metadataCorrectionService({
+        Records: [
+          {
+            messageId: 'message-manual-delay',
+            body: JSON.stringify({
+              source: 'metadataCorrectionApi',
+              requestedAt: '1970-01-01T00:00:08.000Z',
+              collectionConceptId: 'C1234567890-PROV'
+            })
+          }
+        ]
+      })
+
+      expect(delay).toHaveBeenCalledWith(3000)
+      expect(logger.info).toHaveBeenCalledWith(
+        '[metadata-correction] Delaying queued manual metadata correction request',
+        expect.objectContaining({
+          collectionConceptId: 'C1234567890-PROV',
+          messageId: 'message-manual-delay',
+          configuredDelayMs: 5000,
+          remainingDelayMs: 3000
+        })
+      )
+
+      dateNowSpy.mockRestore()
+    })
+
+    test('should skip the delay when requestedAt cannot be parsed', async () => {
+      process.env.METADATA_CORRECTION_REQUEST_DELAY_MS = '5000'
+
+      vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
+        collectionConceptId: 'C1234567890-PROV',
+        providerId: 'PROV',
+        nativeId: 'native-123',
+        revisionId: 7,
+        format: 'application/dif10+xml',
+        umm: {}
+      })
+
+      vi.mocked(validateCmrCollectionUmm).mockResolvedValue({
+        status: 200,
+        errors: [],
+        warnings: [],
+        responseBody: {
+          errors: [],
+          warnings: []
+        }
+      })
+
+      vi.mocked(extractKeywordValidationFailures).mockReturnValue([])
+
+      await metadataCorrectionService({
+        Records: [
+          {
+            messageId: 'message-manual-delay-invalid-requested-at',
+            body: JSON.stringify({
+              source: 'metadataCorrectionApi',
+              requestedAt: 'not-a-date',
+              collectionConceptId: 'C1234567890-PROV'
+            })
+          }
+        ]
+      })
+
+      expect(delay).not.toHaveBeenCalled()
+    })
+
+    test('should skip the delay when the configured delay value is invalid', async () => {
+      process.env.METADATA_CORRECTION_REQUEST_DELAY_MS = 'not-a-number'
+
+      vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
+        collectionConceptId: 'C1234567890-PROV',
+        providerId: 'PROV',
+        nativeId: 'native-123',
+        revisionId: 7,
+        format: 'application/dif10+xml',
+        umm: {}
+      })
+
+      vi.mocked(validateCmrCollectionUmm).mockResolvedValue({
+        status: 200,
+        errors: [],
+        warnings: [],
+        responseBody: {
+          errors: [],
+          warnings: []
+        }
+      })
+
+      vi.mocked(extractKeywordValidationFailures).mockReturnValue([])
+
+      await metadataCorrectionService({
+        Records: [
+          {
+            messageId: 'message-manual-delay-invalid-config',
+            body: JSON.stringify({
+              source: 'metadataCorrectionApi',
+              requestedAt: '1970-01-01T00:00:08.000Z',
+              collectionConceptId: 'C1234567890-PROV'
+            })
+          }
+        ]
+      })
+
+      expect(delay).not.toHaveBeenCalled()
+    })
+
+    test('should skip the delay when the configured window has already elapsed', async () => {
+      const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(20_000)
+      process.env.METADATA_CORRECTION_REQUEST_DELAY_MS = '5000'
+
+      vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
+        collectionConceptId: 'C1234567890-PROV',
+        providerId: 'PROV',
+        nativeId: 'native-123',
+        revisionId: 7,
+        format: 'application/dif10+xml',
+        umm: {}
+      })
+
+      vi.mocked(validateCmrCollectionUmm).mockResolvedValue({
+        status: 200,
+        errors: [],
+        warnings: [],
+        responseBody: {
+          errors: [],
+          warnings: []
+        }
+      })
+
+      vi.mocked(extractKeywordValidationFailures).mockReturnValue([])
+
+      await metadataCorrectionService({
+        Records: [
+          {
+            messageId: 'message-manual-delay-elapsed',
+            body: JSON.stringify({
+              source: 'metadataCorrectionApi',
+              requestedAt: '1970-01-01T00:00:08.000Z',
+              collectionConceptId: 'C1234567890-PROV'
+            })
+          }
+        ]
+      })
+
+      expect(delay).not.toHaveBeenCalled()
+
+      dateNowSpy.mockRestore()
     })
   })
 

--- a/serverless/src/metadataCorrectionService/__tests__/handler.test.js
+++ b/serverless/src/metadataCorrectionService/__tests__/handler.test.js
@@ -1221,7 +1221,7 @@ describe('when the metadata correction service is invoked', () => {
 
     test('should delay queued manual api requests when configured before running correction', async () => {
       const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
-      process.env.METADATA_CORRECTION_REQUEST_DELAY_MS = '5000'
+      process.env.METADATA_CORRECTION_REQUEST_DELAY_MS = '1500'
 
       vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
         collectionConceptId: 'C1234567890-PROV',
@@ -1250,21 +1250,73 @@ describe('when the metadata correction service is invoked', () => {
             messageId: 'message-manual-delay',
             body: JSON.stringify({
               source: 'metadataCorrectionApi',
-              requestedAt: '1970-01-01T00:00:08.000Z',
+              requestedAt: '1970-01-01T00:00:09.000Z',
               collectionConceptId: 'C1234567890-PROV'
             })
           }
         ]
       })
 
-      expect(delay).toHaveBeenCalledWith(3000)
+      expect(delay).toHaveBeenCalledWith(500)
       expect(logger.info).toHaveBeenCalledWith(
         '[metadata-correction] Delaying queued manual metadata correction request',
         expect.objectContaining({
           collectionConceptId: 'C1234567890-PROV',
           messageId: 'message-manual-delay',
-          configuredDelayMs: 5000,
-          remainingDelayMs: 3000
+          configuredDelayMs: 1500,
+          remainingDelayMs: 500
+        })
+      )
+
+      dateNowSpy.mockRestore()
+    })
+
+    test('should clamp oversized delay configuration to 2000ms', async () => {
+      const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+      process.env.METADATA_CORRECTION_REQUEST_DELAY_MS = '5000'
+
+      vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
+        collectionConceptId: 'C1234567890-PROV',
+        providerId: 'PROV',
+        nativeId: 'native-123',
+        revisionId: 7,
+        format: 'application/dif10+xml',
+        umm: {}
+      })
+
+      vi.mocked(validateCmrCollectionUmm).mockResolvedValue({
+        status: 200,
+        errors: [],
+        warnings: [],
+        responseBody: {
+          errors: [],
+          warnings: []
+        }
+      })
+
+      vi.mocked(extractKeywordValidationFailures).mockReturnValue([])
+
+      await metadataCorrectionService({
+        Records: [
+          {
+            messageId: 'message-manual-delay-clamped',
+            body: JSON.stringify({
+              source: 'metadataCorrectionApi',
+              requestedAt: '1970-01-01T00:00:09.000Z',
+              collectionConceptId: 'C1234567890-PROV'
+            })
+          }
+        ]
+      })
+
+      expect(delay).toHaveBeenCalledWith(1000)
+      expect(logger.info).toHaveBeenCalledWith(
+        '[metadata-correction] Delaying queued manual metadata correction request',
+        expect.objectContaining({
+          collectionConceptId: 'C1234567890-PROV',
+          messageId: 'message-manual-delay-clamped',
+          configuredDelayMs: 2000,
+          remainingDelayMs: 1000
         })
       )
 

--- a/serverless/src/metadataCorrectionService/__tests__/handler.test.js
+++ b/serverless/src/metadataCorrectionService/__tests__/handler.test.js
@@ -1271,9 +1271,9 @@ describe('when the metadata correction service is invoked', () => {
       dateNowSpy.mockRestore()
     })
 
-    test('should clamp oversized delay configuration to 2000ms', async () => {
+    test('should clamp oversized delay configuration to 20000ms', async () => {
       const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
-      process.env.METADATA_CORRECTION_REQUEST_DELAY_MS = '5000'
+      process.env.METADATA_CORRECTION_REQUEST_DELAY_MS = '30000'
 
       vi.mocked(getCmrCollectionUmmDetails).mockResolvedValue({
         collectionConceptId: 'C1234567890-PROV',
@@ -1309,14 +1309,14 @@ describe('when the metadata correction service is invoked', () => {
         ]
       })
 
-      expect(delay).toHaveBeenCalledWith(1000)
+      expect(delay).toHaveBeenCalledWith(19_000)
       expect(logger.info).toHaveBeenCalledWith(
         '[metadata-correction] Delaying queued manual metadata correction request',
         expect.objectContaining({
           collectionConceptId: 'C1234567890-PROV',
           messageId: 'message-manual-delay-clamped',
-          configuredDelayMs: 2000,
-          remainingDelayMs: 1000
+          configuredDelayMs: 20_000,
+          remainingDelayMs: 19_000
         })
       )
 

--- a/serverless/src/metadataCorrectionService/handler.js
+++ b/serverless/src/metadataCorrectionService/handler.js
@@ -40,6 +40,8 @@ const buildBatchProcessingMetrics = ({
   return metrics
 }
 
+const MAX_METADATA_CORRECTION_REQUEST_DELAY_MS = 2000
+
 /**
  * Reads the optional async correction request delay from environment configuration.
  *
@@ -55,7 +57,7 @@ const getMetadataCorrectionRequestDelayMs = () => {
   const parsedValue = Number(rawValue)
 
   return Number.isFinite(parsedValue) && parsedValue > 0
-    ? parsedValue
+    ? Math.min(parsedValue, MAX_METADATA_CORRECTION_REQUEST_DELAY_MS)
     : 0
 }
 

--- a/serverless/src/metadataCorrectionService/handler.js
+++ b/serverless/src/metadataCorrectionService/handler.js
@@ -114,7 +114,8 @@ const delayQueuedManualRequestIfNeeded = async ({
  * flow can also be reused by synchronous API endpoints.
  *
  * @param {{ Records?: Array<{ body?: string, messageId?: string }> }} event - SQS batch event.
- * @returns {Promise<{batchItemFailures: Array}>} Empty batch failures for acknowledged messages.
+ * @returns {Promise<{batchItemFailures: Array<{itemIdentifier: string}>}>}
+ *   Failed message identifiers to retry through SQS partial batch response handling.
  */
 export const metadataCorrectionService = async (event) => {
   const records = event?.Records || []
@@ -165,16 +166,18 @@ export const metadataCorrectionService = async (event) => {
         recordCount: records.length
       }
     })
-
-    const firstRejectedResult = settledResults.find(({ status }) => status === 'rejected')
-
-    if (firstRejectedResult) {
-      throw firstRejectedResult.reason
-    }
   }
 
   return {
-    batchItemFailures: []
+    batchItemFailures: settledResults.reduce((failures, result, index) => {
+      const itemIdentifier = records[index]?.messageId
+
+      if (result.status === 'rejected' && itemIdentifier) {
+        failures.push({ itemIdentifier })
+      }
+
+      return failures
+    }, [])
   }
 }
 

--- a/serverless/src/metadataCorrectionService/handler.js
+++ b/serverless/src/metadataCorrectionService/handler.js
@@ -40,7 +40,7 @@ const buildBatchProcessingMetrics = ({
   return metrics
 }
 
-const MAX_METADATA_CORRECTION_REQUEST_DELAY_MS = 2000
+const MAX_METADATA_CORRECTION_REQUEST_DELAY_MS = 20_000
 
 /**
  * Reads the optional async correction request delay from environment configuration.

--- a/serverless/src/metadataCorrectionService/handler.js
+++ b/serverless/src/metadataCorrectionService/handler.js
@@ -1,3 +1,4 @@
+import { delay } from '@/shared/delay'
 import { CONSUMER_METRIC_NAMES } from '@/shared/emitConsumerMetrics'
 import { emitConsumerMetricsSafely } from '@/shared/emitConsumerMetricsSafely'
 import { logger } from '@/shared/logger'
@@ -40,6 +41,70 @@ const buildBatchProcessingMetrics = ({
 }
 
 /**
+ * Reads the optional async correction request delay from environment configuration.
+ *
+ * @returns {number} Delay in milliseconds, or `0` when unset/invalid.
+ */
+const getMetadataCorrectionRequestDelayMs = () => {
+  const rawValue = process.env.METADATA_CORRECTION_REQUEST_DELAY_MS
+
+  if (!rawValue) {
+    return 0
+  }
+
+  const parsedValue = Number(rawValue)
+
+  return Number.isFinite(parsedValue) && parsedValue > 0
+    ? parsedValue
+    : 0
+}
+
+/**
+ * Applies the optional delay window for queued manual API requests before processing starts.
+ *
+ * @param {Object} params Delay inputs.
+ * @param {string|undefined} params.collectionConceptId Collection concept id being processed.
+ * @param {string|undefined} params.messageId SQS message id for logging.
+ * @param {Object} params.metadataCorrectionRequest Parsed metadata correction request.
+ * @returns {Promise<void>}
+ */
+const delayQueuedManualRequestIfNeeded = async ({
+  collectionConceptId,
+  messageId,
+  metadataCorrectionRequest
+}) => {
+  const configuredDelayMs = getMetadataCorrectionRequestDelayMs()
+
+  if (configuredDelayMs <= 0
+    || metadataCorrectionRequest?.source !== 'metadataCorrectionApi'
+    || typeof metadataCorrectionRequest?.requestedAt !== 'string') {
+    return
+  }
+
+  const requestedAtMs = Date.parse(metadataCorrectionRequest.requestedAt)
+
+  if (Number.isNaN(requestedAtMs)) {
+    return
+  }
+
+  const remainingDelayMs = (requestedAtMs + configuredDelayMs) - Date.now()
+
+  if (remainingDelayMs <= 0) {
+    return
+  }
+
+  logger.info('[metadata-correction] Delaying queued manual metadata correction request', {
+    collectionConceptId,
+    messageId,
+    requestedAt: metadataCorrectionRequest.requestedAt,
+    configuredDelayMs,
+    remainingDelayMs
+  })
+
+  await delay(remainingDelayMs)
+}
+
+/**
  * Metadata correction service that consumes collection-scoped correction requests from SQS.
  *
  * The worker remains asynchronous for keyword-event-driven correction requests, but the actual
@@ -57,6 +122,12 @@ export const metadataCorrectionService = async (event) => {
       const metadataCorrectionRequest = JSON.parse(record.body || '{}')
 
       logger.info('[metadata-correction] Received metadata correction request', {
+        collectionConceptId: metadataCorrectionRequest.collectionConceptId,
+        messageId: record.messageId,
+        metadataCorrectionRequest
+      })
+
+      await delayQueuedManualRequestIfNeeded({
         collectionConceptId: metadataCorrectionRequest.collectionConceptId,
         messageId: record.messageId,
         metadataCorrectionRequest

--- a/serverless/src/requestMetadataCorrection/__tests__/handler.test.js
+++ b/serverless/src/requestMetadataCorrection/__tests__/handler.test.js
@@ -1,0 +1,196 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi
+} from 'vitest'
+
+import { logger } from '@/shared/logger'
+import { publishMetadataCorrectionRequest } from '@/shared/publishMetadataCorrectionRequest'
+
+import { requestMetadataCorrection } from '../handler'
+
+vi.mock('@/shared/getConfig', () => ({
+  getApplicationConfig: vi.fn(() => ({
+    defaultResponseHeaders: { 'X-Custom-Header': 'CustomValue' }
+  }))
+}))
+
+vi.mock('@/shared/logAnalyticsData', () => ({
+  logAnalyticsData: vi.fn()
+}))
+
+vi.mock('@/shared/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('@/shared/publishMetadataCorrectionRequest', () => ({
+  publishMetadataCorrectionRequest: vi.fn()
+}))
+
+describe('requestMetadataCorrection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns 202 and publishes one deduplicated message per collection concept id', async () => {
+    vi.mocked(publishMetadataCorrectionRequest)
+      .mockResolvedValueOnce({
+        messageId: 'message-1',
+        messageGroupId: 'C123-PROV'
+      })
+      .mockResolvedValueOnce({
+        messageId: 'message-2',
+        messageGroupId: 'C456-PROV'
+      })
+
+    const result = await requestMetadataCorrection({
+      body: JSON.stringify({
+        collectionConceptIds: [
+          'C123-PROV',
+          ' C456-PROV ',
+          'C123-PROV'
+        ]
+      })
+    })
+
+    expect(publishMetadataCorrectionRequest).toHaveBeenCalledTimes(2)
+    expect(publishMetadataCorrectionRequest).toHaveBeenNthCalledWith(1, {
+      source: 'metadataCorrectionApi',
+      collectionConceptId: 'C123-PROV',
+      requestedAt: expect.any(String)
+    })
+
+    expect(publishMetadataCorrectionRequest).toHaveBeenNthCalledWith(2, {
+      source: 'metadataCorrectionApi',
+      collectionConceptId: 'C456-PROV',
+      requestedAt: expect.any(String)
+    })
+
+    expect(result.statusCode).toBe(202)
+    expect(result.headers['Content-Type']).toBe('application/json')
+    expect(result.headers['X-Custom-Header']).toBe('CustomValue')
+    expect(JSON.parse(result.body)).toEqual({
+      requestedCount: 3,
+      acceptedCount: 2,
+      accepted: [
+        {
+          collectionConceptId: 'C123-PROV',
+          messageId: 'message-1',
+          messageGroupId: 'C123-PROV'
+        },
+        {
+          collectionConceptId: 'C456-PROV',
+          messageId: 'message-2',
+          messageGroupId: 'C456-PROV'
+        }
+      ]
+    })
+  })
+
+  test('returns 400 when collectionConceptIds is missing', async () => {
+    const result = await requestMetadataCorrection({
+      body: JSON.stringify({})
+    })
+
+    expect(result.statusCode).toBe(400)
+    expect(JSON.parse(result.body)).toEqual({
+      error: 'Error: Invalid metadata correction request: collectionConceptIds must be an array'
+    })
+
+    expect(publishMetadataCorrectionRequest).not.toHaveBeenCalled()
+  })
+
+  test('returns 400 when the request body is missing', async () => {
+    const result = await requestMetadataCorrection({})
+
+    expect(result.statusCode).toBe(400)
+    expect(JSON.parse(result.body)).toEqual({
+      error: 'Error: Invalid metadata correction request: missing request body'
+    })
+
+    expect(publishMetadataCorrectionRequest).not.toHaveBeenCalled()
+  })
+
+  test('returns 400 when the body is not valid json', async () => {
+    const result = await requestMetadataCorrection({
+      body: 'not-json'
+    })
+
+    expect(result.statusCode).toBe(400)
+    expect(JSON.parse(result.body)).toEqual({
+      error: 'Error: Invalid metadata correction request: body must be valid JSON'
+    })
+
+    expect(publishMetadataCorrectionRequest).not.toHaveBeenCalled()
+  })
+
+  test('returns 400 when collectionConceptIds is empty', async () => {
+    const result = await requestMetadataCorrection({
+      body: JSON.stringify({
+        collectionConceptIds: []
+      })
+    })
+
+    expect(result.statusCode).toBe(400)
+    expect(JSON.parse(result.body)).toEqual({
+      error: 'Error: Invalid metadata correction request: collectionConceptIds must contain at least one value'
+    })
+
+    expect(publishMetadataCorrectionRequest).not.toHaveBeenCalled()
+  })
+
+  test('returns 400 when a collectionConceptIds entry is blank', async () => {
+    const result = await requestMetadataCorrection({
+      body: JSON.stringify({
+        collectionConceptIds: ['C123-PROV', '   ']
+      })
+    })
+
+    expect(result.statusCode).toBe(400)
+    expect(JSON.parse(result.body)).toEqual({
+      error: 'Error: Invalid metadata correction request: collectionConceptIds[1] must be a non-empty string'
+    })
+
+    expect(publishMetadataCorrectionRequest).not.toHaveBeenCalled()
+  })
+
+  test('returns 500 when publish fails and logs the error', async () => {
+    vi.mocked(publishMetadataCorrectionRequest).mockRejectedValue(new Error('SNS unavailable'))
+
+    const result = await requestMetadataCorrection({
+      body: JSON.stringify({
+        collectionConceptIds: ['C123-PROV']
+      })
+    })
+
+    expect(result.statusCode).toBe(500)
+    expect(JSON.parse(result.body)).toEqual({
+      error: 'Error: SNS unavailable'
+    })
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[metadata-correction] Failed asynchronous metadata correction request',
+      expect.any(Error)
+    )
+  })
+
+  test('returns 500 when a non-validation error has an empty message', async () => {
+    vi.mocked(publishMetadataCorrectionRequest).mockRejectedValue(new Error(''))
+
+    const result = await requestMetadataCorrection({
+      body: JSON.stringify({
+        collectionConceptIds: ['C123-PROV']
+      })
+    })
+
+    expect(result.statusCode).toBe(500)
+    expect(JSON.parse(result.body)).toEqual({
+      error: 'Error'
+    })
+  })
+})

--- a/serverless/src/requestMetadataCorrection/__tests__/handler.test.js
+++ b/serverless/src/requestMetadataCorrection/__tests__/handler.test.js
@@ -77,6 +77,7 @@ describe('requestMetadataCorrection', () => {
     expect(JSON.parse(result.body)).toEqual({
       requestedCount: 3,
       acceptedCount: 2,
+      failedCount: 0,
       accepted: [
         {
           collectionConceptId: 'C123-PROV',
@@ -88,8 +89,56 @@ describe('requestMetadataCorrection', () => {
           messageId: 'message-2',
           messageGroupId: 'C456-PROV'
         }
+      ],
+      failed: []
+    })
+  })
+
+  test('returns 202 with accepted and failed publish results when only part of the batch publishes', async () => {
+    vi.mocked(publishMetadataCorrectionRequest)
+      .mockResolvedValueOnce({
+        messageId: 'message-1',
+        messageGroupId: 'C123-PROV'
+      })
+      .mockRejectedValueOnce(new Error('SNS unavailable'))
+
+    const result = await requestMetadataCorrection({
+      body: JSON.stringify({
+        collectionConceptIds: [
+          'C123-PROV',
+          'C456-PROV'
+        ]
+      })
+    })
+
+    expect(result.statusCode).toBe(202)
+    expect(JSON.parse(result.body)).toEqual({
+      requestedCount: 2,
+      acceptedCount: 1,
+      failedCount: 1,
+      accepted: [
+        {
+          collectionConceptId: 'C123-PROV',
+          messageId: 'message-1',
+          messageGroupId: 'C123-PROV'
+        }
+      ],
+      failed: [
+        {
+          collectionConceptId: 'C456-PROV',
+          error: 'Error: SNS unavailable'
+        }
       ]
     })
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[metadata-correction] Partially failed asynchronous metadata correction request',
+      expect.objectContaining({
+        requestedCount: 2,
+        acceptedCount: 1,
+        failedCount: 1
+      })
+    )
   })
 
   test('returns 400 when collectionConceptIds is missing', async () => {
@@ -124,6 +173,32 @@ describe('requestMetadataCorrection', () => {
     expect(result.statusCode).toBe(400)
     expect(JSON.parse(result.body)).toEqual({
       error: 'Error: Invalid metadata correction request: body must be valid JSON'
+    })
+
+    expect(publishMetadataCorrectionRequest).not.toHaveBeenCalled()
+  })
+
+  test('returns 400 when the body is literal null', async () => {
+    const result = await requestMetadataCorrection({
+      body: 'null'
+    })
+
+    expect(result.statusCode).toBe(400)
+    expect(JSON.parse(result.body)).toEqual({
+      error: 'Error: Invalid metadata correction request: body must be a JSON object'
+    })
+
+    expect(publishMetadataCorrectionRequest).not.toHaveBeenCalled()
+  })
+
+  test('returns 400 when the body is a json array', async () => {
+    const result = await requestMetadataCorrection({
+      body: '[]'
+    })
+
+    expect(result.statusCode).toBe(400)
+    expect(JSON.parse(result.body)).toEqual({
+      error: 'Error: Invalid metadata correction request: body must be a JSON object'
     })
 
     expect(publishMetadataCorrectionRequest).not.toHaveBeenCalled()

--- a/serverless/src/requestMetadataCorrection/__tests__/handler.test.js
+++ b/serverless/src/requestMetadataCorrection/__tests__/handler.test.js
@@ -141,6 +141,44 @@ describe('requestMetadataCorrection', () => {
     )
   })
 
+  test('returns 202 and stringifies non-Error publish failures in partial batch results', async () => {
+    vi.mocked(publishMetadataCorrectionRequest)
+      .mockResolvedValueOnce({
+        messageId: 'message-1',
+        messageGroupId: 'C123-PROV'
+      })
+      .mockRejectedValueOnce('SNS unavailable')
+
+    const result = await requestMetadataCorrection({
+      body: JSON.stringify({
+        collectionConceptIds: [
+          'C123-PROV',
+          'C456-PROV'
+        ]
+      })
+    })
+
+    expect(result.statusCode).toBe(202)
+    expect(JSON.parse(result.body)).toEqual({
+      requestedCount: 2,
+      acceptedCount: 1,
+      failedCount: 1,
+      accepted: [
+        {
+          collectionConceptId: 'C123-PROV',
+          messageId: 'message-1',
+          messageGroupId: 'C123-PROV'
+        }
+      ],
+      failed: [
+        {
+          collectionConceptId: 'C456-PROV',
+          error: 'SNS unavailable'
+        }
+      ]
+    })
+  })
+
   test('returns 400 when collectionConceptIds is missing', async () => {
     const result = await requestMetadataCorrection({
       body: JSON.stringify({})

--- a/serverless/src/requestMetadataCorrection/handler.js
+++ b/serverless/src/requestMetadataCorrection/handler.js
@@ -87,20 +87,6 @@ const getErrorStatusCode = (error) => {
 }
 
 /**
- * Converts a rejected publish reason into a stable response/log string.
- *
- * @param {unknown} error Rejection reason.
- * @returns {string} Serialized error message.
- */
-const toErrorMessage = (error) => {
-  if (error instanceof Error) {
-    return error.toString()
-  }
-
-  return String(error)
-}
-
-/**
  * Queues metadata correction requests for one or more collection concept ids.
  *
  * This endpoint is intentionally fire-and-forget. It validates the request body, deduplicates
@@ -162,7 +148,9 @@ export const requestMetadataCorrection = async (event, context) => {
 
       failed.push({
         collectionConceptId: acceptedCollectionConceptIds[index],
-        error: toErrorMessage(result.reason)
+        error: result.reason instanceof Error
+          ? result.reason.toString()
+          : String(result.reason)
       })
     })
 

--- a/serverless/src/requestMetadataCorrection/handler.js
+++ b/serverless/src/requestMetadataCorrection/handler.js
@@ -1,0 +1,159 @@
+import { getApplicationConfig } from '@/shared/getConfig'
+import { logAnalyticsData } from '@/shared/logAnalyticsData'
+import { logger } from '@/shared/logger'
+import { publishMetadataCorrectionRequest } from '@/shared/publishMetadataCorrectionRequest'
+
+/**
+ * Parses the API Gateway JSON request body.
+ *
+ * @param {string|undefined} body Raw API Gateway request body.
+ * @returns {Object} Parsed request payload.
+ * @throws {Error} When the body is missing or invalid JSON.
+ */
+const parseRequestBody = (body) => {
+  if (typeof body !== 'string' || body.trim().length === 0) {
+    throw new Error('Invalid metadata correction request: missing request body')
+  }
+
+  try {
+    return JSON.parse(body)
+  } catch {
+    throw new Error('Invalid metadata correction request: body must be valid JSON')
+  }
+}
+
+/**
+ * Validates and deduplicates collection concept ids while preserving request order.
+ *
+ * @param {unknown} collectionConceptIds Raw request field value.
+ * @returns {{ requestedCount: number, acceptedCollectionConceptIds: string[] }} Normalized request details.
+ * @throws {Error} When the request does not contain one or more valid concept ids.
+ */
+const normalizeCollectionConceptIds = (collectionConceptIds) => {
+  if (!Array.isArray(collectionConceptIds)) {
+    throw new Error('Invalid metadata correction request: collectionConceptIds must be an array')
+  }
+
+  if (collectionConceptIds.length === 0) {
+    throw new Error('Invalid metadata correction request: collectionConceptIds must contain at least one value')
+  }
+
+  const acceptedCollectionConceptIds = []
+  const seen = new Set()
+
+  collectionConceptIds.forEach((value, index) => {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      throw new Error(
+        `Invalid metadata correction request: collectionConceptIds[${index}] must be a non-empty string`
+      )
+    }
+
+    const normalizedValue = value.trim()
+
+    if (!seen.has(normalizedValue)) {
+      seen.add(normalizedValue)
+      acceptedCollectionConceptIds.push(normalizedValue)
+    }
+  })
+
+  return {
+    requestedCount: collectionConceptIds.length,
+    acceptedCollectionConceptIds
+  }
+}
+
+/**
+ * Maps handler validation failures to a client error and publish/runtime failures to server errors.
+ *
+ * @param {Error} error Thrown handler error.
+ * @returns {number} HTTP status code.
+ */
+const getErrorStatusCode = (error) => {
+  const message = String(error?.message || '')
+
+  if (message.startsWith('Invalid metadata correction request:')) {
+    return 400
+  }
+
+  return 500
+}
+
+/**
+ * Queues metadata correction requests for one or more collection concept ids.
+ *
+ * This endpoint is intentionally fire-and-forget. It validates the request body, deduplicates
+ * concept ids within that request, and publishes one FIFO message per collection so the existing
+ * async correction worker can process them through the same queue contract.
+ *
+ * @param {object} event API Gateway event.
+ * @param {string} [event.body] Raw JSON request body.
+ * @param {object} context Lambda context.
+ * @returns {Promise<object>} API Gateway response object.
+ */
+export const requestMetadataCorrection = async (event, context) => {
+  const { defaultResponseHeaders } = getApplicationConfig()
+
+  logAnalyticsData({
+    event,
+    context
+  })
+
+  try {
+    const requestBody = parseRequestBody(event?.body)
+    const {
+      requestedCount,
+      acceptedCollectionConceptIds
+    } = normalizeCollectionConceptIds(requestBody.collectionConceptIds)
+    const requestedAt = new Date().toISOString()
+
+    logger.info('[metadata-correction] Received asynchronous metadata correction request', {
+      requestedCount,
+      acceptedCount: acceptedCollectionConceptIds.length,
+      collectionConceptIds: acceptedCollectionConceptIds
+    })
+
+    const accepted = await Promise.all(
+      acceptedCollectionConceptIds.map(async (collectionConceptId) => {
+        const publishResult = await publishMetadataCorrectionRequest({
+          source: 'metadataCorrectionApi',
+          collectionConceptId,
+          requestedAt
+        })
+
+        return {
+          collectionConceptId,
+          messageId: publishResult.messageId,
+          messageGroupId: publishResult.messageGroupId
+        }
+      })
+    )
+
+    return {
+      statusCode: 202,
+      headers: {
+        ...defaultResponseHeaders,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        requestedCount,
+        acceptedCount: accepted.length,
+        accepted
+      }, null, 2)
+    }
+  } catch (error) {
+    logger.error('[metadata-correction] Failed asynchronous metadata correction request', error)
+
+    return {
+      statusCode: getErrorStatusCode(error),
+      headers: {
+        ...defaultResponseHeaders,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        error: error.toString()
+      })
+    }
+  }
+}
+
+export default requestMetadataCorrection

--- a/serverless/src/requestMetadataCorrection/handler.js
+++ b/serverless/src/requestMetadataCorrection/handler.js
@@ -167,11 +167,9 @@ export const requestMetadataCorrection = async (event, context) => {
     })
 
     if (failed.length > 0 && accepted.length === 0) {
-      const firstRejectedResult = publishResults.find(({ status }) => status === 'rejected')
+      const firstRejectedResultIndex = publishResults.findIndex(({ status }) => status === 'rejected')
 
-      throw firstRejectedResult?.status === 'rejected'
-        ? firstRejectedResult.reason
-        : new Error('Failed to publish metadata correction requests')
+      throw publishResults[firstRejectedResultIndex].reason
     }
 
     if (failed.length > 0) {

--- a/serverless/src/requestMetadataCorrection/handler.js
+++ b/serverless/src/requestMetadataCorrection/handler.js
@@ -8,18 +8,26 @@ import { publishMetadataCorrectionRequest } from '@/shared/publishMetadataCorrec
  *
  * @param {string|undefined} body Raw API Gateway request body.
  * @returns {Object} Parsed request payload.
- * @throws {Error} When the body is missing or invalid JSON.
+ * @throws {Error} When the body is missing, not valid JSON, or not a JSON object.
  */
 const parseRequestBody = (body) => {
   if (typeof body !== 'string' || body.trim().length === 0) {
     throw new Error('Invalid metadata correction request: missing request body')
   }
 
+  let parsedBody
+
   try {
-    return JSON.parse(body)
+    parsedBody = JSON.parse(body)
   } catch {
     throw new Error('Invalid metadata correction request: body must be valid JSON')
   }
+
+  if (parsedBody === null || typeof parsedBody !== 'object' || Array.isArray(parsedBody)) {
+    throw new Error('Invalid metadata correction request: body must be a JSON object')
+  }
+
+  return parsedBody
 }
 
 /**
@@ -79,6 +87,20 @@ const getErrorStatusCode = (error) => {
 }
 
 /**
+ * Converts a rejected publish reason into a stable response/log string.
+ *
+ * @param {unknown} error Rejection reason.
+ * @returns {string} Serialized error message.
+ */
+const toErrorMessage = (error) => {
+  if (error instanceof Error) {
+    return error.toString()
+  }
+
+  return String(error)
+}
+
+/**
  * Queues metadata correction requests for one or more collection concept ids.
  *
  * This endpoint is intentionally fire-and-forget. It validates the request body, deduplicates
@@ -112,7 +134,7 @@ export const requestMetadataCorrection = async (event, context) => {
       collectionConceptIds: acceptedCollectionConceptIds
     })
 
-    const accepted = await Promise.all(
+    const publishResults = await Promise.allSettled(
       acceptedCollectionConceptIds.map(async (collectionConceptId) => {
         const publishResult = await publishMetadataCorrectionRequest({
           source: 'metadataCorrectionApi',
@@ -128,6 +150,40 @@ export const requestMetadataCorrection = async (event, context) => {
       })
     )
 
+    const accepted = []
+    const failed = []
+
+    publishResults.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        accepted.push(result.value)
+
+        return
+      }
+
+      failed.push({
+        collectionConceptId: acceptedCollectionConceptIds[index],
+        error: toErrorMessage(result.reason)
+      })
+    })
+
+    if (failed.length > 0 && accepted.length === 0) {
+      const firstRejectedResult = publishResults.find(({ status }) => status === 'rejected')
+
+      throw firstRejectedResult?.status === 'rejected'
+        ? firstRejectedResult.reason
+        : new Error('Failed to publish metadata correction requests')
+    }
+
+    if (failed.length > 0) {
+      logger.error('[metadata-correction] Partially failed asynchronous metadata correction request', {
+        requestedCount,
+        acceptedCount: accepted.length,
+        failedCount: failed.length,
+        accepted,
+        failed
+      })
+    }
+
     return {
       statusCode: 202,
       headers: {
@@ -137,7 +193,9 @@ export const requestMetadataCorrection = async (event, context) => {
       body: JSON.stringify({
         requestedCount,
         acceptedCount: accepted.length,
-        accepted
+        failedCount: failed.length,
+        accepted,
+        failed
       }, null, 2)
     }
   } catch (error) {


### PR DESCRIPTION
# Overview

### What is the feature?

Add a new asynchronous metadata correction endpoint for one or more collection concept ids. This keeps the existing sync endpoint unchanged while adding a fire-and-forget API that queues collection-scoped correction work through the existing FIFO processing flow.

### What is the Solution?

This change adds `POST /metadata_correction`, which accepts a JSON body with `collectionConceptIds`, validates the request, trims and deduplicates ids while preserving order, and publishes one metadata-correction request message per accepted collection concept id.

It also adds an optional `METADATA_CORRECTION_REQUEST_DELAY_MS` delay in the async consumer for requests originating from the new API. That delay is applied only to `source=metadataCorrectionApi` messages and uses the published `requestedAt` timestamp so we can reduce the chance of processing a collection while it is still being indexed after ingest.

Infrastructure updates thread the metadata-correction requests topic ARN into the KMS API Lambdas, add publish permissions for that topic, and expose the delay configuration to the processing stack. 

### What areas of the application does this impact?

- KMS API Gateway/Lambda routing
- Async metadata correction request publishing
- Metadata correction consumer behavior
- CDK wiring for topic ARN, publish permissions, and delay configuration

# Testing

export KMS_AUTHORIZATION='Bearer <working level-5 token>'

curl --request POST \
  --header "Authorization: ${KMS_AUTHORIZATION}" \
  --header 'Content-Type: application/json' \
  --header 'Accept: application/json' \
  --data '{
    "collectionConceptIds": [
      "C1234567890-PROV", 
      "C1234567891-PROV"
    ]
  }' 
  "https://cmr.sit.earthdata.nasa.gov/kms/metadata_correction"

Tail cloudwatch logs in kms-sit-metadata-correction-service, kms-sit-request-metadata-correction

and check the audit log.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/extended the async metadata correction request endpoint to validate input, trim/deduplicate concept IDs, enqueue work, and return accepted/failed counts with details.
  * Introduced optional queued manual-request delay via `METADATA_CORRECTION_REQUEST_DELAY_MS`, configurable through stack settings (with clamping).
* **Bug Fixes**
  * Improved metadata correction service SQS batch handling to return `batchItemFailures` per failed record (by message ID) for correct partial retries.
* **Tests**
  * Expanded automated tests for request validation, partial publish outcomes, delay timing, and batch failure behavior.
  * Added local smoke tests covering end-to-end delay and partial batch failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->