### PR TITLE
KMS-689: Add 'xml:base' to rdf result's header

### DIFF
--- a/serverless/src/getConcept/__tests__/handler.test.js
+++ b/serverless/src/getConcept/__tests__/handler.test.js
@@ -378,6 +378,23 @@ describe('getConcept', () => {
       })
     })
 
+    test('returns RDF format with correct root namespaces and xml:base', async () => {
+      const mockEvent = { pathParameters: { conceptId: '123' } }
+      const mockSkosConcept = {
+        '@rdf:about': '123',
+        'skos:prefLabel': { _text: 'Test PrefLabel' },
+        'skos:inScheme': { '@rdf:resource': 'https://example.com/scheme' }
+      }
+      mockSuccessfulResponse(mockSkosConcept)
+
+      const result = await getConcept(mockEvent)
+
+      expect(result.statusCode).toBe(200)
+      expect(result.body).toContain(
+        '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:gcmd="https://gcmd.earthdata.nasa.gov/kms#" xmlns:dcterms="http://purl.org/dc/terms/" xml:base="https://gcmd.earthdata.nasa.gov/kms/concept/">'
+      )
+    })
+
     describe('when retrieving by short name', () => {
       test('should successfully retrieve concept using short name', async () => {
         const mockEvent = { pathParameters: { shortName: 'Test+Short+Name' } }

--- a/serverless/src/getConcepts/__tests__/handler.test.js
+++ b/serverless/src/getConcepts/__tests__/handler.test.js
@@ -831,6 +831,26 @@ describe('getConcepts', () => {
   })
 
   describe('when successful', () => {
+    test('returns RDF format with correct root namespaces and xml:base', async () => {
+      getFilteredTriples.mockResolvedValue([])
+      processTriples.mockReturnValue({
+        bNodeMap: {},
+        nodes: {},
+        conceptURIs: []
+      })
+
+      getTotalConceptCount.mockResolvedValue(0)
+      getGcmdMetadata.mockResolvedValue({})
+
+      const event = {}
+      const result = await getConcepts(event)
+
+      expect(result.statusCode).toBe(200)
+      expect(result.body).toContain(
+        '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:gcmd="https://gcmd.earthdata.nasa.gov/kms#" xmlns:dcterms="http://purl.org/dc/terms/" xml:base="https://gcmd.earthdata.nasa.gov/kms/concept/">'
+      )
+    })
+
     test('returns concepts by pattern', async () => {
       const mockTriples = [
         {

--- a/serverless/src/getConcepts/handler.js
+++ b/serverless/src/getConcepts/handler.js
@@ -411,6 +411,7 @@ export const getConcepts = async (event, context) => {
       const rdfJson = {
         'rdf:RDF': {
           ...namespaces,
+          '@xml:base': 'https://gcmd.earthdata.nasa.gov/kms/concept/',
           'gcmd:gcmd': await getGcmdMetadata({
             pageNum,
             pageSize,


### PR DESCRIPTION
# Overview

### What is the feature?

RDF response from /kms/concepts should have xml:base="https://gcmd.earthdata.nasa.gov/kms/concept/" in header.

### What is the Solution?

Add 'xml:base' to RDF result in getConcepts handler.

### What areas of the application does this impact?

/kms/concepts(*)

# Testing

http://localhost:3013/concepts
http://localhost:3013/concepts/concept_scheme/instruments 
should show 'xml:base' in RDF header

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RDF/XML responses now include the concept base URL through the `xml:base` attribute.

* **Tests**
  * Added coverage verifying RDF root namespace declarations and `xml:base` in concept responses.
  * Added validation for successful RDF response status and exact root element formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->