### PR TITLE
KMS-598: Support Older Versions of the GCMD Keywords in KMS

### DIFF
--- a/cdk/app/lib/helper/KmsLambdaFunctions.ts
+++ b/cdk/app/lib/helper/KmsLambdaFunctions.ts
@@ -236,6 +236,15 @@ export class LambdaFunctions {
 
     this.createApiLambda(
       scope,
+      'getHistoricalConceptsInScheme/handler.js',
+      'get-historical-concepts-in-scheme',
+      'getHistoricalConceptsInScheme',
+      '/concepts/historical/concept_scheme/{conceptScheme}',
+      'GET'
+    )
+
+    this.createApiLambda(
+      scope,
       'getConcepts/handler.js',
       'get-concepts-root',
       'getConcepts',
@@ -276,6 +285,15 @@ export class LambdaFunctions {
       'get-concept-versions',
       'getConceptVersions',
       '/concept_versions/version_type/{versionType}',
+      'GET'
+    )
+
+    this.createApiLambda(
+      scope,
+      'getHistoricalConceptVersions/handler.js',
+      'get-historical-concept-versions',
+      'getHistoricalConceptVersions',
+      '/concept_versions/historical',
       'GET'
     )
 

--- a/serverless/src/getCapabilities/__tests__/handler.test.js
+++ b/serverless/src/getCapabilities/__tests__/handler.test.js
@@ -56,6 +56,8 @@ describe('getCapabilities', () => {
       expect(result.body).toContain('<a name="get_historical_concept_by_full_path"')
       expect(result.body).toContain('<a name="get_historical_concept_by_short_name"')
       expect(result.body).not.toContain('/cache/rebuild')
+      expect(result.body).toContain('<a name="get_historical_concept_versions"')
+      expect(result.body).toContain('<a name="get_historical_concepts_in_scheme"')
     })
   })
 

--- a/serverless/src/getCapabilities/handler.js
+++ b/serverless/src/getCapabilities/handler.js
@@ -168,6 +168,22 @@ export const getCapabilities = async () => {
                 params: 'scheme=',
                 action: 'GET'
               }
+            },
+            {
+              ':@': {
+                name: 'get_historical_concept_versions',
+                href: '/concept_versions/historical',
+                params: 'None',
+                action: 'GET'
+              }
+            },
+            {
+              ':@': {
+                name: 'get_historical_concepts_in_scheme',
+                href: '/concepts/historical/concept_scheme/{conceptScheme}',
+                params: 'version=',
+                action: 'GET'
+              }
             }
 
           ]

--- a/serverless/src/getHistoricalConceptVersions/__tests__/handler.test.js
+++ b/serverless/src/getHistoricalConceptVersions/__tests__/handler.test.js
@@ -1,3 +1,4 @@
+import { S3Client } from '@aws-sdk/client-s3'
 import {
   beforeEach,
   describe,
@@ -10,15 +11,6 @@ import { logAnalyticsData } from '@/shared/logAnalyticsData'
 
 import { getHistoricalConceptVersions } from '../handler'
 
-// `getS3Client()` is called once at module-load time in handler.js, so the
-// mocked client needs to exist before the handler module is imported. Using
-// vi.hoisted + a mock factory ensures `mockSend` is available when the
-// `@/shared/awsClients` mock is set up, and lets us control its behavior
-// per test via mockSend.mockResolvedValueOnce(...).
-//
-// handler.js also now reads `RDF_BUCKET_NAME` at module-load time and throws
-// if it's missing, so it must be set here too, before the static import of
-// `../handler` below runs (vi.hoisted is lifted above all imports).
 const { mockSend } = vi.hoisted(() => {
   process.env.RDF_BUCKET_NAME = 'test-bucket'
 
@@ -26,7 +18,12 @@ const { mockSend } = vi.hoisted(() => {
 })
 
 vi.mock('@/shared/awsClients', () => ({
-  getS3Client: () => ({ send: mockSend })
+  getS3Client: () => {
+    const client = new S3Client({ region: 'us-east-1' })
+    client.send = mockSend
+
+    return client
+  }
 }))
 
 vi.mock('@/shared/getConfig')

--- a/serverless/src/getHistoricalConceptVersions/__tests__/handler.test.js
+++ b/serverless/src/getHistoricalConceptVersions/__tests__/handler.test.js
@@ -15,9 +15,15 @@ import { getHistoricalConceptVersions } from '../handler'
 // vi.hoisted + a mock factory ensures `mockSend` is available when the
 // `@/shared/awsClients` mock is set up, and lets us control its behavior
 // per test via mockSend.mockResolvedValueOnce(...).
-const { mockSend } = vi.hoisted(() => ({
-  mockSend: vi.fn()
-}))
+//
+// handler.js also now reads `RDF_BUCKET_NAME` at module-load time and throws
+// if it's missing, so it must be set here too, before the static import of
+// `../handler` below runs (vi.hoisted is lifted above all imports).
+const { mockSend } = vi.hoisted(() => {
+  process.env.RDF_BUCKET_NAME = 'test-bucket'
+
+  return { mockSend: vi.fn() }
+})
 
 vi.mock('@/shared/awsClients', () => ({
   getS3Client: () => ({ send: mockSend })
@@ -38,13 +44,23 @@ describe('getHistoricalConceptVersions', () => {
   })
 
   describe('when successful', () => {
-    test('should return 200 with the list of version directories', async () => {
-      mockSend.mockResolvedValueOnce({
-        CommonPrefixes: [
-          { Prefix: 'A/' },
-          { Prefix: 'B/' }
-        ]
-      })
+    test('should return 200 with the list of version directories that contain a CSV', async () => {
+      mockSend
+        // Top-level listing: two candidate version prefixes
+        .mockResolvedValueOnce({
+          CommonPrefixes: [
+            { Prefix: 'A/' },
+            { Prefix: 'B/' }
+          ]
+        })
+        // Per-version CSV check for "A"
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'A/ScienceKeywords.csv' }]
+        })
+        // Per-version CSV check for "B"
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'B/ScienceKeywords.csv' }]
+        })
 
       const event = {}
       const context = {}
@@ -56,16 +72,54 @@ describe('getHistoricalConceptVersions', () => {
     })
 
     test('should exclude the draft directory', async () => {
-      mockSend.mockResolvedValueOnce({
-        CommonPrefixes: [
-          { Prefix: 'draft/' },
-          { Prefix: 'A/' }
-        ]
-      })
+      mockSend
+        .mockResolvedValueOnce({
+          CommonPrefixes: [
+            { Prefix: 'draft/' },
+            { Prefix: 'A/' }
+          ]
+        })
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'A/ScienceKeywords.csv' }]
+        })
 
       const response = await getHistoricalConceptVersions({}, {})
 
       expect(JSON.parse(response.body)).toEqual({ historicalVersions: ['A'] })
+    })
+
+    test('should exclude versions that have no CSV files, e.g. an rdf.xml-only or incomplete export', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          CommonPrefixes: [
+            { Prefix: 'A/' },
+            { Prefix: 'B/' }
+          ]
+        })
+        // "A" only has an rdf.xml export, no CSV
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'A/rdf.xml' }]
+        })
+        // "B" has a CSV
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'B/ScienceKeywords.csv' }]
+        })
+
+      const response = await getHistoricalConceptVersions({}, {})
+
+      expect(JSON.parse(response.body)).toEqual({ historicalVersions: ['B'] })
+    })
+
+    test('should exclude a version whose prefix has no objects at all', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          CommonPrefixes: [{ Prefix: 'A/' }]
+        })
+        .mockResolvedValueOnce({})
+
+      const response = await getHistoricalConceptVersions({}, {})
+
+      expect(JSON.parse(response.body)).toEqual({ historicalVersions: [] })
     })
 
     test('should return an empty array when there are no common prefixes', async () => {
@@ -75,9 +129,11 @@ describe('getHistoricalConceptVersions', () => {
 
       expect(response.statusCode).toBe(200)
       expect(JSON.parse(response.body)).toEqual({ historicalVersions: [] })
+      // No candidate versions, so no per-version CSV checks should happen
+      expect(mockSend).toHaveBeenCalledTimes(1)
     })
 
-    test('should paginate through multiple pages of results', async () => {
+    test('should paginate through multiple pages of top-level results', async () => {
       mockSend
         .mockResolvedValueOnce({
           CommonPrefixes: [{ Prefix: 'A/' }],
@@ -86,11 +142,36 @@ describe('getHistoricalConceptVersions', () => {
         .mockResolvedValueOnce({
           CommonPrefixes: [{ Prefix: 'B/' }]
         })
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'A/ScienceKeywords.csv' }]
+        })
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'B/ScienceKeywords.csv' }]
+        })
 
       const response = await getHistoricalConceptVersions({}, {})
 
-      expect(mockSend).toHaveBeenCalledTimes(2)
+      expect(mockSend).toHaveBeenCalledTimes(4)
       expect(JSON.parse(response.body)).toEqual({ historicalVersions: ['A', 'B'] })
+    })
+
+    test('should paginate through multiple pages when checking a single version for CSVs', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          CommonPrefixes: [{ Prefix: 'A/' }]
+        })
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'A/rdf.xml' }],
+          NextContinuationToken: 'version-page-2-token'
+        })
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'A/ScienceKeywords.csv' }]
+        })
+
+      const response = await getHistoricalConceptVersions({}, {})
+
+      expect(mockSend).toHaveBeenCalledTimes(3)
+      expect(JSON.parse(response.body)).toEqual({ historicalVersions: ['A'] })
     })
 
     test('should call logAnalyticsData with the event and context', async () => {
@@ -131,6 +212,36 @@ describe('getHistoricalConceptVersions', () => {
         'Failed to list S3 version directories:',
         error.message
       )
+    })
+
+    test('should return 500 when checking a version for CSVs fails', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          CommonPrefixes: [{ Prefix: 'A/' }]
+        })
+        .mockRejectedValueOnce(new Error('Access denied'))
+
+      const response = await getHistoricalConceptVersions({}, {})
+
+      expect(response.statusCode).toBe(500)
+      expect(JSON.parse(response.body)).toEqual({
+        message: 'Failed to fetch version directories'
+      })
+    })
+  })
+
+  describe('when RDF_BUCKET_NAME is not set', () => {
+    test('should throw a clear error at module load instead of silently falling back to a default bucket', async () => {
+      const originalValue = process.env.RDF_BUCKET_NAME
+      delete process.env.RDF_BUCKET_NAME
+
+      vi.resetModules()
+
+      await expect(import('../handler')).rejects.toThrow(
+        'Missing required environment variable: RDF_BUCKET_NAME'
+      )
+
+      process.env.RDF_BUCKET_NAME = originalValue
     })
   })
 })

--- a/serverless/src/getHistoricalConceptVersions/__tests__/handler.test.js
+++ b/serverless/src/getHistoricalConceptVersions/__tests__/handler.test.js
@@ -1,0 +1,136 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  vi
+} from 'vitest'
+
+import { getApplicationConfig } from '@/shared/getConfig'
+import { logAnalyticsData } from '@/shared/logAnalyticsData'
+
+import { getHistoricalConceptVersions } from '../handler'
+
+// `getS3Client()` is called once at module-load time in handler.js, so the
+// mocked client needs to exist before the handler module is imported. Using
+// vi.hoisted + a mock factory ensures `mockSend` is available when the
+// `@/shared/awsClients` mock is set up, and lets us control its behavior
+// per test via mockSend.mockResolvedValueOnce(...).
+const { mockSend } = vi.hoisted(() => ({
+  mockSend: vi.fn()
+}))
+
+vi.mock('@/shared/awsClients', () => ({
+  getS3Client: () => ({ send: mockSend })
+}))
+
+vi.mock('@/shared/getConfig')
+vi.mock('@/shared/logAnalyticsData')
+
+describe('getHistoricalConceptVersions', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Mock getApplicationConfig
+    getApplicationConfig.mockReturnValue({
+      defaultResponseHeaders: { 'X-Test': 'test-header' }
+    })
+  })
+
+  describe('when successful', () => {
+    test('should return 200 with the list of version directories', async () => {
+      mockSend.mockResolvedValueOnce({
+        CommonPrefixes: [
+          { Prefix: 'A/' },
+          { Prefix: 'B/' }
+        ]
+      })
+
+      const event = {}
+      const context = {}
+      const response = await getHistoricalConceptVersions(event, context)
+
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['X-Test']).toBe('test-header')
+      expect(JSON.parse(response.body)).toEqual({ historicalVersions: ['A', 'B'] })
+    })
+
+    test('should exclude the draft directory', async () => {
+      mockSend.mockResolvedValueOnce({
+        CommonPrefixes: [
+          { Prefix: 'draft/' },
+          { Prefix: 'A/' }
+        ]
+      })
+
+      const response = await getHistoricalConceptVersions({}, {})
+
+      expect(JSON.parse(response.body)).toEqual({ historicalVersions: ['A'] })
+    })
+
+    test('should return an empty array when there are no common prefixes', async () => {
+      mockSend.mockResolvedValueOnce({})
+
+      const response = await getHistoricalConceptVersions({}, {})
+
+      expect(response.statusCode).toBe(200)
+      expect(JSON.parse(response.body)).toEqual({ historicalVersions: [] })
+    })
+
+    test('should paginate through multiple pages of results', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          CommonPrefixes: [{ Prefix: 'A/' }],
+          NextContinuationToken: 'page-2-token'
+        })
+        .mockResolvedValueOnce({
+          CommonPrefixes: [{ Prefix: 'B/' }]
+        })
+
+      const response = await getHistoricalConceptVersions({}, {})
+
+      expect(mockSend).toHaveBeenCalledTimes(2)
+      expect(JSON.parse(response.body)).toEqual({ historicalVersions: ['A', 'B'] })
+    })
+
+    test('should call logAnalyticsData with the event and context', async () => {
+      mockSend.mockResolvedValueOnce({ CommonPrefixes: [] })
+
+      const event = { some: 'event' }
+      const context = { some: 'context' }
+      await getHistoricalConceptVersions(event, context)
+
+      expect(logAnalyticsData).toHaveBeenCalledWith({
+        event,
+        context
+      })
+    })
+  })
+
+  describe('when unsuccessful', () => {
+    test('should return 500 when the S3 request fails', async () => {
+      mockSend.mockRejectedValueOnce(new Error('The specified bucket does not exist'))
+
+      const response = await getHistoricalConceptVersions({}, {})
+
+      expect(response.statusCode).toBe(500)
+      expect(response.headers['X-Test']).toBe('test-header')
+      expect(JSON.parse(response.body)).toEqual({
+        message: 'Failed to fetch version directories'
+      })
+    })
+
+    test('should log the error to the console', async () => {
+      const error = new Error('The specified bucket does not exist')
+      mockSend.mockRejectedValueOnce(error)
+
+      await getHistoricalConceptVersions({}, {})
+
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledWith(
+        'Failed to list S3 version directories:',
+        error.message
+      )
+    })
+  })
+})

--- a/serverless/src/getHistoricalConceptVersions/handler.js
+++ b/serverless/src/getHistoricalConceptVersions/handler.js
@@ -1,4 +1,4 @@
-import { ListObjectsV2Command } from '@aws-sdk/client-s3'
+import { paginateListObjectsV2 } from '@aws-sdk/client-s3'
 
 import { getS3Client } from '@/shared/awsClients'
 import { getApplicationConfig } from '@/shared/getConfig'
@@ -21,6 +21,43 @@ if (!bucketName) {
 const s3Client = getS3Client()
 
 /**
+ * Lists candidate version "directory" names in the S3 bucket by using a
+ * delimiter so S3 groups keys into CommonPrefixes (its equivalent of
+ * folders), excluding the "draft/" prefix.
+ *
+ * @returns {Promise<Array<string>>} Array of candidate version/directory names
+ */
+const listCandidateVersions = async () => {
+  const candidateVersions = []
+
+  const paginator = paginateListObjectsV2(
+    {
+      client: s3Client,
+      pageSize: 1000
+    },
+    {
+      Bucket: bucketName,
+      Delimiter: '/'
+    }
+  )
+
+  // eslint-disable-next-line no-restricted-syntax
+  for await (const page of paginator) {
+    if (page.CommonPrefixes) {
+      const prefixes = page.CommonPrefixes
+        .map((p) => p.Prefix)
+        .filter(Boolean)
+        .map((prefix) => prefix.replace(/\/$/, '')) // Strip trailing slash
+        .filter((name) => name !== 'draft') // Exclude the draft "directory"
+
+      candidateVersions.push(...prefixes)
+    }
+  }
+
+  return candidateVersions
+}
+
+/**
  * Checks whether a given version "directory" contains at least one
  * downloadable CSV file. A version may exist as a top-level prefix while
  * only containing an rdf.xml export (or an incomplete export with no CSVs
@@ -30,64 +67,36 @@ const s3Client = getS3Client()
  * @returns {Promise<boolean>} Whether the version contains at least one .csv key
  */
 const versionHasCsv = async (version) => {
-  let continuationToken
-
-  /* eslint-disable no-await-in-loop */
-  do {
-    const command = new ListObjectsV2Command({
+  const paginator = paginateListObjectsV2(
+    {
+      client: s3Client,
+      pageSize: 1000
+    },
+    {
       Bucket: bucketName,
-      Prefix: `${version}/`,
-      ContinuationToken: continuationToken
-    })
+      Prefix: `${version}/`
+    }
+  )
 
-    const response = await s3Client.send(command)
-
-    if (response.Contents?.some((object) => object.Key.endsWith('.csv'))) {
+  // eslint-disable-next-line no-restricted-syntax
+  for await (const page of paginator) {
+    if (page.Contents?.some((object) => object.Key.endsWith('.csv'))) {
       return true
     }
-
-    continuationToken = response.NextContinuationToken
-  } while (continuationToken)
-  /* eslint-enable no-await-in-loop */
+  }
 
   return false
 }
 
 /**
- * Lists top-level "directory" names in the S3 bucket by using a delimiter
- * so S3 groups keys into CommonPrefixes (its equivalent of folders),
- * excluding the "draft/" prefix, and excluding any version that has no
- * downloadable CSV files (e.g. rdf.xml-only or incomplete exports).
+ * Lists top-level "directory" names in the S3 bucket, excluding the
+ * "draft/" prefix, and excluding any version that has no downloadable CSV
+ * files (e.g. rdf.xml-only or incomplete exports).
  *
  * @returns {Promise<Array<string>>} Array of version/directory names
  */
 const listVersionDirectories = async () => {
-  const candidateVersions = []
-  let continuationToken
-
-  /* eslint-disable no-await-in-loop */
-  do {
-    const command = new ListObjectsV2Command({
-      Bucket: bucketName,
-      Delimiter: '/',
-      ContinuationToken: continuationToken
-    })
-
-    const response = await s3Client.send(command)
-
-    if (response.CommonPrefixes) {
-      const prefixes = response.CommonPrefixes
-        .map((p) => p.Prefix)
-        .filter(Boolean)
-        .map((prefix) => prefix.replace(/\/$/, '')) // Strip trailing slash
-        .filter((name) => name !== 'draft') // Exclude the draft "directory"
-
-      candidateVersions.push(...prefixes)
-    }
-
-    continuationToken = response.NextContinuationToken
-  } while (continuationToken)
-  /* eslint-enable no-await-in-loop */
+  const candidateVersions = await listCandidateVersions()
 
   const versionCsvChecks = await Promise.all(
     candidateVersions.map(async (version) => ({

--- a/serverless/src/getHistoricalConceptVersions/handler.js
+++ b/serverless/src/getHistoricalConceptVersions/handler.js
@@ -1,0 +1,84 @@
+import { ListObjectsV2Command } from '@aws-sdk/client-s3'
+
+import { getS3Client } from '@/shared/awsClients'
+import { getApplicationConfig } from '@/shared/getConfig'
+import { logAnalyticsData } from '@/shared/logAnalyticsData'
+
+/**
+ * S3 bucket name to list version directories from
+ * @type {string}
+ */
+const bucketName = process.env.S3_BUCKET_NAME || 'kms-rdf-backup-sit'
+
+/**
+ * S3 Client from shared configuration
+ * @type {S3Client}
+ */
+const s3Client = getS3Client()
+
+/**
+ * Lists top-level "directory" names in the S3 bucket by using a delimiter
+ * so S3 groups keys into CommonPrefixes (its equivalent of folders),
+ * excluding the "draft/" prefix.
+ *
+ * @returns {Promise<Array<string>>} Array of version/directory names
+ */
+const listVersionDirectories = async () => {
+  const historicalVersions = []
+  let continuationToken
+
+  /* eslint-disable no-await-in-loop */
+  do {
+    const command = new ListObjectsV2Command({
+      Bucket: bucketName,
+      Delimiter: '/',
+      ContinuationToken: continuationToken
+    })
+
+    const response = await s3Client.send(command)
+
+    if (response.CommonPrefixes) {
+      const prefixes = response.CommonPrefixes
+        .map((p) => p.Prefix)
+        .filter(Boolean)
+        .map((prefix) => prefix.replace(/\/$/, '')) // Strip trailing slash
+        .filter((name) => name !== 'draft') // Exclude the draft "directory"
+
+      historicalVersions.push(...prefixes)
+    }
+
+    continuationToken = response.NextContinuationToken
+  } while (continuationToken)
+  /* eslint-enable no-await-in-loop */
+
+  return historicalVersions
+}
+
+export const getHistoricalConceptVersions = async (event, context) => {
+  const { defaultResponseHeaders } = getApplicationConfig()
+
+  logAnalyticsData({
+    event,
+    context
+  })
+
+  try {
+    const historicalVersions = await listVersionDirectories()
+
+    return {
+      statusCode: 200,
+      headers: defaultResponseHeaders,
+      body: JSON.stringify({ historicalVersions })
+    }
+  } catch (error) {
+    console.error('Failed to list S3 version directories:', error.message)
+
+    return {
+      statusCode: 500,
+      headers: defaultResponseHeaders,
+      body: JSON.stringify({ message: 'Failed to fetch version directories' })
+    }
+  }
+}
+
+export default getHistoricalConceptVersions

--- a/serverless/src/getHistoricalConceptVersions/handler.js
+++ b/serverless/src/getHistoricalConceptVersions/handler.js
@@ -5,10 +5,14 @@ import { getApplicationConfig } from '@/shared/getConfig'
 import { logAnalyticsData } from '@/shared/logAnalyticsData'
 
 /**
- * S3 bucket name to list version directories from
+ * S3 bucket name to list version directories from.
  * @type {string}
  */
-const bucketName = process.env.S3_BUCKET_NAME || 'kms-rdf-backup-sit'
+const bucketName = process.env.RDF_BUCKET_NAME
+
+if (!bucketName) {
+  throw new Error('Missing required environment variable: RDF_BUCKET_NAME')
+}
 
 /**
  * S3 Client from shared configuration
@@ -17,14 +21,48 @@ const bucketName = process.env.S3_BUCKET_NAME || 'kms-rdf-backup-sit'
 const s3Client = getS3Client()
 
 /**
+ * Checks whether a given version "directory" contains at least one
+ * downloadable CSV file. A version may exist as a top-level prefix while
+ * only containing an rdf.xml export (or an incomplete export with no CSVs
+ * at all), so this is used to filter those out.
+ *
+ * @param {string} version - Version/directory name, e.g. "1.9.1"
+ * @returns {Promise<boolean>} Whether the version contains at least one .csv key
+ */
+const versionHasCsv = async (version) => {
+  let continuationToken
+
+  /* eslint-disable no-await-in-loop */
+  do {
+    const command = new ListObjectsV2Command({
+      Bucket: bucketName,
+      Prefix: `${version}/`,
+      ContinuationToken: continuationToken
+    })
+
+    const response = await s3Client.send(command)
+
+    if (response.Contents?.some((object) => object.Key.endsWith('.csv'))) {
+      return true
+    }
+
+    continuationToken = response.NextContinuationToken
+  } while (continuationToken)
+  /* eslint-enable no-await-in-loop */
+
+  return false
+}
+
+/**
  * Lists top-level "directory" names in the S3 bucket by using a delimiter
  * so S3 groups keys into CommonPrefixes (its equivalent of folders),
- * excluding the "draft/" prefix.
+ * excluding the "draft/" prefix, and excluding any version that has no
+ * downloadable CSV files (e.g. rdf.xml-only or incomplete exports).
  *
  * @returns {Promise<Array<string>>} Array of version/directory names
  */
 const listVersionDirectories = async () => {
-  const historicalVersions = []
+  const candidateVersions = []
   let continuationToken
 
   /* eslint-disable no-await-in-loop */
@@ -44,14 +82,23 @@ const listVersionDirectories = async () => {
         .map((prefix) => prefix.replace(/\/$/, '')) // Strip trailing slash
         .filter((name) => name !== 'draft') // Exclude the draft "directory"
 
-      historicalVersions.push(...prefixes)
+      candidateVersions.push(...prefixes)
     }
 
     continuationToken = response.NextContinuationToken
   } while (continuationToken)
   /* eslint-enable no-await-in-loop */
 
-  return historicalVersions
+  const versionCsvChecks = await Promise.all(
+    candidateVersions.map(async (version) => ({
+      version,
+      hasCsv: await versionHasCsv(version)
+    }))
+  )
+
+  return versionCsvChecks
+    .filter((result) => result.hasCsv)
+    .map((result) => result.version)
 }
 
 export const getHistoricalConceptVersions = async (event, context) => {

--- a/serverless/src/getHistoricalConceptsInScheme/__tests__/handler.test.js
+++ b/serverless/src/getHistoricalConceptsInScheme/__tests__/handler.test.js
@@ -1,0 +1,230 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  vi
+} from 'vitest'
+
+import { getApplicationConfig } from '@/shared/getConfig'
+import { logAnalyticsData } from '@/shared/logAnalyticsData'
+
+import { getHistoricalConceptsInScheme } from '../handler'
+
+// GetS3Client() is called once at module-load time in handler.js, so the
+// mocked client needs to exist before the handler module is imported. Using
+// vi.hoisted + a mock factory ensures `mockSend` is available when the
+// `@/shared/awsClients` mock is set up, and lets us control its behavior
+// per test via mockSend.mockResolvedValueOnce(...).
+const { mockSend } = vi.hoisted(() => ({
+  mockSend: vi.fn()
+}))
+
+vi.mock('@/shared/awsClients', () => ({
+  getS3Client: () => ({ send: mockSend })
+}))
+
+vi.mock('@/shared/getConfig')
+vi.mock('@/shared/logAnalyticsData')
+
+describe('getHistoricalConceptsInScheme', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Mock getApplicationConfig
+    getApplicationConfig.mockReturnValue({
+      defaultResponseHeaders: { 'X-Test': 'test-header' }
+    })
+  })
+
+  describe('when validation errors occur', () => {
+    test('should return 400 when conceptScheme path parameter is missing', async () => {
+      const event = {
+        pathParameters: {},
+        queryStringParameters: { version: 'A' }
+      }
+      const response = await getHistoricalConceptsInScheme(event, {})
+
+      expect(response.statusCode).toBe(400)
+      expect(response.headers['X-Test']).toBe('test-header')
+      expect(JSON.parse(response.body)).toEqual({ error: 'scheme is required' })
+      expect(mockSend).not.toHaveBeenCalled()
+    })
+
+    test('should return 400 when version query parameter is missing', async () => {
+      const event = {
+        pathParameters: { conceptScheme: 'ScienceKeywords' },
+        queryStringParameters: {}
+      }
+      const response = await getHistoricalConceptsInScheme(event, {})
+
+      expect(response.statusCode).toBe(400)
+      expect(JSON.parse(response.body)).toEqual({ error: 'version is required' })
+      expect(mockSend).not.toHaveBeenCalled()
+    })
+
+    test('should return 400 when pathParameters and queryStringParameters are absent entirely', async () => {
+      const response = await getHistoricalConceptsInScheme({}, {})
+
+      expect(response.statusCode).toBe(400)
+      expect(JSON.parse(response.body)).toEqual({ error: 'scheme is required' })
+    })
+  })
+
+  describe('when successful', () => {
+    test('should return 200 with the CSV content, matching the scheme case-insensitively', async () => {
+      // First call: ListObjectsV2 under the version prefix
+      mockSend.mockResolvedValueOnce({
+        Contents: [
+          { Key: 'A/ScienceKeywords.csv' },
+          { Key: 'A/instruments.csv' }
+        ]
+      })
+
+      // Second call: GetObject for the matched key
+      mockSend.mockResolvedValueOnce({
+        Body: { transformToString: () => Promise.resolve('id,label\n1,Foo\n2,Bar') }
+      })
+
+      const event = {
+        pathParameters: { conceptScheme: 'sciencekeywords' },
+        queryStringParameters: { version: 'A' }
+      }
+      const response = await getHistoricalConceptsInScheme(event, {})
+
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['Content-Type']).toBe('text/csv; charset=utf-8')
+      expect(response.headers['Content-Disposition']).toBe('attachment; filename="sciencekeywords.csv"')
+      expect(response.headers['X-Test']).toBe('test-header')
+      expect(response.body).toBe('id,label\n1,Foo\n2,Bar')
+
+      expect(mockSend).toHaveBeenCalledTimes(2)
+    })
+
+    test('should paginate through multiple pages when listing keys', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'A/other.csv' }],
+          NextContinuationToken: 'page-2-token'
+        })
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'A/instruments.csv' }]
+        })
+        .mockResolvedValueOnce({
+          Body: { transformToString: () => Promise.resolve('id,label\n1,Sensor') }
+        })
+
+      const event = {
+        pathParameters: { conceptScheme: 'instruments' },
+        queryStringParameters: { version: 'A' }
+      }
+      const response = await getHistoricalConceptsInScheme(event, {})
+
+      expect(response.statusCode).toBe(200)
+      expect(response.body).toBe('id,label\n1,Sensor')
+      expect(mockSend).toHaveBeenCalledTimes(3)
+    })
+
+    test('should call logAnalyticsData with the event and context', async () => {
+      mockSend.mockResolvedValueOnce({
+        Contents: [{ Key: 'A/instruments.csv' }]
+      })
+
+      mockSend.mockResolvedValueOnce({
+        Body: { transformToString: () => Promise.resolve('id,label') }
+      })
+
+      const event = {
+        pathParameters: { conceptScheme: 'instruments' },
+        queryStringParameters: { version: 'A' }
+      }
+      const context = { some: 'context' }
+      await getHistoricalConceptsInScheme(event, context)
+
+      expect(logAnalyticsData).toHaveBeenCalledWith({
+        event,
+        context
+      })
+    })
+  })
+
+  describe('when unsuccessful', () => {
+    test('should return 404 when no CSV matches the requested scheme', async () => {
+      mockSend.mockResolvedValueOnce({
+        Contents: [{ Key: 'A/instruments.csv' }]
+      })
+
+      const event = {
+        pathParameters: { conceptScheme: 'doesnotexist' },
+        queryStringParameters: { version: 'A' }
+      }
+      const response = await getHistoricalConceptsInScheme(event, {})
+
+      expect(response.statusCode).toBe(404)
+      expect(JSON.parse(response.body)).toEqual({
+        error: 'No concept scheme "doesnotexist" found for version "A"'
+      })
+
+      // Only the list call should happen, never a GetObject
+      expect(mockSend).toHaveBeenCalledTimes(1)
+    })
+
+    test('should return 404 when the version prefix has no objects at all', async () => {
+      mockSend.mockResolvedValueOnce({})
+
+      const event = {
+        pathParameters: { conceptScheme: 'instruments' },
+        queryStringParameters: { version: 'unknown-version' }
+      }
+      const response = await getHistoricalConceptsInScheme(event, {})
+
+      expect(response.statusCode).toBe(404)
+    })
+
+    test('should return 500 when listing objects fails', async () => {
+      mockSend.mockRejectedValueOnce(new Error('The specified bucket does not exist'))
+
+      const event = {
+        pathParameters: { conceptScheme: 'instruments' },
+        queryStringParameters: { version: 'A' }
+      }
+      const response = await getHistoricalConceptsInScheme(event, {})
+
+      expect(response.statusCode).toBe(500)
+      expect(JSON.parse(response.body)).toEqual({ error: 'Failed to fetch concept scheme CSV' })
+    })
+
+    test('should return 500 when downloading the matched object fails', async () => {
+      mockSend.mockResolvedValueOnce({
+        Contents: [{ Key: 'A/instruments.csv' }]
+      })
+
+      mockSend.mockRejectedValueOnce(new Error('Access denied'))
+
+      const event = {
+        pathParameters: { conceptScheme: 'instruments' },
+        queryStringParameters: { version: 'A' }
+      }
+      const response = await getHistoricalConceptsInScheme(event, {})
+
+      expect(response.statusCode).toBe(500)
+      expect(JSON.parse(response.body)).toEqual({ error: 'Failed to fetch concept scheme CSV' })
+    })
+
+    test('should log the error to the console', async () => {
+      const error = new Error('Access denied')
+      mockSend.mockRejectedValueOnce(error)
+
+      const event = {
+        pathParameters: { conceptScheme: 'instruments' },
+        queryStringParameters: { version: 'A' }
+      }
+      await getHistoricalConceptsInScheme(event, {})
+
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledWith(
+        'Failed to download CSV for scheme="instruments", version="A": Access denied'
+      )
+    })
+  })
+})

--- a/serverless/src/getHistoricalConceptsInScheme/__tests__/handler.test.js
+++ b/serverless/src/getHistoricalConceptsInScheme/__tests__/handler.test.js
@@ -10,15 +10,6 @@ import { logAnalyticsData } from '@/shared/logAnalyticsData'
 
 import { getHistoricalConceptsInScheme } from '../handler'
 
-// GetS3Client() is called once at module-load time in handler.js, so the
-// mocked client needs to exist before the handler module is imported. Using
-// vi.hoisted + a mock factory ensures `mockSend` is available when the
-// `@/shared/awsClients` mock is set up, and lets us control its behavior
-// per test via mockSend.mockResolvedValueOnce(...).
-//
-// handler.js also reads `RDF_BUCKET_NAME` at module-load time and throws if
-// it's missing, so it must be set here too, before the static import of
-// `../handler` below runs (vi.hoisted is lifted above all imports).
 const { mockSend } = vi.hoisted(() => {
   process.env.RDF_BUCKET_NAME = 'test-bucket'
 

--- a/serverless/src/getHistoricalConceptsInScheme/__tests__/handler.test.js
+++ b/serverless/src/getHistoricalConceptsInScheme/__tests__/handler.test.js
@@ -186,7 +186,7 @@ describe('getHistoricalConceptsInScheme', () => {
 
       expect(response.statusCode).toBe(404)
       expect(JSON.parse(response.body)).toEqual({
-        error: 'No concept scheme "doesnotexist" found for version "A"'
+        error: 'No concept scheme doesnotexist found for version A'
       })
 
       // Only the list call should happen, never a GetObject
@@ -247,7 +247,7 @@ describe('getHistoricalConceptsInScheme', () => {
 
       // eslint-disable-next-line no-console
       expect(console.error).toHaveBeenCalledWith(
-        'Failed to download CSV for scheme="instruments", version="A": Access denied'
+        'Failed to download CSV for scheme=instruments, version=A: Access denied'
       )
     })
   })

--- a/serverless/src/getHistoricalConceptsInScheme/__tests__/handler.test.js
+++ b/serverless/src/getHistoricalConceptsInScheme/__tests__/handler.test.js
@@ -69,6 +69,30 @@ describe('getHistoricalConceptsInScheme', () => {
       expect(response.statusCode).toBe(400)
       expect(JSON.parse(response.body)).toEqual({ error: 'scheme is required' })
     })
+
+    test('should return 400 when conceptScheme contains invalid characters', async () => {
+      const event = {
+        pathParameters: { conceptScheme: 'instruments"; DROP TABLE--' },
+        queryStringParameters: { version: 'A' }
+      }
+      const response = await getHistoricalConceptsInScheme(event, {})
+
+      expect(response.statusCode).toBe(400)
+      expect(JSON.parse(response.body)).toEqual({ error: 'scheme contains invalid characters' })
+      expect(mockSend).not.toHaveBeenCalled()
+    })
+
+    test('should return 400 when version contains invalid characters', async () => {
+      const event = {
+        pathParameters: { conceptScheme: 'instruments' },
+        queryStringParameters: { version: 'A\r\nX-Injected: true' }
+      }
+      const response = await getHistoricalConceptsInScheme(event, {})
+
+      expect(response.statusCode).toBe(400)
+      expect(JSON.parse(response.body)).toEqual({ error: 'version contains invalid characters' })
+      expect(mockSend).not.toHaveBeenCalled()
+    })
   })
 
   describe('when successful', () => {

--- a/serverless/src/getHistoricalConceptsInScheme/__tests__/handler.test.js
+++ b/serverless/src/getHistoricalConceptsInScheme/__tests__/handler.test.js
@@ -15,9 +15,15 @@ import { getHistoricalConceptsInScheme } from '../handler'
 // vi.hoisted + a mock factory ensures `mockSend` is available when the
 // `@/shared/awsClients` mock is set up, and lets us control its behavior
 // per test via mockSend.mockResolvedValueOnce(...).
-const { mockSend } = vi.hoisted(() => ({
-  mockSend: vi.fn()
-}))
+//
+// handler.js also reads `RDF_BUCKET_NAME` at module-load time and throws if
+// it's missing, so it must be set here too, before the static import of
+// `../handler` below runs (vi.hoisted is lifted above all imports).
+const { mockSend } = vi.hoisted(() => {
+  process.env.RDF_BUCKET_NAME = 'test-bucket'
+
+  return { mockSend: vi.fn() }
+})
 
 vi.mock('@/shared/awsClients', () => ({
   getS3Client: () => ({ send: mockSend })
@@ -249,6 +255,21 @@ describe('getHistoricalConceptsInScheme', () => {
       expect(console.error).toHaveBeenCalledWith(
         'Failed to download CSV for scheme=instruments, version=A: Access denied'
       )
+    })
+  })
+
+  describe('when RDF_BUCKET_NAME is not set', () => {
+    test('should throw a clear error at module load instead of silently falling back to a default bucket', async () => {
+      const originalValue = process.env.RDF_BUCKET_NAME
+      delete process.env.RDF_BUCKET_NAME
+
+      vi.resetModules()
+
+      await expect(import('../handler')).rejects.toThrow(
+        'Missing required environment variable: RDF_BUCKET_NAME'
+      )
+
+      process.env.RDF_BUCKET_NAME = originalValue
     })
   })
 })

--- a/serverless/src/getHistoricalConceptsInScheme/__tests__/handler.test.js
+++ b/serverless/src/getHistoricalConceptsInScheme/__tests__/handler.test.js
@@ -232,6 +232,29 @@ describe('getHistoricalConceptsInScheme', () => {
       expect(JSON.parse(response.body)).toEqual({ error: 'Failed to fetch concept scheme CSV' })
     })
 
+    test('should return 500 when the matched object has no Body', async () => {
+      mockSend.mockResolvedValueOnce({
+        Contents: [{ Key: 'A/instruments.csv' }]
+      })
+
+      // GetObject resolves, but with no Body on the response
+      mockSend.mockResolvedValueOnce({})
+
+      const event = {
+        pathParameters: { conceptScheme: 'instruments' },
+        queryStringParameters: { version: 'A' }
+      }
+      const response = await getHistoricalConceptsInScheme(event, {})
+
+      expect(response.statusCode).toBe(500)
+      expect(JSON.parse(response.body)).toEqual({ error: 'Failed to fetch concept scheme CSV' })
+
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledWith(
+        'Failed to download CSV for scheme=instruments, version=A: No data returned from S3'
+      )
+    })
+
     test('should log the error to the console', async () => {
       const error = new Error('Access denied')
       mockSend.mockRejectedValueOnce(error)

--- a/serverless/src/getHistoricalConceptsInScheme/handler.js
+++ b/serverless/src/getHistoricalConceptsInScheme/handler.js
@@ -11,6 +11,16 @@ import { logAnalyticsData } from '@/shared/logAnalyticsData'
 const bucketName = process.env.S3_BUCKET_NAME || 'kms-rdf-backup-sit'
 
 /**
+ * Allow-list pattern for the `conceptScheme` and `version` inputs. Both
+ * values are reflected into the S3 Prefix, the Content-Disposition header,
+ * and error messages, so they're restricted to characters seen in real
+ * version/scheme names (letters, digits, dot, hyphen, underscore) to rule
+ * out header injection or unexpectedly broad S3 prefix listings.
+ * @type {RegExp}
+ */
+const SAFE_IDENTIFIER_PATTERN = /^[A-Za-z0-9._-]+$/
+
+/**
  * S3 Client from shared configuration
  * @type {S3Client}
  */
@@ -95,6 +105,28 @@ export const getHistoricalConceptsInScheme = async (event, context) => {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({ error: 'version is required' })
+    }
+  }
+
+  if (!SAFE_IDENTIFIER_PATTERN.test(scheme)) {
+    return {
+      statusCode: 400,
+      headers: {
+        ...defaultResponseHeaders,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ error: 'scheme contains invalid characters' })
+    }
+  }
+
+  if (!SAFE_IDENTIFIER_PATTERN.test(version)) {
+    return {
+      statusCode: 400,
+      headers: {
+        ...defaultResponseHeaders,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ error: 'version contains invalid characters' })
     }
   }
 

--- a/serverless/src/getHistoricalConceptsInScheme/handler.js
+++ b/serverless/src/getHistoricalConceptsInScheme/handler.js
@@ -8,7 +8,11 @@ import { logAnalyticsData } from '@/shared/logAnalyticsData'
  * S3 bucket name to download the concept scheme CSV from
  * @type {string}
  */
-const bucketName = process.env.S3_BUCKET_NAME || 'kms-rdf-backup-sit'
+const bucketName = process.env.RDF_BUCKET_NAME
+
+if (!bucketName) {
+  throw new Error('Missing required environment variable: RDF_BUCKET_NAME')
+}
 
 /**
  * Allow-list pattern for the `conceptScheme` and `version` inputs. Both

--- a/serverless/src/getHistoricalConceptsInScheme/handler.js
+++ b/serverless/src/getHistoricalConceptsInScheme/handler.js
@@ -1,0 +1,154 @@
+import { GetObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3'
+
+import { getS3Client } from '@/shared/awsClients'
+import { getApplicationConfig } from '@/shared/getConfig'
+import { logAnalyticsData } from '@/shared/logAnalyticsData'
+
+/**
+ * S3 bucket name to download the concept scheme CSV from
+ * @type {string}
+ */
+const bucketName = process.env.S3_BUCKET_NAME || 'kms-rdf-backup-sit'
+
+/**
+ * S3 Client from shared configuration
+ * @type {S3Client}
+ */
+const s3Client = getS3Client()
+
+/**
+ * Lists all object keys directly under a version's S3 prefix.
+ *
+ * @param {string} versionPrefix - The "{version}/" prefix to list under.
+ * @returns {Promise<Array<string>>} Array of full S3 object keys.
+ */
+const listKeysUnderPrefix = async (versionPrefix) => {
+  const keys = []
+  let continuationToken
+
+  /* eslint-disable no-await-in-loop */
+  do {
+    const command = new ListObjectsV2Command({
+      Bucket: bucketName,
+      Prefix: versionPrefix,
+      ContinuationToken: continuationToken
+    })
+
+    const response = await s3Client.send(command)
+
+    if (response.Contents) {
+      keys.push(...response.Contents.map((obj) => obj.Key).filter(Boolean))
+    }
+
+    continuationToken = response.NextContinuationToken
+  } while (continuationToken)
+  /* eslint-enable no-await-in-loop */
+
+  return keys
+}
+
+/**
+ * Finds the actual S3 key for a scheme's CSV file under a version prefix,
+ * matching case-insensitively since scheme file names in S3 may be
+ * lowercase, CamelCase, or any other casing.
+ *
+ * @param {Array<string>} keys - Object keys under the version prefix.
+ * @param {string} versionPrefix - The "{version}/" prefix the keys live under.
+ * @param {string} scheme - The lowercased scheme name to match against.
+ * @returns {string|undefined} The matching S3 key, if found.
+ */
+const findSchemeKey = (keys, versionPrefix, scheme) => keys.find((key) => {
+  const fileName = key.slice(versionPrefix.length)
+
+  return fileName.toLowerCase() === `${scheme}.csv`
+})
+
+export const getHistoricalConceptsInScheme = async (event, context) => {
+  const { defaultResponseHeaders } = getApplicationConfig()
+
+  logAnalyticsData({
+    event,
+    context
+  })
+
+  const { pathParameters, queryStringParameters } = event
+  const { conceptScheme } = pathParameters || {}
+  const scheme = conceptScheme?.toLowerCase()
+  const { version } = queryStringParameters || {}
+
+  if (!scheme) {
+    return {
+      statusCode: 400,
+      headers: {
+        ...defaultResponseHeaders,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ error: 'scheme is required' })
+    }
+  }
+
+  if (!version) {
+    return {
+      statusCode: 400,
+      headers: {
+        ...defaultResponseHeaders,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ error: 'version is required' })
+    }
+  }
+
+  const versionPrefix = `${version}/`
+
+  try {
+    const keys = await listKeysUnderPrefix(versionPrefix)
+    const matchedKey = findSchemeKey(keys, versionPrefix, scheme)
+
+    if (!matchedKey) {
+      return {
+        statusCode: 404,
+        headers: {
+          ...defaultResponseHeaders,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ error: `No concept scheme "${scheme}" found for version "${version}"` })
+      }
+    }
+
+    const command = new GetObjectCommand({
+      Bucket: bucketName,
+      Key: matchedKey
+    })
+
+    const response = await s3Client.send(command)
+
+    if (!response.Body) {
+      throw new Error('No data returned from S3')
+    }
+
+    const csvContent = await response.Body.transformToString()
+
+    return {
+      statusCode: 200,
+      headers: {
+        ...defaultResponseHeaders,
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${scheme}.csv"`
+      },
+      body: csvContent
+    }
+  } catch (error) {
+    console.error(`Failed to download CSV for scheme="${scheme}", version="${version}": ${error.message}`)
+
+    return {
+      statusCode: 500,
+      headers: {
+        ...defaultResponseHeaders,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ error: 'Failed to fetch concept scheme CSV' })
+    }
+  }
+}
+
+export default getHistoricalConceptsInScheme

--- a/serverless/src/getHistoricalConceptsInScheme/handler.js
+++ b/serverless/src/getHistoricalConceptsInScheme/handler.js
@@ -143,7 +143,7 @@ export const getHistoricalConceptsInScheme = async (event, context) => {
           ...defaultResponseHeaders,
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ error: `No concept scheme "${scheme}" found for version "${version}"` })
+        body: JSON.stringify({ error: `No concept scheme ${scheme} found for version ${version}` })
       }
     }
 
@@ -170,7 +170,7 @@ export const getHistoricalConceptsInScheme = async (event, context) => {
       body: csvContent
     }
   } catch (error) {
-    console.error(`Failed to download CSV for scheme="${scheme}", version="${version}": ${error.message}`)
+    console.error(`Failed to download CSV for scheme=${scheme}, version=${version}: ${error.message}`)
 
     return {
       statusCode: 500,

--- a/serverless/src/getHistoricalConceptsInScheme/handler.js
+++ b/serverless/src/getHistoricalConceptsInScheme/handler.js
@@ -143,7 +143,7 @@ export const getHistoricalConceptsInScheme = async (event, context) => {
           ...defaultResponseHeaders,
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ error: `No concept scheme ${scheme} found for version ${version}` })
+        body: JSON.stringify({ error: `No concept scheme ${conceptScheme} found for version ${version}` })
       }
     }
 
@@ -165,12 +165,12 @@ export const getHistoricalConceptsInScheme = async (event, context) => {
       headers: {
         ...defaultResponseHeaders,
         'Content-Type': 'text/csv; charset=utf-8',
-        'Content-Disposition': `attachment; filename="${scheme}.csv"`
+        'Content-Disposition': `attachment; filename="${conceptScheme}.csv"`
       },
       body: csvContent
     }
   } catch (error) {
-    console.error(`Failed to download CSV for scheme=${scheme}, version=${version}: ${error.message}`)
+    console.error(`Failed to download CSV for scheme=${conceptScheme}, version=${version}: ${error.message}`)
 
     return {
       statusCode: 500,


### PR DESCRIPTION
# Overview

### What is the feature?

Support Older Versions of the GCMD Keywords in KMS.

### What is the Solution?

Add new endpoint to fetch list of older versions.
Add new endpoint to download concepts in scheme (csv download) for given version.

### What areas of the application does this impact?

There add 2 new endpoints added:
1. /kms/concept_versions/historical
2. /kms/concepts/historical/concept_scheme/{conceptScheme}?version={version}

# Testing

Check responses of the new endpoints.

For local testing: 
1. Create S3 bucket:
aws --endpoint-url=http://localhost:4566 s3 mb s3://kms-rdf-backup-sit

2. Seed it with version folders for testing
aws --endpoint-url=http://localhost:4566 s3 cp instruments.csv s3://kms-rdf-backup-sit/versionA/
aws --endpoint-url=http://localhost:4566 s3 cp instruments.csv s3://kms-rdf-backup-sit/versionB/
aws --endpoint-url=http://localhost:4566 s3 cp instruments.csv s3://kms-rdf-backup-sit/versionC/
...
also upload other concepts in scheme csv files projects.csv, sciencekeywords.csv...

Then start local kms and call the new endpoints:
http://127.0.0.1:3013/concept_versions/historical - to get the list of historical versions

Example to download csv of 'instruments' of version 'versionA'
http://127.0.0.1:3013/concepts/historical/concept_scheme/instruments?version=versionA 

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
