### PR TITLE
CMR-11421: Pass the Cmr-Send-Kms-Metadata-Fixer to CMR during writeback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11491,9 +11491,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/serverless/src/shared/__tests__/writeCorrectedMetadataToCmr.test.js
+++ b/serverless/src/shared/__tests__/writeCorrectedMetadataToCmr.test.js
@@ -102,7 +102,8 @@ describe('when writing corrected metadata to cmr', () => {
         Authorization: 'Bearer writer-token',
         'Client-Id': 'kms-metadata-correction-service',
         'Cmr-Validate-Keywords': 'false',
-        'Cmr-Validate-Umm-C': 'false'
+        'Cmr-Validate-Umm-C': 'false',
+        'Cmr-Send-Kms-Metadata-Fixer': 'false'
       }
     })
   })
@@ -125,7 +126,8 @@ describe('when writing corrected metadata to cmr', () => {
         Authorization: 'Bearer writer-token',
         'Client-Id': 'kms-metadata-correction-service',
         'Cmr-Validate-Keywords': 'true',
-        'Cmr-Validate-Umm-C': 'true'
+        'Cmr-Validate-Umm-C': 'true',
+        'Cmr-Send-Kms-Metadata-Fixer': 'false'
       }
     }))
   })
@@ -287,6 +289,7 @@ describe('when writing corrected metadata to cmr', () => {
       headers: {
         Authorization: 'Bearer writer-token',
         'Client-Id': 'kms-metadata-correction-service',
+        'Cmr-Send-Kms-Metadata-Fixer': 'false',
         'Cmr-Validate-Keywords': 'false',
         'Cmr-Validate-Umm-C': 'false'
       }

--- a/serverless/src/shared/writeCorrectedMetadataToCmr.js
+++ b/serverless/src/shared/writeCorrectedMetadataToCmr.js
@@ -354,7 +354,8 @@ export const writeCorrectedMetadataToCmr = async ({
       Authorization: authorizationToken,
       'Client-Id': CMR_WRITEBACK_CLIENT_ID,
       'Cmr-Validate-Keywords': getValidationHeaderValue('CMR_WRITEBACK_VALIDATE_KEYWORDS'),
-      'Cmr-Validate-Umm-C': getValidationHeaderValue('CMR_WRITEBACK_VALIDATE_UMM_C')
+      'Cmr-Validate-Umm-C': getValidationHeaderValue('CMR_WRITEBACK_VALIDATE_UMM_C'),
+      'Cmr-Send-Kms-Metadata-Fixer': 'false' // Explicitly disable the CMR metadata fixer for writeback requests to prevent loops
     }
   })
 


### PR DESCRIPTION
npm audit fixing

# Overview

### What is the feature?

We noticed in some SIT testing that we could occassionaly get into a loop condition where CMR sends a collection to KMS to fix keyword issues KMS will fix those and then ingest to CMR. This is usually fine if all fixes work but, if the service is only able to fix part of the metadata e.g. if some of the keywords can be fixed because they were old keywords that have been moved/renamed, but, some are "garbage" values meaning they have never existed in KMS we cannot resolve those directly but, we will ingest the revision on KMS to fix the ones we can fix. That results in a subsequent call to KMS. There are several things on the KMS side that make this not an infinite loop but, we still want to be able to just stop this cycle from the KMS call.


### What is the Solution?

Pass the header in https://github.com/nasa/Common-Metadata-Repository/pull/2484 in the writeback call

### What areas of the application does this impact?

CMR writeback for the KMS metadata fixer service

# Testing

### Reproduction steps

- **Environment for testing:*SIT*
- **Collection to test with:*any*

1. Test e2e that when we have a collection that has partial fixes we can have those work but, we don't get a subsequent request back to KMS
2. Use cloudwatch or splunk to see when we ingest a collection into CMR that has keyword errors using the `cmr-validate-keywords` false flag that a metadata correction event works to fix some of the issues there but, if there are some it cannot resolve e.g. a keyword which has never existed then we don't get a subsequent request back from CMR back into KMS

### Attachments

NA

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected metadata writeback requests now explicitly disable the CMR metadata fixer.
  * Updated validation behavior to consistently send the appropriate request header for DIF10 and UMM metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->