### PR TITLE
Fix grammar typo and broken badge links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # KMS 2.0
 
-[![codecov](https://codecov.io/gh/nasa/mmt/graph/badge.svg?token=B8Qspgsjou)](https://codecov.io/gh/nasa/kms (https://codecov.io/gh/nasa/mmt/graph/badge.svg?token=B8Qspgsjou)%5D(https://codecov.io/gh/nasa/kms))
+[![codecov](https://codecov.io/gh/nasa/mmt/graph/badge.svg?token=B8Qspgsjou)](https://codecov.io/gh/nasa/kms)
 
-[![Known Vulnerabilities](https://snyk.io/test/github/nasa/kms/badge.svg)](https://snyk.io/test/github/nasa/kms (https://snyk.io/test/github/nasa/kms/badge.svg)%5D(https://snyk.io/test/github/nasa/kms))
+[![Known Vulnerabilities](https://snyk.io/test/github/nasa/kms/badge.svg)](https://snyk.io/test/github/nasa/kms)
 
-Keyword Management System (KMS) is a application for maintaining keywords (science keywords, platforms, instruments, data centers, locations, projects, services, resolution, etc.) in the earthdata/IDN system.
+Keyword Management System (KMS) is an application for maintaining keywords (science keywords, platforms, instruments, data centers, locations, projects, services, resolution, etc.) in the earthdata/IDN system.
 
 ## Links
 


### PR DESCRIPTION
## Summary
- Fixes #11 — "a application" → "an application" in the intro paragraph.
- Also fixes the codecov and Snyk badge links, which had malformed nested markdown (`](url (badge-url)%5D(url))`) that rendered as broken/garbled URLs instead of clickable badges.

## Test plan
- Rendered README.md locally to confirm both badges render correctly and the intro sentence reads naturally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Codecov and “Known Vulnerabilities” badge formatting.
  * Improved grammar in the opening project description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->